### PR TITLE
Kumarde/modify output to match protobuf

### DIFF
--- a/lints/lint_basic_constraints_not_critical.go
+++ b/lints/lint_basic_constraints_not_critical.go
@@ -47,7 +47,7 @@ func (l *basicConstCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "basic_constraints_not_critical",
+		Name:          "e_basic_constraints_not_critical",
 		Description:   "Conforming CAs must mark Basic Constraints as critical when it is included in CA certs",
 		Providence:    "RFC 5280: 4.2.1.9",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_basic_constraints_not_critical_test.go
+++ b/lints/lint_basic_constraints_not_critical_test.go
@@ -9,7 +9,7 @@ func TestBasicConstNotCrit(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caBasicConstNotCrit.cer"
 	desEnum := Error
-	out, _ := Lints["basic_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_basic_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestBasicConstCrit(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caBasicConstCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["basic_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_basic_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ca_country_name_invalid.go
+++ b/lints/lint_ca_country_name_invalid.go
@@ -41,7 +41,7 @@ func (l *caCountryNameInvalid) RunTest(c *x509.Certificate) (ResultStruct, error
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ca_country_name_invalid",
+		Name:          "e_ca_country_name_invalid",
 		Description:   "Root & Subordinate CA certificates must have a two-letter country code that is in ISO 3166-1",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ca_country_name_invalid_test.go
+++ b/lints/lint_ca_country_name_invalid_test.go
@@ -9,7 +9,7 @@ func TestCaCountryNameInvalid(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caInvalCountryCode.cer"
 	desEnum := Error
-	out, _ := Lints["ca_country_name_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_country_name_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCaCountryNameValid(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caValCountry.cer"
 	desEnum := Pass
-	out, _ := Lints["ca_country_name_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_country_name_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ca_country_name_missing.go
+++ b/lints/lint_ca_country_name_missing.go
@@ -36,7 +36,7 @@ func (l *caCountryNameMissing) RunTest(c *x509.Certificate) (ResultStruct, error
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ca_country_name_missing",
+		Name:          "e_ca_country_name_missing",
 		Description:   "Root & Subordinate CA certificates must have a countryName present in subject information",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ca_country_name_missing_test.go
+++ b/lints/lint_ca_country_name_missing_test.go
@@ -9,7 +9,7 @@ func TestCaCountryNameMissing(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caBlankCountry.cer"
 	desEnum := Error
-	out, _ := Lints["ca_country_name_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_country_name_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCaCountryNamePresent(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caValCountry.cer"
 	desEnum := Pass
-	out, _ := Lints["ca_country_name_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_country_name_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ca_crl_sign_not_set.go
+++ b/lints/lint_ca_crl_sign_not_set.go
@@ -35,7 +35,7 @@ func (l *caCRLSignNotSet) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ca_crl_sign_not_set",
+		Name:          "e_ca_crl_sign_not_set",
 		Description:   "Root & Subordinate CA certificate keyUsage extension's crlSign bit must be set",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ca_crl_sign_not_set_test.go
+++ b/lints/lint_ca_crl_sign_not_set_test.go
@@ -9,7 +9,7 @@ func TestCaKeyUsageNoCRLSign(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caKeyUsageNoCRL.cer"
 	desEnum := Error
-	out, _ := Lints["ca_crl_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_crl_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestKeyUsageCRLSign(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caKeyUsageCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["ca_crl_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_crl_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ca_dig_sign_not_set.go
+++ b/lints/lint_ca_dig_sign_not_set.go
@@ -35,7 +35,7 @@ func (l *caDigSignNotSet) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ca_dig_sign_not_set",
+		Name:          "w_ca_dig_sign_not_set",
 		Description:   "Root & Subordinate CA Certificates that wish to use their private key for signing OCSP responses will not be able to with out digital signature set",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ca_dig_sign_not_set_test.go
+++ b/lints/lint_ca_dig_sign_not_set_test.go
@@ -9,7 +9,7 @@ func TestCaKeyUsageNoDigSign(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caKeyUsageNoCertSign.cer"
 	desEnum := Warn
-	out, _ := Lints["ca_dig_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ca_dig_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestKeyUsageDigSign(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caKeyUsageWDigSign.cer"
 	desEnum := Pass
-	out, _ := Lints["ca_dig_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ca_dig_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ca_key_cert_sign_not_set.go
+++ b/lints/lint_ca_key_cert_sign_not_set.go
@@ -35,7 +35,7 @@ func (l *caKeyCertSignNotSet) RunTest(c *x509.Certificate) (ResultStruct, error)
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ca_key_cert_sign_not_set",
+		Name:          "e_ca_key_cert_sign_not_set",
 		Description:   "Root & Subordinate CA certificate keyUsage extension's keyCertSign bit must be set",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ca_key_cert_sign_not_set_test.go
+++ b/lints/lint_ca_key_cert_sign_not_set_test.go
@@ -9,7 +9,7 @@ func TestCaKeyUsageNoCertSign(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caKeyUsageNoCertSign.cer"
 	desEnum := Error
-	out, _ := Lints["ca_key_cert_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_key_cert_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestKeyUsageCertSign(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caKeyUsageCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["ca_key_cert_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_key_cert_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ca_key_usage_missing.go
+++ b/lints/lint_ca_key_usage_missing.go
@@ -37,7 +37,7 @@ func (l *caKeyUsageMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ca_key_usage_missing",
+		Name:          "e_ca_key_usage_missing",
 		Description:   "Root & Subordinate CA certificate keyUsage extension must be present",
 		Providence:    "CAB: 7.1.2.1, RFC 5280: 4.2.1.3",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_ca_key_usage_missing_test.go
+++ b/lints/lint_ca_key_usage_missing_test.go
@@ -9,7 +9,7 @@ func TestCaKeyUsageMissing(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caKeyUsageMissing.cer"
 	desEnum := Error
-	out, _ := Lints["ca_key_usage_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_key_usage_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestKeyUsagePresent(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caKeyUsageCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["ca_key_usage_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_key_usage_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ca_key_usage_not_critical.go
+++ b/lints/lint_ca_key_usage_not_critical.go
@@ -35,7 +35,7 @@ func (l *caKeyUsageNotCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ca_key_usage_not_critical",
+		Name:          "e_ca_key_usage_not_critical",
 		Description:   "Root & Subordinate CA certificate keyUsage extension must be marked as critical",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ca_key_usage_not_critical_test.go
+++ b/lints/lint_ca_key_usage_not_critical_test.go
@@ -9,7 +9,7 @@ func TestCaKeyUsageNotCrit(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caKeyUsageNotCrit.cer"
 	desEnum := Error
-	out, _ := Lints["ca_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestKeyUsageCrit(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caKeyUsageCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["ca_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ca_organization_name_missing.go
+++ b/lints/lint_ca_organization_name_missing.go
@@ -34,7 +34,7 @@ func (l *caOrganizationNameMissing) RunTest(c *x509.Certificate) (ResultStruct, 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ca_organization_name_missing",
+		Name:          "e_ca_organization_name_missing",
 		Description:   "Root & Subordinate CA certificates must have a organizationName present in subject information",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ca_organization_name_missing_test.go
+++ b/lints/lint_ca_organization_name_missing_test.go
@@ -9,7 +9,7 @@ func TestCAOrgNameBlank(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caOrgNameEmpty.cer"
 	desEnum := Error
-	out, _ := Lints["ca_organization_name_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_organization_name_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCAOrgNameMissing(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caOrgNameMissing.cer"
 	desEnum := Error
-	out, _ := Lints["ca_organization_name_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_organization_name_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestCAOrgNameValid(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caValOrgName.cer"
 	desEnum := Pass
-	out, _ := Lints["ca_organization_name_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_organization_name_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ca_subject_field_empty.go
+++ b/lints/lint_ca_subject_field_empty.go
@@ -41,7 +41,7 @@ func (l *caSubjectEmpty) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ca_subject_field_empty",
+		Name:          "e_ca_subject_field_empty",
 		Description:   "CA Certificates subject field must not be empty and must have a non-empty distingushed name",
 		Providence:    "RFC 5280: 4.1.2.6",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ca_subject_field_empty_test.go
+++ b/lints/lint_ca_subject_field_empty_test.go
@@ -9,7 +9,7 @@ func TestCaSubjectMissing(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caSubjectMissing.cer"
 	desEnum := Error
-	out, _ := Lints["ca_subject_field_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_subject_field_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCaSubjectValid(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caValCountry.cer"
 	desEnum := Pass
-	out, _ := Lints["ca_subject_field_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ca_subject_field_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_contains_unique_identifier.go
+++ b/lints/lint_cert_contains_unique_identifier.go
@@ -40,7 +40,7 @@ func (l *CertContainsUniqueIdentifier) RunTest(cert *x509.Certificate) (ResultSt
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_contains_unique_identifier",
+		Name:          "e_cert_contains_unique_identifier",
 		Description:   "CAs must not generate certificate with unique identifiers.",
 		Providence:    "RFC 5280: 4.1.2.8",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_cert_contains_unique_identifier_test.go
+++ b/lints/lint_cert_contains_unique_identifier_test.go
@@ -9,7 +9,7 @@ func TestUIDPresentIssuer(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/issuerUID.cer"
 	desEnum := Error
-	out, _ := Lints["cert_contains_unique_identifier"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_contains_unique_identifier"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestUIDPresentSubject(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/subjectUID.cer"
 	desEnum := Error
-	out, _ := Lints["cert_contains_unique_identifier"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_contains_unique_identifier"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestUIDMissing(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_contains_unique_identifier"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_contains_unique_identifier"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_extensions_version_not_3.go
+++ b/lints/lint_cert_extensions_version_not_3.go
@@ -46,7 +46,7 @@ func (l *CertExtensionsVersonNot3) RunTest(cert *x509.Certificate) (ResultStruct
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_extensions_version_not_3",
+		Name:          "e_cert_extensions_version_not_3",
 		Description:   "The extensions field must only appear in version 3 certificates.",
 		Providence:    "RFC 5280: 4.1.2.9",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_cert_extensions_version_not_3_test.go
+++ b/lints/lint_cert_extensions_version_not_3_test.go
@@ -9,7 +9,7 @@ func TestExtsV2(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/certVersion2WithExtension.cer"
 	desEnum := Error
-	out, _ := Lints["cert_extensions_version_not_3"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_extensions_version_not_3"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestExtsV3(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caBasicConstCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_extensions_version_not_3"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_extensions_version_not_3"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestNoExtsV2(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/certVersion2NoExtensions.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_extensions_version_not_3"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_extensions_version_not_3"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_policy_conflicts_with_locality.go
+++ b/lints/lint_cert_policy_conflicts_with_locality.go
@@ -33,7 +33,7 @@ func (l *certPolicyConflictsWithLocality) RunTest(cert *x509.Certificate) (Resul
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_policy_conflicts_with_locality",
+		Name:          "e_cert_policy_conflicts_with_locality",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, locality name must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cert_policy_conflicts_with_locality_test.go
+++ b/lints/lint_cert_policy_conflicts_with_locality_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyNotConflictWithLocal(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_policy_conflicts_with_locality"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_conflicts_with_locality"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyConflictsWithLocal(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValWithLocal.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_conflicts_with_locality"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_conflicts_with_locality"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_policy_conflicts_with_org.go
+++ b/lints/lint_cert_policy_conflicts_with_org.go
@@ -33,7 +33,7 @@ func (l *certPolicyConflictsWithOrg) RunTest(cert *x509.Certificate) (ResultStru
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_policy_conflicts_with_org",
+		Name:          "e_cert_policy_conflicts_with_org",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, organization name must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cert_policy_conflicts_with_org_test.go
+++ b/lints/lint_cert_policy_conflicts_with_org_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyNotConflictWithOrg(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_policy_conflicts_with_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_conflicts_with_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyConflictsWithOrg(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValWithOrg.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_conflicts_with_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_conflicts_with_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_policy_conflicts_with_postal.go
+++ b/lints/lint_cert_policy_conflicts_with_postal.go
@@ -33,7 +33,7 @@ func (l *certPolicyConflictsWithPostal) RunTest(cert *x509.Certificate) (ResultS
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_policy_conflicts_with_postal",
+		Name:          "e_cert_policy_conflicts_with_postal",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, postalCode must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cert_policy_conflicts_with_postal_test.go
+++ b/lints/lint_cert_policy_conflicts_with_postal_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyNotConflictWithPostal(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_policy_conflicts_with_postal"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_conflicts_with_postal"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyConflictsWithPostal(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValWithPostal.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_conflicts_with_postal"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_conflicts_with_postal"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_policy_conflicts_with_province.go
+++ b/lints/lint_cert_policy_conflicts_with_province.go
@@ -33,7 +33,7 @@ func (l *certPolicyConflictsWithProvince) RunTest(cert *x509.Certificate) (Resul
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_policy_conflicts_with_province",
+		Name:          "e_cert_policy_conflicts_with_province",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, stateOrProvinceName must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cert_policy_conflicts_with_province_test.go
+++ b/lints/lint_cert_policy_conflicts_with_province_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyNotConflictWithProv(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_policy_conflicts_with_province"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_conflicts_with_province"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyConflictsWithProv(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValWithProvince.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_conflicts_with_province"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_conflicts_with_province"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_policy_conflicts_with_street.go
+++ b/lints/lint_cert_policy_conflicts_with_street.go
@@ -33,7 +33,7 @@ func (l *certPolicyConflictsWithStreet) RunTest(cert *x509.Certificate) (ResultS
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_policy_conflicts_with_street",
+		Name:          "e_cert_policy_conflicts_with_street",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, streetAddress must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cert_policy_conflicts_with_street_test.go
+++ b/lints/lint_cert_policy_conflicts_with_street_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyNotConflictWithStreet(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_policy_conflicts_with_street"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_conflicts_with_street"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyConflictsWithStreet(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValWithStreet.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_conflicts_with_street"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_conflicts_with_street"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_policy_iv_requires_country.go
+++ b/lints/lint_cert_policy_iv_requires_country.go
@@ -32,7 +32,7 @@ func (l *CertPolicyIVRequiresCountry) RunTest(cert *x509.Certificate) (ResultStr
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_policy_iv_requires_country",
+		Name:          "e_cert_policy_iv_requires_country",
 		Description:   "If certificate policy 2.23.140.1.2.3 is included, countryName must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,

--- a/lints/lint_cert_policy_iv_requires_country_test.go
+++ b/lints/lint_cert_policy_iv_requires_country_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyIvCountry(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_policy_iv_requires_country"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_iv_requires_country"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyIvNoCountry(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValNoCountry.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_iv_requires_country"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_iv_requires_country"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_policy_iv_requires_province_or_locality.go
+++ b/lints/lint_cert_policy_iv_requires_province_or_locality.go
@@ -32,7 +32,7 @@ func (l *CertPolicyIVRequiresProvinceOrLocal) RunTest(cert *x509.Certificate) (R
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_policy_iv_requires_province_or_locality",
+		Name:          "e_cert_policy_iv_requires_province_or_locality",
 		Description:   "If certificate policy 2.23.140.1.2.3 is included, localityName or stateOrProvinceName must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,

--- a/lints/lint_cert_policy_iv_requires_province_or_locality_test.go
+++ b/lints/lint_cert_policy_iv_requires_province_or_locality_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyHasCountryOrLocal(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_policy_iv_requires_province_or_locality"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_iv_requires_province_or_locality"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyIvNoCountryOrLocal(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValNoLocalOrProvince.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_iv_requires_province_or_locality"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_iv_requires_province_or_locality"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_policy_ov_requires_country.go
+++ b/lints/lint_cert_policy_ov_requires_country.go
@@ -32,7 +32,7 @@ func (l *CertPolicyOVRequiresCountry) RunTest(cert *x509.Certificate) (ResultStr
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_policy_ov_requires_country",
+		Name:          "e_cert_policy_ov_requires_country",
 		Description:   "If certificate policy 2.23.140.1.2.2 is included, countryName must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cert_policy_ov_requires_country_test.go
+++ b/lints/lint_cert_policy_ov_requires_country_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyOvHasCountry(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_policy_ov_requires_country"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_ov_requires_country"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyOvNoCountry(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/orgValNoCountry.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_ov_requires_country"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_ov_requires_country"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_policy_ov_requires_province_or_locality.go
+++ b/lints/lint_cert_policy_ov_requires_province_or_locality.go
@@ -32,7 +32,7 @@ func (l *CertPolicyOVRequiresProvinceOrLocal) RunTest(cert *x509.Certificate) (R
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_policy_ov_requires_province_or_locality",
+		Name:          "e_cert_policy_ov_requires_province_or_locality",
 		Description:   "If certificate policy 2.23.140.1.2.2 is included, localityName or stateOrProvinceName must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cert_policy_ov_requires_province_or_locality_test.go
+++ b/lints/lint_cert_policy_ov_requires_province_or_locality_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyOvHasCountryOrLocal(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_policy_ov_requires_province_or_locality"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_ov_requires_province_or_locality"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyOvNoCountryOrLocal(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/orgValNoProvinceOrLocal.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_ov_requires_province_or_locality"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_ov_requires_province_or_locality"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_policy_requires_org.go
+++ b/lints/lint_cert_policy_requires_org.go
@@ -32,7 +32,7 @@ func (l *CertPolicyRequiresOrg) RunTest(cert *x509.Certificate) (ResultStruct, e
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_policy_requires_org",
+		Name:          "e_cert_policy_requires_org",
 		Description:   "If certificate policy 2.23.140.1.2.2 is included, organizationName must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cert_policy_requires_org_test.go
+++ b/lints/lint_cert_policy_requires_org_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyOvHasOrg(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_policy_requires_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_requires_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyOvNoOrg(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/orgValNoOrg.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_requires_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_requires_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_policy_requires_personal_name.go
+++ b/lints/lint_cert_policy_requires_personal_name.go
@@ -32,7 +32,7 @@ func (l *CertPolicyRequiresPersonalName) RunTest(cert *x509.Certificate) (Result
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_policy_requires_personal_name",
+		Name:          "e_cert_policy_requires_personal_name",
 		Description:   "If certificate policy 2.23.140.1.2.3 is included, either organizationName or givenName and surname must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,

--- a/lints/lint_cert_policy_requires_personal_name_test.go
+++ b/lints/lint_cert_policy_requires_personal_name_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyIvHasPerson(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyIvHasSurname(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValSurnameOnly.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestCertPolicyIvHasLastName(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValGivenNameOnly.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -51,7 +51,7 @@ func TestCertPolicyIvNoPerson(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValNoOrgOrPersonalNames.cer"
 	desEnum := Error
-	out, _ := Lints["cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cert_unique_identifier_version_not_2_or_3.go
+++ b/lints/lint_cert_unique_identifier_version_not_2_or_3.go
@@ -42,7 +42,7 @@ func (l *certUniqueIdVersion) RunTest(c *x509.Certificate) (ResultStruct, error)
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "cert_unique_identifier_version_not_2_or_3",
+		Name:          "e_cert_unique_identifier_version_not_2_or_3",
 		Description:   "Unique identifiers must only appear if the version is 2 or 3.",
 		Providence:    "RFC 5280: 4.1.2.8",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_cert_unique_identifier_version_not_2_or_3_test.go
+++ b/lints/lint_cert_unique_identifier_version_not_2_or_3_test.go
@@ -8,7 +8,7 @@ import (
 func TestUniqueIdVersionNot1(t *testing.T) {
 	inputPath := "../testlint/testCerts/uniqueIdVersion3.cer"
 	desEnum := Pass
-	out, _ := Lints["cert_unique_identifier_version_not_2_or_3"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_unique_identifier_version_not_2_or_3"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestUniqueIdVersionNot1(t *testing.T) {
 func TestUniqueIdVersion1(t *testing.T) {
 	inputPath := "../testlint/testCerts/uniqueIdVersion1.cer"
 	desEnum := Error
-	out, _ := Lints["cert_unique_identifier_version_not_2_or_3"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cert_unique_identifier_version_not_2_or_3"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_dh_params_missing.go
+++ b/lints/lint_dh_params_missing.go
@@ -31,7 +31,7 @@ func (l *dsaParamsMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "dh_params_missing",
+		Name:          "e_dh_params_missing",
 		Description:   "DH keys must have parameters",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_distribution_point_incomplete.go
+++ b/lints/lint_distribution_point_incomplete.go
@@ -59,7 +59,7 @@ func (l *dpIncomplete) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "distribution_point_incomplete",
+		Name:          "e_distribution_point_incomplete",
 		Description:   "A DistributionPoint from the CRLDistributionPoints extension MUST NOT consist of only the reasons field; either distributionPoint or CRLIssuer must be present",
 		Providence:    "RFC 5280: 4.2.1.13",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_distribution_point_incomplete_test.go
+++ b/lints/lint_distribution_point_incomplete_test.go
@@ -9,7 +9,7 @@ func crlCompleteDp(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/crlComlepteDp.cer"
 	desEnum := Pass
-	out, _ := Lints["distribution_point_incomplete"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_distribution_point_incomplete"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func crlIncompleteDp(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/crlIncomlepteDp.cer"
 	desEnum := Error
-	out, _ := Lints["distribution_point_incomplete"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_distribution_point_incomplete"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_distribution_point_missing_ldap_or_uri.go
+++ b/lints/lint_distribution_point_missing_ldap_or_uri.go
@@ -36,7 +36,7 @@ func (l *distribNoLDAPorURI) RunTest(c *x509.Certificate) (ResultStruct, error) 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "distribution_point_missing_ldap_or_uri",
+		Name:          "w_distribution_point_missing_ldap_or_uri",
 		Description:   "When present in the CRLDistributionPoints extension, DistributionPointName SHOULD include at least one LDAP or HTTP URI.",
 		Providence:    "RFC 5280: 4.2.1.13",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_distribution_point_missing_ldap_or_uri_test.go
+++ b/lints/lint_distribution_point_missing_ldap_or_uri_test.go
@@ -9,7 +9,7 @@ func TestCRLDistNoHttp(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/crlDistribNoHTTP.cer"
 	desEnum := Warn
-	out, _ := Lints["distribution_point_missing_ldap_or_uri"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_distribution_point_missing_ldap_or_uri"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCRLDistHttp(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/crlDistribWithHTTP.cer"
 	desEnum := Pass
-	out, _ := Lints["distribution_point_missing_ldap_or_uri"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_distribution_point_missing_ldap_or_uri"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestCRLDistLdap(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/crlDistribWithLDAP.cer"
 	desEnum := Pass
-	out, _ := Lints["distribution_point_missing_ldap_or_uri"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_distribution_point_missing_ldap_or_uri"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_dsa_improper_modulus_or_divisor_size.go
+++ b/lints/lint_dsa_improper_modulus_or_divisor_size.go
@@ -42,7 +42,7 @@ func (l *dsaImproperSize) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:        "dsa_improper_modulus_or_divisor_size",
+		Name:        "e_dsa_improper_modulus_or_divisor_size",
 		Description: "Minimum DSA modulus and divisor size is either L= 2048, N= 224 or L= 2048, N= 256 (extras come from FIPS 186-4)",
 		Providence:  "CAB: 6.1.5",
 		// Refer to CAB: 6.1.5, taking the statement "Before 31 Dec 2010" literally

--- a/lints/lint_dsa_shorter_than_2048_bits.go
+++ b/lints/lint_dsa_shorter_than_2048_bits.go
@@ -36,7 +36,7 @@ func (l *dsaTooShort) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:        "dsa_shorter_than_2048_bits",
+		Name:        "e_dsa_shorter_than_2048_bits",
 		Description: "DSA modulus size must be at least 2048 bits",
 		Providence:  "CAB: 6.1.5",
 		// Refer to CAB: 6.1.5, taking the statement "Before 31 Dec 2010" literally

--- a/lints/lint_ec_improper_curves.go
+++ b/lints/lint_ec_improper_curves.go
@@ -49,7 +49,7 @@ func (l *ecImproperCurves) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:        "ec_improper_curves",
+		Name:        "e_ec_improper_curves",
 		Description: "Only one of NIST P‐256, P‐384, or P‐521 can be used for all types of certificate",
 		Providence:  "CAB: 6.1.5",
 		// Refer to CAB: 6.1.5, taking the statement "Before 31 Dec 2010" literally

--- a/lints/lint_ec_improper_curves_test.go
+++ b/lints/lint_ec_improper_curves_test.go
@@ -9,7 +9,7 @@ func TestECP224(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/ecdsaP224.cer"
 	desEnum := Error
-	out, _ := Lints["ec_improper_curves"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ec_improper_curves"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestECP256(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/ecdsaP256.cer"
 	desEnum := Pass
-	out, _ := Lints["ec_improper_curves"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ec_improper_curves"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestECP384(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/ecdsaP384.cer"
 	desEnum := Pass
-	out, _ := Lints["ec_improper_curves"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ec_improper_curves"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -51,7 +51,7 @@ func TestECP521(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/ecdsaP521.cer"
 	desEnum := Pass
-	out, _ := Lints["ec_improper_curves"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ec_improper_curves"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_eku_critical_improperly.go
+++ b/lints/lint_eku_critical_improperly.go
@@ -46,7 +46,7 @@ func (l *ekuBadCritical) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "eku_critical_improperly",
+		Name:          "w_eku_critical_improperly",
 		Description:   "Conforming CAs SHOULD NOT mark extended key usage extension as critical if the anyExtendedKeyUsage KeyPurposedID is present",
 		Providence:    "RFC 5280: 4.2.1.12",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_eku_critical_improperly_test.go
+++ b/lints/lint_eku_critical_improperly_test.go
@@ -9,7 +9,7 @@ func TestEKUAnyCrit(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/ekuAnyCrit.cer"
 	desEnum := Warn
-	out, _ := Lints["eku_critical_improperly"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_eku_critical_improperly"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestEKUNoCritWAny(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/ekuAnyNoCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["eku_critical_improperly"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_eku_critical_improperly"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestEKUNoAnyCrit(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/ekuNoAnyCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["eku_critical_improperly"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_eku_critical_improperly"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ev_business_category_missing.go
+++ b/lints/lint_ev_business_category_missing.go
@@ -29,7 +29,7 @@ func (l *evNoBiz) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ev_business_category_missing",
+		Name:          "e_ev_business_category_missing",
 		Description:   "EV certificates must include businessCategory in subject",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ev_business_category_missing_test.go
+++ b/lints/lint_ev_business_category_missing_test.go
@@ -7,7 +7,7 @@ import (
 func TestEvNoBiz(t *testing.T) {
 	inputPath := "../testlint/testCerts/evAllGood.cer"
 	desEnum := Error
-	out, _ := Lints["ev_business_category_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ev_business_category_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ev_country_name_missing.go
+++ b/lints/lint_ev_country_name_missing.go
@@ -29,7 +29,7 @@ func (l *evCountryMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ev_country_name_missing",
+		Name:          "e_ev_country_name_missing",
 		Description:   "EV certificates must include countryName in subject",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ev_country_name_missing_test.go
+++ b/lints/lint_ev_country_name_missing_test.go
@@ -7,7 +7,7 @@ import (
 func TestEvHasCountry(t *testing.T) {
 	inputPath := "../testlint/testCerts/evAllGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ev_country_name_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ev_country_name_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -20,7 +20,7 @@ func TestEvHasCountry(t *testing.T) {
 func TestEvNoCountry(t *testing.T) {
 	inputPath := "../testlint/testCerts/evNoCountry.cer"
 	desEnum := Error
-	out, _ := Lints["ev_country_name_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ev_country_name_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ev_locality_name_missing.go
+++ b/lints/lint_ev_locality_name_missing.go
@@ -29,7 +29,7 @@ func (l *evLocalityMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ev_locality_name_missing",
+		Name:          "e_ev_locality_name_missing",
 		Description:   "EV certificates must include localityName in subject",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ev_locality_name_missing_test.go
+++ b/lints/lint_ev_locality_name_missing_test.go
@@ -7,7 +7,7 @@ import (
 func TestEvHasLocality(t *testing.T) {
 	inputPath := "../testlint/testCerts/evAllGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ev_locality_name_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ev_locality_name_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -20,7 +20,7 @@ func TestEvHasLocality(t *testing.T) {
 func TestEvNoLocality(t *testing.T) {
 	inputPath := "../testlint/testCerts/evNoLocal.cer"
 	desEnum := Error
-	out, _ := Lints["ev_locality_name_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ev_locality_name_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ev_organization_name_missing.go
+++ b/lints/lint_ev_organization_name_missing.go
@@ -29,7 +29,7 @@ func (l *evOrgMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ev_organization_name_missing",
+		Name:          "e_ev_organization_name_missing",
 		Description:   "EV certificates must include organizationName in subject",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ev_organization_name_missing_test.go
+++ b/lints/lint_ev_organization_name_missing_test.go
@@ -7,7 +7,7 @@ import (
 func TestEvHasOrg(t *testing.T) {
 	inputPath := "../testlint/testCerts/evAllGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ev_organization_name_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ev_organization_name_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -20,7 +20,7 @@ func TestEvHasOrg(t *testing.T) {
 func TestEvNoOrg(t *testing.T) {
 	inputPath := "../testlint/testCerts/evNoOrg.cer"
 	desEnum := Error
-	out, _ := Lints["ev_organization_name_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ev_organization_name_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ev_serial_number_missing.go
+++ b/lints/lint_ev_serial_number_missing.go
@@ -28,7 +28,7 @@ func (l *evSNMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ev_serial_number_missing",
+		Name:          "e_ev_serial_number_missing",
 		Description:   "EV certificates must include serialNumber in subject",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ev_serial_number_missing_test.go
+++ b/lints/lint_ev_serial_number_missing_test.go
@@ -7,7 +7,7 @@ import (
 func TestEvHasSN(t *testing.T) {
 	inputPath := "../testlint/testCerts/evAllGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ev_serial_number_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ev_serial_number_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -20,7 +20,7 @@ func TestEvHasSN(t *testing.T) {
 func TestEvNoSN(t *testing.T) {
 	inputPath := "../testlint/testCerts/evNoSN.cer"
 	desEnum := Error
-	out, _ := Lints["ev_serial_number_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ev_serial_number_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ev_valid_time_too_long.go
+++ b/lints/lint_ev_valid_time_too_long.go
@@ -28,7 +28,7 @@ func (l *evValidTooLong) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ev_valid_time_too_long",
+		Name:          "e_ev_valid_time_too_long",
 		Description:   "EV certificates must be 27 months in validity or less",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ev_valid_time_too_long_test.go
+++ b/lints/lint_ev_valid_time_too_long_test.go
@@ -7,7 +7,7 @@ import (
 func TestEvValidTooLong(t *testing.T) {
 	inputPath := "../testlint/testCerts/evValidTooLong.cer"
 	desEnum := Error
-	out, _ := Lints["ev_valid_time_too_long"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ev_valid_time_too_long"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -20,7 +20,7 @@ func TestEvValidTooLong(t *testing.T) {
 func TestEvValidNotTooLong(t *testing.T) {
 	inputPath := "../testlint/testCerts/evValidNotTooLong.cer"
 	desEnum := Pass
-	out, _ := Lints["ev_valid_time_too_long"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ev_valid_time_too_long"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_aia_access_location_missing.go
+++ b/lints/lint_ext_aia_access_location_missing.go
@@ -42,7 +42,7 @@ func (l *aiaNoHTTPorLDAP) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_aia_access_location_missing",
+		Name:          "w_ext_aia_access_location_missing",
 		Description:   "When the id-ad-caIssuers accessMethod is used, at least one instance SHOULD specify an accessLocation that is an HTTP or LDAP URI.",
 		Providence:    "RFC 5280: 4.2.2.1",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_aia_access_location_missing_test.go
+++ b/lints/lint_ext_aia_access_location_missing_test.go
@@ -9,7 +9,7 @@ func TestAIAcaIssuerMissingHTTPorLDAP(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caIssuerNoHTTPLDAP.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_aia_access_location_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_aia_access_location_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestAIAcaIssuerHTTP(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caIssuerHTTP.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_aia_access_location_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_aia_access_location_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestAIAcaIssuerLDAP(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caIssuerLDAP.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_aia_access_location_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_aia_access_location_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -51,7 +51,7 @@ func TestAIAcaIssuerBlank(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caIssuerBlank.cer"
 	desEnum := NA
-	out, _ := Lints["ext_aia_access_location_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_aia_access_location_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_aia_marked_critical.go
+++ b/lints/lint_ext_aia_marked_critical.go
@@ -34,7 +34,7 @@ func (l *ExtAiaMarkedCritical) RunTest(cert *x509.Certificate) (ResultStruct, er
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_aia_marked_critical",
+		Name:          "e_ext_aia_marked_critical",
 		Description:   "Conforming CAs must mark the Authority Information Access extension as non-critical",
 		Providence:    "RFC 5280: 4.2.2.1",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_aia_marked_critical_test.go
+++ b/lints/lint_ext_aia_marked_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestAiaCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/aiaCrit.cer"
 	desEnum := Error
-	out, _ := Lints["ext_aia_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_aia_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestAiaCrit(t *testing.T) {
 func TestAiaNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAAIAValid.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_aia_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_aia_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_authority_key_identifier_critical.go
+++ b/lints/lint_ext_authority_key_identifier_critical.go
@@ -34,7 +34,7 @@ func (l *authorityKeyIdCritical) RunTest(c *x509.Certificate) (ResultStruct, err
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_authority_key_identifier_critical",
+		Name:          "e_ext_authority_key_identifier_critical",
 		Description:   "The authority key identifier extension must be non-critical.",
 		Providence:    "RFC 5280: 4.2.1.1",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_authority_key_identifier_critical_test.go
+++ b/lints/lint_ext_authority_key_identifier_critical_test.go
@@ -9,7 +9,7 @@ func TestAKICrit(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/akiCritical.cer"
 	desEnum := Error
-	out, _ := Lints["ext_authority_key_identifier_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_authority_key_identifier_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestAKINoCrit(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_authority_key_identifier_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_authority_key_identifier_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_authority_key_identifier_missing.go
+++ b/lints/lint_ext_authority_key_identifier_missing.go
@@ -43,7 +43,7 @@ func (l *authorityKeyIdMissing) RunTest(c *x509.Certificate) (ResultStruct, erro
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_authority_key_identifier_missing",
+		Name:          "e_ext_authority_key_identifier_missing",
 		Description:   "CAs must support key identifiers and include them in all certs",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.1",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_authority_key_identifier_missing_test.go
+++ b/lints/lint_ext_authority_key_identifier_missing_test.go
@@ -9,7 +9,7 @@ func TestAKIMissing(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/akiMissing.cer"
 	desEnum := Error
-	out, _ := Lints["ext_authority_key_identifier_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_authority_key_identifier_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestAKIPresent(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_authority_key_identifier_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_authority_key_identifier_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_authority_key_identifier_no_key_identifier.go
+++ b/lints/lint_ext_authority_key_identifier_no_key_identifier.go
@@ -43,7 +43,7 @@ func (l *authorityKeyIdNoKeyIdField) RunTest(c *x509.Certificate) (ResultStruct,
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_authority_key_identifier_no_key_identifier",
+		Name:          "e_ext_authority_key_identifier_no_key_identifier",
 		Description:   "CAs must include keyIdentifer field of aki in all non-self-issued certs",
 		Providence:    "RFC 5280: 4.2.1.1",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_authority_key_identifier_no_key_identifier_test.go
+++ b/lints/lint_ext_authority_key_identifier_no_key_identifier_test.go
@@ -9,7 +9,7 @@ func TestAKINoKeyID(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/akiNoKeyIdentifier.cer"
 	desEnum := Error
-	out, _ := Lints["ext_authority_key_identifier_no_key_identifier"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_authority_key_identifier_no_key_identifier"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestAKIKeyID(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_authority_key_identifier_no_key_identifier"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_authority_key_identifier_no_key_identifier"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestAKINoKeyIDOnRoot(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/rootCANoKeyIdentifiers.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_authority_key_identifier_no_key_identifier"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_authority_key_identifier_no_key_identifier"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_cert_policy_contains_noticeref.go
+++ b/lints/lint_ext_cert_policy_contains_noticeref.go
@@ -45,7 +45,7 @@ func (l *noticeRefPres) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_cert_policy_contains_noticeref",
+		Name:          "w_ext_cert_policy_contains_noticeref",
 		Description:   "Compliant certificates should not use the noticeRef option",
 		Providence:    "RFC 5280: 4.2.1.4",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_cert_policy_contains_noticeref_test.go
+++ b/lints/lint_ext_cert_policy_contains_noticeref_test.go
@@ -9,7 +9,7 @@ func TestNoticeRefUsed(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/userNoticePres.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_cert_policy_contains_noticeref"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_contains_noticeref"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestNoticeRefNotUsed(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/userNoticeMissing.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_cert_policy_contains_noticeref"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_contains_noticeref"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_cert_policy_disallowed_any_policy_qualifier.go
+++ b/lints/lint_ext_cert_policy_disallowed_any_policy_qualifier.go
@@ -42,7 +42,7 @@ func (l *unrecommendedQualifier) RunTest(c *x509.Certificate) (ResultStruct, err
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_cert_policy_disallowed_any_policy_qualifier",
+		Name:          "e_ext_cert_policy_disallowed_any_policy_qualifier",
 		Description:   "when qualifiers are used with the special policy anyPolicy, the must be limited to qualifiers identified in this section (4.2.1.4)",
 		Providence:    "RFC 5280: 4.2.1.4",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_ext_cert_policy_disallowed_any_policy_qualifier_test.go
+++ b/lints/lint_ext_cert_policy_disallowed_any_policy_qualifier_test.go
@@ -9,7 +9,7 @@ func TestNoticeRef(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/userNoticePres.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_cert_policy_disallowed_any_policy_qualifier"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_disallowed_any_policy_qualifier"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCps(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/userNoticeMissing.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_cert_policy_disallowed_any_policy_qualifier"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_disallowed_any_policy_qualifier"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestNoticeRefUnknown(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/userNoticeUnrecommended.cer"
 	desEnum := Error
-	out, _ := Lints["ext_cert_policy_disallowed_any_policy_qualifier"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_disallowed_any_policy_qualifier"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_cert_policy_duplicate.go
+++ b/lints/lint_ext_cert_policy_duplicate.go
@@ -43,7 +43,7 @@ func (l *ExtCertPolicyDuplicate) RunTest(cert *x509.Certificate) (ResultStruct, 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_cert_policy_duplicate",
+		Name:          "e_ext_cert_policy_duplicate",
 		Description:   "a cert policy OID must not appear more than once in the extension",
 		Providence:    "RFC 5280: 4.2.1.4",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_cert_policy_duplicate_test.go
+++ b/lints/lint_ext_cert_policy_duplicate_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyDuplicated(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/certPolicyDuplicateShort.cer"
 	desEnum := Error
-	out, _ := Lints["ext_cert_policy_duplicate"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_duplicate"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -22,7 +22,7 @@ func TestCertPolicyDuplicatedAssertion(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/certPolicyAssertionDuplicated.cer"
 	desEnum := Error
-	out, _ := Lints["ext_cert_policy_duplicate"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_duplicate"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -36,7 +36,7 @@ func TestCertPolicyNotDuplicated(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/certPolicyNoDuplicate.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_cert_policy_duplicate"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_duplicate"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_cert_policy_explicit_text_ia5_string.go
+++ b/lints/lint_ext_cert_policy_explicit_text_ia5_string.go
@@ -50,7 +50,7 @@ func (l *explicitTextIa5) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_cert_policy_explicit_text_ia5_string",
+		Name:          "e_ext_cert_policy_explicit_text_ia5_string",
 		Description:   "Compliant certificates must not encode explicitTest as IA5String",
 		Providence:    "RFC 6818: 3",
 		EffectiveDate: util.RFC6818Date,

--- a/lints/lint_ext_cert_policy_explicit_text_ia5_string_test.go
+++ b/lints/lint_ext_cert_policy_explicit_text_ia5_string_test.go
@@ -8,7 +8,7 @@ import (
 func TestExplicitTextIa5(t *testing.T) {
 	inputPath := "../testlint/testCerts/userNoticePres.cer"
 	desEnum := Error
-	out, _ := Lints["ext_cert_policy_explicit_text_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_explicit_text_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestExplicitTextIa5(t *testing.T) {
 func TestExplicitTextNotIa5(t *testing.T) {
 	inputPath := "../testlint/testCerts/userNoticeExpTextNotIa5.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_cert_policy_explicit_text_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_explicit_text_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestExplicitTextNotIa5(t *testing.T) {
 func TestExplicitTextNotPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/userNoticeMissing.cer"
 	desEnum := NA
-	out, _ := Lints["ext_cert_policy_explicit_text_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_explicit_text_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -48,7 +48,7 @@ func TestExplicitTextNotPresent2(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/userNoticeUnrecommended.cer"
 	desEnum := NA
-	out, _ := Lints["ext_cert_policy_explicit_text_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_explicit_text_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_cert_policy_explicit_text_includes_control.go
+++ b/lints/lint_ext_cert_policy_explicit_text_includes_control.go
@@ -68,7 +68,7 @@ func (l *controlChar) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_cert_policy_explicit_text_includes_control",
+		Name:          "w_ext_cert_policy_explicit_text_includes_control",
 		Description:   "Explicit text should not include any control charaters",
 		Providence:    "RFC 6818: 3",
 		EffectiveDate: util.RFC6818Date,

--- a/lints/lint_ext_cert_policy_explicit_text_includes_control_test.go
+++ b/lints/lint_ext_cert_policy_explicit_text_includes_control_test.go
@@ -9,7 +9,7 @@ func TestExplicitTextUtfControlX10(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/utf8ControlX10.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_cert_policy_explicit_text_includes_control"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_explicit_text_includes_control"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestExplicitTextUtfControlX88(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/utf8ControlX88.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_cert_policy_explicit_text_includes_control"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_explicit_text_includes_control"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestExplicitTextUtfNoControl(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/utf8NoControl.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_cert_policy_explicit_text_includes_control"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_explicit_text_includes_control"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_cert_policy_explicit_text_not_nfc.go
+++ b/lints/lint_ext_cert_policy_explicit_text_not_nfc.go
@@ -44,7 +44,7 @@ func (l *ExtCertPolicyExplicitTextNotNFC) RunTest(c *x509.Certificate) (ResultSt
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_cert_policy_explicit_text_not_nfc",
+		Name:          "w_ext_cert_policy_explicit_text_not_nfc",
 		Description:   "When utf8string or bmpstring encoding is used for explicitText field in cert policy, it SHOULD BE normalized by NFC format",
 		Providence:    "Fill this in...",
 		EffectiveDate: util.RFC6818Date,

--- a/lints/lint_ext_cert_policy_explicit_text_not_nfc_test.go
+++ b/lints/lint_ext_cert_policy_explicit_text_not_nfc_test.go
@@ -8,7 +8,7 @@ func TestExplicitTextUtf8NFC(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/userNoticeExpTextUtf8.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_cert_policy_explicit_text_not_nfc"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_explicit_text_not_nfc"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -22,7 +22,7 @@ func TestExplicitTextUtf8NotNFC(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/explicitTextUtf8NotNFC.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_cert_policy_explicit_text_not_nfc"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_explicit_text_not_nfc"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -36,7 +36,7 @@ func TestExplicitTextBMPNFC(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/explicitTextBMPNFC.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_cert_policy_explicit_text_not_nfc"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_explicit_text_not_nfc"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -50,7 +50,7 @@ func TestExplicitTextBMPNotNFC(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/explicitTextBMPNotNFC.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_cert_policy_explicit_text_not_nfc"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_explicit_text_not_nfc"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_cert_policy_explicit_text_not_utf8.go
+++ b/lints/lint_ext_cert_policy_explicit_text_not_utf8.go
@@ -49,7 +49,7 @@ func (l *explicitTextUtf8) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_cert_policy_explicit_text_not_utf8",
+		Name:          "w_ext_cert_policy_explicit_text_not_utf8",
 		Description:   "Compliant certificates should use the utf8string encoding for explicitText",
 		Providence:    "RFC 6818: 3",
 		EffectiveDate: util.RFC6818Date,

--- a/lints/lint_ext_cert_policy_explicit_text_not_utf8_test.go
+++ b/lints/lint_ext_cert_policy_explicit_text_not_utf8_test.go
@@ -9,7 +9,7 @@ func TestExplicitTextNotUtf8(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/userNoticePres.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_cert_policy_explicit_text_not_utf8"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_explicit_text_not_utf8"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestExplicitTextNotPresentUtf8(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/userNoticeMissing.cer"
 	desEnum := NA
-	out, _ := Lints["ext_cert_policy_explicit_text_not_utf8"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_explicit_text_not_utf8"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestExplicitTextUtf8(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/userNoticeExpTextUtf8.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_cert_policy_explicit_text_not_utf8"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_cert_policy_explicit_text_not_utf8"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_cert_policy_explicit_text_too_long.go
+++ b/lints/lint_ext_cert_policy_explicit_text_too_long.go
@@ -49,7 +49,7 @@ func (l *explicitTextTooLong) RunTest(c *x509.Certificate) (ResultStruct, error)
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_cert_policy_explicit_text_too_long",
+		Name:          "e_ext_cert_policy_explicit_text_too_long",
 		Description:   "explicit text has a maximum size of 200 characters",
 		Providence:    "RFC 6818: 3",
 		EffectiveDate: util.RFC6818Date,

--- a/lints/lint_ext_cert_policy_explicit_text_too_long_test.go
+++ b/lints/lint_ext_cert_policy_explicit_text_too_long_test.go
@@ -9,7 +9,7 @@ func TestExplicitText200Char(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/explicitText200Char.cer"
 	desEnum := Error
-	out, _ := Lints["ext_cert_policy_explicit_text_too_long"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_explicit_text_too_long"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestExplicitText7Char(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/userNoticeExpTextUtf8.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_cert_policy_explicit_text_too_long"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_cert_policy_explicit_text_too_long"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_crl_distribution_marked_critical.go
+++ b/lints/lint_ext_crl_distribution_marked_critical.go
@@ -35,7 +35,7 @@ func (l *ExtCrlDistributionMarkedCritical) RunTest(cert *x509.Certificate) (Resu
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_crl_distribution_marked_critical",
+		Name:          "w_ext_crl_distribution_marked_critical",
 		Description:   "If included, the CRL Distribution Points extension SHOULD NOT be marked critical.",
 		Providence:    "RFC 5280: 4.2.1.13",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_crl_distribution_marked_critical_test.go
+++ b/lints/lint_ext_crl_distribution_marked_critical_test.go
@@ -9,7 +9,7 @@ func TestCRLDistribCrit(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/subCAWcrlDistCrit.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_crl_distribution_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_crl_distribution_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCRLDistribNoCrit(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/subCAWcrlDistNoCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_crl_distribution_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_crl_distribution_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_duplicate_extension.go
+++ b/lints/lint_ext_duplicate_extension.go
@@ -37,7 +37,7 @@ func (l *ExtDuplicateExtension) RunTest(cert *x509.Certificate) (ResultStruct, e
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_duplicate_extension",
+		Name:          "e_ext_duplicate_extension",
 		Description:   "A certificate MUST NOT include more than one instance of a particular extension.",
 		Providence:    "RFC 5280: 4.2",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_duplicate_extension_test.go
+++ b/lints/lint_ext_duplicate_extension_test.go
@@ -9,7 +9,7 @@ func TestDuplicateExtension(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/extSANDuplicated.cer"
 	desEnum := Error
-	out, _ := Lints["ext_duplicate_extension"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_duplicate_extension"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestNoDuplicateExtension(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caBasicConstCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_duplicate_extension"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_duplicate_extension"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_freshest_crl_marked_critical.go
+++ b/lints/lint_ext_freshest_crl_marked_critical.go
@@ -35,7 +35,7 @@ func (l *ExtFreshestCrlMarkedCritical) RunTest(cert *x509.Certificate) (ResultSt
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_freshest_crl_marked_critical",
+		Name:          "e_ext_freshest_crl_marked_critical",
 		Description:   "Freshest CRL MUST be marked as non-critical by conforming CAs.",
 		Providence:    "RFC 5280: 4.2.1.15",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_ext_freshest_crl_marked_critical_test.go
+++ b/lints/lint_ext_freshest_crl_marked_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestFreshestCrlCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/frshCRLCritical.cer"
 	desEnum := Error
-	out, _ := Lints["ext_freshest_crl_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_freshest_crl_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestFreshestCrlCrit(t *testing.T) {
 func TestFreshestCrlNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/frshCRLNotCritical.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_freshest_crl_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_freshest_crl_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_ian_critical.go
+++ b/lints/lint_ext_ian_critical.go
@@ -34,7 +34,7 @@ func (l *ExtIANCritical) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_ian_critical",
+		Name:          "w_ext_ian_critical",
 		Description:   "issuer alternate name should be marked as non-critical",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_ian_critical_test.go
+++ b/lints/lint_ext_ian_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestIanCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianCritical.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_ian_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_ian_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestIanCrit(t *testing.T) {
 func TestIanNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianNotCritical.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_ian_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_ian_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_ian_dns_not_ia5_string.go
+++ b/lints/lint_ext_ian_dns_not_ia5_string.go
@@ -68,7 +68,7 @@ func (l *ianDnsNotIa5) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_ian_dns_not_ia5_string",
+		Name:          "e_ext_ian_dns_not_ia5_string",
 		Description:   "dNSNames are IA5 strings",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_ian_dns_not_ia5_string_test.go
+++ b/lints/lint_ext_ian_dns_not_ia5_string_test.go
@@ -8,7 +8,7 @@ import (
 func TestIanDnsIa5(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianDnsIa5.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_ian_dns_not_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_dns_not_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestIanDnsIa5(t *testing.T) {
 func TestIanDnsNotIa5(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianDnsNotIa5.cer"
 	desEnum := Error
-	out, _ := Lints["ext_ian_dns_not_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_dns_not_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_ian_empty_name.go
+++ b/lints/lint_ext_ian_empty_name.go
@@ -61,7 +61,7 @@ func (l *ianEmptyName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_ian_empty_name",
+		Name:          "e_ext_ian_empty_name",
 		Description:   "general name fields must not be empty in ian",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_ian_empty_name_test.go
+++ b/lints/lint_ext_ian_empty_name_test.go
@@ -8,7 +8,7 @@ import (
 func TestIanEmptyName(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianEmptyName.cer"
 	desEnum := Error
-	out, _ := Lints["ext_ian_empty_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_empty_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestIanEmptyName(t *testing.T) {
 func TestIanNotEmptyName(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianDnsIa5.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_ian_empty_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_empty_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_ian_no_entries.go
+++ b/lints/lint_ext_ian_no_entries.go
@@ -41,7 +41,7 @@ func (l *ianNoEntry) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_ian_no_entries",
+		Name:          "e_ext_ian_no_entries",
 		Description:   "if present, the ian extension must contain at least one entry",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_ian_no_entries_test.go
+++ b/lints/lint_ext_ian_no_entries_test.go
@@ -8,7 +8,7 @@ import (
 func TestIanNoEntry(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianEmpty.cer"
 	desEnum := Error
-	out, _ := Lints["ext_ian_no_entries"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_no_entries"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestIanNoEntry(t *testing.T) {
 func TestIanHasEntry(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianDnsIa5.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_ian_no_entries"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_no_entries"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_ian_rfc822_format_invalid.go
+++ b/lints/lint_ext_ian_rfc822_format_invalid.go
@@ -44,7 +44,7 @@ func (l *ianEmail) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_ian_rfc822_format_invalid",
+		Name:          "e_ext_ian_rfc822_format_invalid",
 		Description:   "email must not be surrounded with `<>`, and there must be no trailing comments in `()`",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_ian_rfc822_format_invalid_test.go
+++ b/lints/lint_ext_ian_rfc822_format_invalid_test.go
@@ -8,7 +8,7 @@ import (
 func TestIanInvalidEmail(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianInvalidEmail.cer"
 	desEnum := Error
-	out, _ := Lints["ext_ian_rfc822_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_rfc822_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestIanInvalidEmail(t *testing.T) {
 func TestIanValidEmail(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianValidEmail.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_ian_rfc822_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_rfc822_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_ian_space_dns_name.go
+++ b/lints/lint_ext_ian_space_dns_name.go
@@ -45,7 +45,7 @@ func (l *ianSpace) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_ian_space_dns_name",
+		Name:          "e_ext_ian_space_dns_name",
 		Description:   "the dNSName ` ` must not be used",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_ian_space_dns_name_test.go
+++ b/lints/lint_ext_ian_space_dns_name_test.go
@@ -8,7 +8,7 @@ import (
 func TestIanEmptyDns(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianEmptyDns.cer"
 	desEnum := Error
-	out, _ := Lints["ext_ian_space_dns_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_space_dns_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestIanEmptyDns(t *testing.T) {
 func TestIanNotEmptyDns(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianNonEmptyDns.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_ian_space_dns_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_space_dns_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_ian_uri_format_invalid.go
+++ b/lints/lint_ext_ian_uri_format_invalid.go
@@ -47,7 +47,7 @@ func (l *ianUriFormat) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_ian_uri_format_invalid",
+		Name:          "e_ext_ian_uri_format_invalid",
 		Description:   "URIs in SAN extension must have a scheme and scheme specific part",
 		Providence:    "RFC5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_ian_uri_format_invalid_test.go
+++ b/lints/lint_ext_ian_uri_format_invalid_test.go
@@ -8,7 +8,7 @@ import (
 func TestIanUriValid(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_ian_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestIanUriValid(t *testing.T) {
 func TestIanUriNoScheme(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURINoScheme.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestIanUriNoScheme(t *testing.T) {
 func TestIanUriNoSchemeSpecificPart(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURINoSchemeSpecificPart.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_ian_uri_host_not_fqdn_or_ip.go
+++ b/lints/lint_ext_ian_uri_host_not_fqdn_or_ip.go
@@ -45,7 +45,7 @@ func (l *ianUriFqdnOrIp) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_ian_uri_host_not_fqdn_or_ip",
+		Name:          "e_ext_ian_uri_host_not_fqdn_or_ip",
 		Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host.",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_ian_uri_host_not_fqdn_or_ip_test.go
+++ b/lints/lint_ext_ian_uri_host_not_fqdn_or_ip_test.go
@@ -8,7 +8,7 @@ import (
 func TestIanUriNotFqdn(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianUriHostNotFqdnOrIp.cer"
 	desEnum := Error
-	out, _ := Lints["ext_ian_uri_host_not_fqdn_or_ip"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_uri_host_not_fqdn_or_ip"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestIanUriNotFqdn(t *testing.T) {
 func TestIanUriFqdn(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianUriHostFqdn.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_ian_uri_host_not_fqdn_or_ip"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_uri_host_not_fqdn_or_ip"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestIanUriFqdn(t *testing.T) {
 func TestIanUriIp(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianUriHostIp.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_ian_uri_host_not_fqdn_or_ip"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_uri_host_not_fqdn_or_ip"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_ian_uri_not_ia5.go
+++ b/lints/lint_ext_ian_uri_not_ia5.go
@@ -37,7 +37,7 @@ func (l *ianUriIa5) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_ian_uri_not_ia5",
+		Name:          "e_ext_ian_uri_not_ia5",
 		Description:   "When SAN contains a URI, the name must be an IA5 string",
 		Providence:    "RFC5280: 4.2.1.7",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_ian_uri_not_ia5_test.go
+++ b/lints/lint_ext_ian_uri_not_ia5_test.go
@@ -8,7 +8,7 @@ import (
 func TestIanUriIA5(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURIIa5.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_ian_uri_not_ia5"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_uri_not_ia5"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestIanUriIA5(t *testing.T) {
 func TestIanUriNotIA5(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURINotIa5.cer"
 	desEnum := Error
-	out, _ := Lints["ext_ian_uri_not_ia5"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_uri_not_ia5"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_ian_uri_relative.go
+++ b/lints/lint_ext_ian_uri_relative.go
@@ -48,7 +48,7 @@ func (l *uriRelative) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_ian_uri_relative",
+		Name:          "e_ext_ian_uri_relative",
 		Description:   "When IAN extension is present and URI is used, the name must not be a relative URI ",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_ian_uri_relative_test.go
+++ b/lints/lint_ext_ian_uri_relative_test.go
@@ -8,7 +8,7 @@ import (
 func TestIanUriRelative(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURINoScheme.cer"
 	desEnum := Error
-	out, _ := Lints["ext_ian_uri_relative"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_uri_relative"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestIanUriRelative(t *testing.T) {
 func TestIanUriAbsolute(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_ian_uri_relative"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_ian_uri_relative"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_key_usage_cert_sign_without_ca.go
+++ b/lints/lint_ext_key_usage_cert_sign_without_ca.go
@@ -43,7 +43,7 @@ func (l *keyUsageCertSignNoCa) RunTest(c *x509.Certificate) (ResultStruct, error
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_key_usage_cert_sign_without_ca",
+		Name:          "e_ext_key_usage_cert_sign_without_ca",
 		Description:   "if the keyCertSign bit is asserted, then the cA bit MUST also be asserted",
 		Providence:    "RFC 5280: 4.2.1.3 & 4.2.1.9",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_ext_key_usage_cert_sign_without_ca_test.go
+++ b/lints/lint_ext_key_usage_cert_sign_without_ca_test.go
@@ -8,7 +8,7 @@ import (
 func TestCertSignNoCa(t *testing.T) {
 	inputPath := "../testlint/testCerts/keyUsageCertSignNoBC.cer"
 	desEnum := Error
-	out, _ := Lints["ext_key_usage_cert_sign_without_ca"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_key_usage_cert_sign_without_ca"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCertSignNoCa(t *testing.T) {
 func TestCertSignIsCa(t *testing.T) {
 	inputPath := "../testlint/testCerts/caKeyUsageNoCertSign.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_key_usage_cert_sign_without_ca"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_key_usage_cert_sign_without_ca"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_key_usage_not_critical.go
+++ b/lints/lint_ext_key_usage_not_critical.go
@@ -35,7 +35,7 @@ func (l *checkKeyUsageCritical) RunTest(c *x509.Certificate) (ResultStruct, erro
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_key_usage_not_critical",
+		Name:          "w_ext_key_usage_not_critical",
 		Description:   "The keyUsage extension SHOULD be critical.",
 		Providence:    "RFC 5280: 4.2.1.3",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_key_usage_not_critical_test.go
+++ b/lints/lint_ext_key_usage_not_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCertKeyUsageNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/keyUsageNotCriticalSubCert.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCertKeyUsageNotCrit(t *testing.T) {
 func TestSubCaKeyUsageNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/caKeyUsageNotCrit.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSubCaKeyUsageNotCrit(t *testing.T) {
 func TestSubCertKeyUsageCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -47,7 +47,7 @@ func TestSubCertKeyUsageCrit(t *testing.T) {
 func TestCaKeyUsageCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/caKeyUsageCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_key_usage_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -60,7 +60,7 @@ func TestCaKeyUsageCrit(t *testing.T) {
 func TestSubCertKeyUsageNotIncludedCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/caKeyUsageMissing.cer"
 	desEnum := NA
-	out, _ := Lints["ext_key_usage_without_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_key_usage_without_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_key_usage_without_bits.go
+++ b/lints/lint_ext_key_usage_without_bits.go
@@ -37,7 +37,7 @@ func (l *keyUsageBitsSet) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_key_usage_without_bits",
+		Name:          "e_ext_key_usage_without_bits",
 		Description:   "when included, at least one bit must be set to 1",
 		Providence:    "RFC 5280: 4.2.1.3",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_key_usage_without_bits_test.go
+++ b/lints/lint_ext_key_usage_without_bits_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCertKeyUsageWithoutBits(t *testing.T) {
 	inputPath := "../testlint/testCerts/keyUsageNoBits.cer"
 	desEnum := Error
-	out, _ := Lints["ext_key_usage_without_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_key_usage_without_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCertKeyUsageWithoutBits(t *testing.T) {
 func TestSubCertKeyUsageWithBits(t *testing.T) {
 	inputPath := "../testlint/testCerts/caKeyUsageCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_key_usage_without_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_key_usage_without_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSubCertKeyUsageWithBits(t *testing.T) {
 func TestSubCertKeyUsageNotIncludedBits(t *testing.T) {
 	inputPath := "../testlint/testCerts/caKeyUsageMissing.cer"
 	desEnum := NA
-	out, _ := Lints["ext_key_usage_without_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_key_usage_without_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_name_constraints_not_critical.go
+++ b/lints/lint_ext_name_constraints_not_critical.go
@@ -41,7 +41,7 @@ func (l *nameConstraintCrit) RunTest(c *x509.Certificate) (ResultStruct, error) 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_name_constraints_not_critical",
+		Name:          "e_ext_name_constraints_not_critical",
 		Description:   "If it is included, conforming CAs must mark the name constrains extension as critical.",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_name_constraints_not_critical_test.go
+++ b/lints/lint_ext_name_constraints_not_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestNameConstraintsNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWNameConstNoCrit.cer"
 	desEnum := Error
-	out, _ := Lints["ext_name_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_name_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestNameConstraintsNotCrit(t *testing.T) {
 func TestNameConstraintsCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWNameConstCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_name_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_name_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_name_constraints_not_in_ca.go
+++ b/lints/lint_ext_name_constraints_not_in_ca.go
@@ -39,7 +39,7 @@ func (l *nameConstraintNotCa) RunTest(c *x509.Certificate) (ResultStruct, error)
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_name_constraints_not_in_ca",
+		Name:          "e_ext_name_constraints_not_in_ca",
 		Description:   "The name constraints extension must only be used in CA certificates",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_name_constraints_not_in_ca_test.go
+++ b/lints/lint_ext_name_constraints_not_in_ca_test.go
@@ -8,7 +8,7 @@ import (
 func TestNameConstraintsNotInCa(t *testing.T) {
 	inputPath := "../testlint/testCerts/noNameConstraint.cer"
 	desEnum := Error
-	out, _ := Lints["ext_name_constraints_not_in_ca"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_name_constraints_not_in_ca"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestNameConstraintsNotInCa(t *testing.T) {
 func TestNameConstraintsInCa(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWNameConstCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_name_constraints_not_in_ca"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_name_constraints_not_in_ca"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_policy_constraints_empty.go
+++ b/lints/lint_ext_policy_constraints_empty.go
@@ -50,7 +50,7 @@ func (l *policyConstraintsContents) RunTest(c *x509.Certificate) (ResultStruct, 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_policy_constraints_empty",
+		Name:          "e_ext_policy_constraints_empty",
 		Description:   "Conforming CAs MUST NOT issue certificates where policy constraints is an empty sequence. That is, either the inhibitPolicyMapping field or the requireExplicityPolicy field MUST be present",
 		Providence:    "RFC 5280: 4.2.1.11",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_policy_constraints_empty_test.go
+++ b/lints/lint_ext_policy_constraints_empty_test.go
@@ -8,7 +8,7 @@ import (
 func TestPolicyConstraintsEmpty(t *testing.T) {
 	inputPath := "../testlint/testCerts/policyConstEmpty.cer"
 	desEnum := Error
-	out, _ := Lints["ext_policy_constraints_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_policy_constraints_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestPolicyConstraintsEmpty(t *testing.T) {
 func TestPolicyConstraintsNotEmpty(t *testing.T) {
 	inputPath := "../testlint/testCerts/policyConstGoodBoth.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_policy_constraints_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_policy_constraints_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_policy_constraints_not_critical.go
+++ b/lints/lint_ext_policy_constraints_not_critical.go
@@ -34,7 +34,7 @@ func (l *policyConstraintsCritical) RunTest(c *x509.Certificate) (ResultStruct, 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_policy_constraints_not_critical",
+		Name:          "e_ext_policy_constraints_not_critical",
 		Description:   "Conforming CAs must mark the policy constraints extension as critical.",
 		Providence:    "RFC 5280: 4.2.1.11",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_policy_constraints_not_critical_test.go
+++ b/lints/lint_ext_policy_constraints_not_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestPolicyConstraintsNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/policyConstNotCritical.cer"
 	desEnum := Error
-	out, _ := Lints["ext_policy_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_policy_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestPolicyConstraintsNotCrit(t *testing.T) {
 func TestPolicyConstraintsCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/policyConstGoodBoth.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_policy_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_policy_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_policy_map_any_policy.go
+++ b/lints/lint_ext_policy_map_any_policy.go
@@ -43,7 +43,7 @@ func (l *policyMapAnyPolicy) RunTest(c *x509.Certificate) (ResultStruct, error) 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_policy_map_any_policy",
+		Name:          "e_ext_policy_map_any_policy",
 		Description:   "policies must not be mapped to or from the anyPolicy value",
 		Providence:    "RFC 5280: 4.2.1.5",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_ext_policy_map_any_policy_test.go
+++ b/lints/lint_ext_policy_map_any_policy_test.go
@@ -8,7 +8,7 @@ import (
 func TestPolicyMapFromAnyPolicy(t *testing.T) {
 	inputPath := "../testlint/testCerts/policyMapFromAnyPolicy.cer"
 	desEnum := Error
-	out, _ := Lints["ext_policy_map_any_policy"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_policy_map_any_policy"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestPolicyMapFromAnyPolicy(t *testing.T) {
 func TestPolicyMapToAnyPolicy(t *testing.T) {
 	inputPath := "../testlint/testCerts/policyMapToAnyPolicy.cer"
 	desEnum := Error
-	out, _ := Lints["ext_policy_map_any_policy"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_policy_map_any_policy"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestPolicyMapToAnyPolicy(t *testing.T) {
 func TestPolicyMapToNoAnyPolicy(t *testing.T) {
 	inputPath := "../testlint/testCerts/policyMapGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_policy_map_any_policy"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_policy_map_any_policy"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_policy_map_not_critical.go
+++ b/lints/lint_ext_policy_map_not_critical.go
@@ -35,7 +35,7 @@ func (l *policyMapCritical) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_policy_map_not_critical",
+		Name:          "w_ext_policy_map_not_critical",
 		Description:   "Policy mappings should be marked as critical",
 		Providence:    "RFC 5280: 4.2.1.5",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_policy_map_not_critical_test.go
+++ b/lints/lint_ext_policy_map_not_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestPolicyMapNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/policyMapNotCritical.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_policy_map_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_policy_map_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestPolicyMapNotCrit(t *testing.T) {
 func TestPolicyMapCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/policyMapGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_policy_map_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_policy_map_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_policy_map_not_in_cert_policy.go
+++ b/lints/lint_ext_policy_map_not_in_cert_policy.go
@@ -43,7 +43,7 @@ func (l *policyMapMatchesCertPolicy) RunTest(c *x509.Certificate) (ResultStruct,
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_policy_map_not_in_cert_policy",
+		Name:          "w_ext_policy_map_not_in_cert_policy",
 		Description:   "each issuerDomainPolicy named in policy mappings extension should also be asserted in a certificate policies extension",
 		Providence:    "RFC 5280: 4.2.1.5",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_ext_policy_map_not_in_cert_policy_test.go
+++ b/lints/lint_ext_policy_map_not_in_cert_policy_test.go
@@ -8,7 +8,7 @@ import (
 func TestPolicyMapInCertPolicy(t *testing.T) {
 	inputPath := "../testlint/testCerts/policyMapIssuerNotInCertPolicy.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_policy_map_not_in_cert_policy"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_policy_map_not_in_cert_policy"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestPolicyMapInCertPolicy(t *testing.T) {
 func TestPolicyMapNotInCertPolicy(t *testing.T) {
 	inputPath := "../testlint/testCerts/policyMapGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_policy_map_not_in_cert_policy"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_policy_map_not_in_cert_policy"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_contains_reserved_ip.go
+++ b/lints/lint_ext_san_contains_reserved_ip.go
@@ -39,7 +39,7 @@ func (l *sanReservedIP) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_contains_reserved_ip",
+		Name:          "e_ext_san_contains_reserved_ip",
 		Description:   "Certs and expiring after 2015-11-01 must not contain a reserved ip address in the subjectAlternativeName extension.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ext_san_contains_reserved_ip_test.go
+++ b/lints/lint_ext_san_contains_reserved_ip_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanIPReserved(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanReservedIP.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanIPReserved(t *testing.T) {
 func TestSanIPReserved6(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanReservedIP6.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSanIPReserved6(t *testing.T) {
 func TestSanIPNotReserved(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanValidIP.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_critical_with_subject_dn.go
+++ b/lints/lint_ext_san_critical_with_subject_dn.go
@@ -39,7 +39,7 @@ func (l *ExtSANCriticalWithSubjectDN) RunTest(cert *x509.Certificate) (ResultStr
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_critical_with_subject_dn",
+		Name:          "w_ext_san_critical_with_subject_dn",
 		Description:   "If the subject contains a distinguished name SAN should be non-critical.",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_san_critical_with_subject_dn_test.go
+++ b/lints/lint_ext_san_critical_with_subject_dn_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanCritWithSubjectDn(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanCriticalSubjectUncommonOnly.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_san_critical_with_subject_dn"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_san_critical_with_subject_dn"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanCritWithSubjectDn(t *testing.T) {
 func TestSanNotCritWithSubjectDn(t *testing.T) {
 	inputPath := "../testlint/testCerts/indivValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_critical_with_subject_dn"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_san_critical_with_subject_dn"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_directory_name_present.go
+++ b/lints/lint_ext_san_directory_name_present.go
@@ -38,7 +38,7 @@ func (l *sanDirName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_directory_name_present",
+		Name:          "e_ext_san_directory_name_present",
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ext_san_directory_name_present_test.go
+++ b/lints/lint_ext_san_directory_name_present_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanDirNamePresent2(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanDirectoryNameBeginning.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_directory_name_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_directory_name_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanDirNamePresent2(t *testing.T) {
 func TestSanDirNamePresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanDirectoryNameEnd.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_directory_name_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_directory_name_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSanDirNamePresent(t *testing.T) {
 func TestSanDirNameMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanCaGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_directory_name_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_directory_name_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_dns_not_ia5_string.go
+++ b/lints/lint_ext_san_dns_not_ia5_string.go
@@ -68,7 +68,7 @@ func (l *sanDnsNotIa5) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_dns_not_ia5_string",
+		Name:          "e_ext_san_dns_not_ia5_string",
 		Description:   "dNSNames are IA5 strings",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_san_dns_not_ia5_string_test.go
+++ b/lints/lint_ext_san_dns_not_ia5_string_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanDnsNotIa5(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanDnsNotIa5.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_dns_not_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_dns_not_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanDnsNotIa5(t *testing.T) {
 func TestSanDnsIa5(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanCaGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_dns_not_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_dns_not_ia5_string"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_dns_syntax_incorrect.go
+++ b/lints/lint_ext_san_dns_syntax_incorrect.go
@@ -43,7 +43,7 @@ func (l *sanDNSPrefSyntax) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_dns_syntax_incorrect",
+		Name:          "e_ext_san_dns_syntax_incorrect",
 		Description:   "DNSNames must be in the preferred syntax.",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_ext_san_dns_syntax_incorrect_test.go
+++ b/lints/lint_ext_san_dns_syntax_incorrect_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanDNSSyntaxEndingHyphen(t *testing.T) {
 	inputPath := "../testlint/testCerts/sandnshyphensyntax.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_dns_syntax_incorrect"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_dns_syntax_incorrect"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanDNSSyntaxEndingHyphen(t *testing.T) {
 func TestSanDNSSyntaxExtraPeriods(t *testing.T) {
 	inputPath := "../testlint/testCerts/sandnsbadsyntax.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_dns_syntax_incorrect"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_dns_syntax_incorrect"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSanDNSSyntaxExtraPeriods(t *testing.T) {
 func TestSanDNSSyntaxNotAllowedChar(t *testing.T) {
 	inputPath := "../testlint/testCerts/sandnsdollarsyntax.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_dns_syntax_incorrect"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_dns_syntax_incorrect"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -47,7 +47,7 @@ func TestSanDNSSyntaxNotAllowedChar(t *testing.T) {
 func TestSanDNSSyntaxCorrect(t *testing.T) {
 	inputPath := "../testlint/testCerts/sandnsgoodsyntax.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_dns_syntax_incorrect"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_dns_syntax_incorrect"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_dnsname_not_fqdn.go
+++ b/lints/lint_ext_san_dnsname_not_fqdn.go
@@ -40,7 +40,7 @@ func (l *dnsFqdn) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_dnsname_not_fqdn",
+		Name:          "e_ext_san_dnsname_not_fqdn",
 		Description:   "SAN dnsnames must be a fully qualified domain name.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ext_san_dnsname_not_fqdn_test.go
+++ b/lints/lint_ext_san_dnsname_not_fqdn_test.go
@@ -8,7 +8,7 @@ import (
 func TestDnsFqdn(t *testing.T) {
 	inputPath := "../testlint/testCerts/dnsFqdn.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_dnsname_not_fqdn"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_dnsname_not_fqdn"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestDnsFqdn(t *testing.T) {
 func TestDnsNotFqdn(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanOtherName.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_dnsname_not_fqdn"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_dnsname_not_fqdn"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_edi_party_name_present.go
+++ b/lints/lint_ext_san_edi_party_name_present.go
@@ -38,7 +38,7 @@ func (l *sanEdi) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_edi_party_name_present",
+		Name:          "e_ext_san_edi_party_name_present",
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ext_san_edi_party_name_present_test.go
+++ b/lints/lint_ext_san_edi_party_name_present_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanEdiPartyPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanEdiParty.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_edi_party_name_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_edi_party_name_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanEdiPartyPresent(t *testing.T) {
 func TestSanEdiPartyMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanOtherName.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_edi_party_name_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_edi_party_name_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_empty_name.go
+++ b/lints/lint_ext_san_empty_name.go
@@ -61,7 +61,7 @@ func (l *sanEmptyName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_empty_name",
+		Name:          "e_ext_san_empty_name",
 		Description:   "general name fields must not be empty in san",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_san_empty_name_test.go
+++ b/lints/lint_ext_san_empty_name_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanEmptyName(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanEmptyName.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_empty_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_empty_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanEmptyName(t *testing.T) {
 func TestSanNotEmptyName(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanCaGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_empty_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_empty_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_missing.go
+++ b/lints/lint_ext_san_missing.go
@@ -35,7 +35,7 @@ func (l *sanMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_missing",
+		Name:          "e_ext_san_missing",
 		Description:   "Certificates must contain the Subject Alternate Name extension.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ext_san_missing_test.go
+++ b/lints/lint_ext_san_missing_test.go
@@ -8,7 +8,7 @@ import (
 func TestNoSan(t *testing.T) {
 	inputPath := "../testlint/testCerts/subjectEmptyNoSan.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestNoSan(t *testing.T) {
 func TestHasSan(t *testing.T) {
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_no_entries.go
+++ b/lints/lint_ext_san_no_entries.go
@@ -41,7 +41,7 @@ func (l *sanNoEntry) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_no_entries",
+		Name:          "e_ext_san_no_entries",
 		Description:   "if present, the san extension must contain at least one entry",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_san_no_entries_test.go
+++ b/lints/lint_ext_san_no_entries_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanNoEntry(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanNoEntries.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_no_entries"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_no_entries"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanNoEntry(t *testing.T) {
 func TestSanHasEntry(t *testing.T) {
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_no_entries"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_no_entries"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_not_critical_without_subject.go
+++ b/lints/lint_ext_san_not_critical_without_subject.go
@@ -41,7 +41,7 @@ func (l *extSanNotCritNoSubject) RunTest(c *x509.Certificate) (ResultStruct, err
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_not_critical_without_subject",
+		Name:          "e_ext_san_not_critical_without_subject",
 		Description:   "If there is an empty subject field, then the san extension must be critical",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_san_not_critical_without_subject_test.go
+++ b/lints/lint_ext_san_not_critical_without_subject_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubjectEmptySanNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanSubjectEmptyNotCritical.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_not_critical_without_subject"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_not_critical_without_subject"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubjectEmptySanNotCrit(t *testing.T) {
 func TestSubjectEmptySanCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCaEmptySubject.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_not_critical_without_subject"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_not_critical_without_subject"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSubjectEmptySanCrit(t *testing.T) {
 func TestSubjectNotEmptySanCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanCriticalSubjectUncommonOnly.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_not_critical_without_subject"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_not_critical_without_subject"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_other_name_present.go
+++ b/lints/lint_ext_san_other_name_present.go
@@ -38,7 +38,7 @@ func (l *sanOtherName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_other_name_present",
+		Name:          "e_ext_san_other_name_present",
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ext_san_other_name_present_test.go
+++ b/lints/lint_ext_san_other_name_present_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanOtherNamePresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanOtherName.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_other_name_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_other_name_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanOtherNamePresent(t *testing.T) {
 func TestSanOtherNameMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanEdiParty.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_other_name_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_other_name_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_registered_id_present.go
+++ b/lints/lint_ext_san_registered_id_present.go
@@ -38,7 +38,7 @@ func (l *sanRegId) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_registered_id_present",
+		Name:          "e_ext_san_registered_id_present",
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ext_san_registered_id_present_test.go
+++ b/lints/lint_ext_san_registered_id_present_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanRegIdMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanCaGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_registered_id_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_registered_id_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanRegIdMissing(t *testing.T) {
 func TestSanRegIdPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanRegisteredIdBeginning.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_registered_id_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_registered_id_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSanRegIdPresent(t *testing.T) {
 func TestSanRegIdPresent2(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanRegisteredIdEnd.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_registered_id_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_registered_id_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_rfc822_format_invalid.go
+++ b/lints/lint_ext_san_rfc822_format_invalid.go
@@ -44,7 +44,7 @@ func (l *invalidEmail) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_rfc822_format_invalid",
+		Name:          "e_ext_san_rfc822_format_invalid",
 		Description:   "email must not be surrounded with `<>`, and there must be no trailing comments in `()`",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_san_rfc822_format_invalid_test.go
+++ b/lints/lint_ext_san_rfc822_format_invalid_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanInvalidEmail(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanWithInvalidEmail.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_rfc822_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_rfc822_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanInvalidEmail(t *testing.T) {
 func TestSanInvalidEmail2(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanWithInvalidEmail2.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_rfc822_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_rfc822_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSanInvalidEmail2(t *testing.T) {
 func TestSanValidEmail(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanWithValidEmail.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_rfc822_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_rfc822_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_rfc822_name_present.go
+++ b/lints/lint_ext_san_rfc822_name_present.go
@@ -38,7 +38,7 @@ func (l *sanRfc822) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_rfc822_name_present",
+		Name:          "e_ext_san_rfc822_name_present",
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ext_san_rfc822_name_present_test.go
+++ b/lints/lint_ext_san_rfc822_name_present_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanEmailPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanRFC822Beginning.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_rfc822_name_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_rfc822_name_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanEmailPresent(t *testing.T) {
 func TestSanEmailPresent2(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanRFC822End.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_rfc822_name_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_rfc822_name_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSanEmailPresent2(t *testing.T) {
 func TestSanEmailMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanCaGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_rfc822_name_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_rfc822_name_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_space_dns_name.go
+++ b/lints/lint_ext_san_space_dns_name.go
@@ -45,7 +45,7 @@ func (l *sanIsSpaceDNS) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_space_dns_name",
+		Name:          "e_ext_san_space_dns_name",
 		Description:   "the dNSName ` ` must not be used",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_san_space_dns_name_test.go
+++ b/lints/lint_ext_san_space_dns_name_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanGood(t *testing.T) {
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_space_dns_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_space_dns_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanGood(t *testing.T) {
 func TestSanSpace(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanWithSpaceDns.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_space_dns_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_space_dns_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_uniform_resource_identifier_present.go
+++ b/lints/lint_ext_san_uniform_resource_identifier_present.go
@@ -38,7 +38,7 @@ func (l *sanUri) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_uniform_resource_identifier_present",
+		Name:          "e_ext_san_uniform_resource_identifier_present",
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ext_san_uniform_resource_identifier_present_test.go
+++ b/lints/lint_ext_san_uniform_resource_identifier_present_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanURIMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanCaGood.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_uniform_resource_identifier_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uniform_resource_identifier_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanURIMissing(t *testing.T) {
 func TestSanURIPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURIBeginning.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_uniform_resource_identifier_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uniform_resource_identifier_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSanURIPresent(t *testing.T) {
 func TestSanURIPresent2(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURIEnd.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_uniform_resource_identifier_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uniform_resource_identifier_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_uri_format_invalid.go
+++ b/lints/lint_ext_san_uri_format_invalid.go
@@ -47,7 +47,7 @@ func (l *extSanURIFormatInvalid) RunTest(c *x509.Certificate) (ResultStruct, err
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_uri_format_invalid",
+		Name:          "e_ext_san_uri_format_invalid",
 		Description:   "URIs in SAN extension must have a scheme and scheme specific part",
 		Providence:    "RFC5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_san_uri_format_invalid_test.go
+++ b/lints/lint_ext_san_uri_format_invalid_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanUriValid(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanUriValid(t *testing.T) {
 func TestSanUriNoScheme(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURINoScheme.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSanUriNoScheme(t *testing.T) {
 func TestSanUriNoSchemeSpecificPart(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURINoSchemeSpecificPart.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uri_format_invalid"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
+++ b/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
@@ -45,7 +45,7 @@ func (l *sanUriHost) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_uri_host_not_fqdn_or_ip",
+		Name:          "e_ext_san_uri_host_not_fqdn_or_ip",
 		Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host.",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_san_uri_host_not_fqdn_or_ip_test.go
+++ b/lints/lint_ext_san_uri_host_not_fqdn_or_ip_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanUriNotFqdn(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanUriNotFqdn.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_uri_host_not_fqdn_or_ip"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uri_host_not_fqdn_or_ip"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_uri_not_ia5.go
+++ b/lints/lint_ext_san_uri_not_ia5.go
@@ -37,7 +37,7 @@ func (l *extSanURINotIA5) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_uri_not_ia5",
+		Name:          "e_ext_san_uri_not_ia5",
 		Description:   "When SAN contains a URI, the name must be an IA5 string",
 		Providence:    "RFC5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_san_uri_not_ia5_test.go
+++ b/lints/lint_ext_san_uri_not_ia5_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanUriIA5(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURIIA5.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_uri_not_ia5"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uri_not_ia5"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanUriIA5(t *testing.T) {
 func TestSanUriNotIA5(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURINotIA5.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_uri_not_ia5"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uri_not_ia5"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_san_uri_relative.go
+++ b/lints/lint_ext_san_uri_relative.go
@@ -48,7 +48,7 @@ func (l *extSanUriRelative) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_san_uri_relative",
+		Name:          "e_ext_san_uri_relative",
 		Description:   "When SAN extension is present and URI is used, the name must not be a relative URI ",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_ext_san_uri_relative_test.go
+++ b/lints/lint_ext_san_uri_relative_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanUriRelative(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURIRelative.cer"
 	desEnum := Error
-	out, _ := Lints["ext_san_uri_relative"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uri_relative"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanUriRelative(t *testing.T) {
 func TestSanUriAbsolute(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURIAbsolute.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_san_uri_relative"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_san_uri_relative"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_subject_directory_attr_critical.go
+++ b/lints/lint_ext_subject_directory_attr_critical.go
@@ -36,7 +36,7 @@ func (l *subDirAttrCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_subject_directory_attr_critical",
+		Name:          "e_ext_subject_directory_attr_critical",
 		Description:   "Conforming CAs must mark the Subject Directory Attributes extension as not critical",
 		Providence:    "RFC 5280: 4.2.1.8",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_subject_directory_attr_critical_test.go
+++ b/lints/lint_ext_subject_directory_attr_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestSdaCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subDirAttCritical.cer"
 	desEnum := Error
-	out, _ := Lints["ext_subject_directory_attr_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_subject_directory_attr_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSdaCrit(t *testing.T) {
 func TestSdaNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/RFC5280example2.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_subject_directory_attr_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_subject_directory_attr_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_subject_key_identifier_critical.go
+++ b/lints/lint_ext_subject_key_identifier_critical.go
@@ -34,7 +34,7 @@ func (l *subjectKeyIdCritical) RunTest(c *x509.Certificate) (ResultStruct, error
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_subject_key_identifier_critical",
+		Name:          "e_ext_subject_key_identifier_critical",
 		Description:   "The subject key identifier extension must be non-critical.",
 		Providence:    "RFC 5280: 4.2.1.2",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_subject_key_identifier_critical_test.go
+++ b/lints/lint_ext_subject_key_identifier_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestSkiCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/skiCriticalCA.cer"
 	desEnum := Error
-	out, _ := Lints["ext_subject_key_identifier_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_subject_key_identifier_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSkiCrit(t *testing.T) {
 func TestSkiNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/skiNotCriticalCA.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_subject_key_identifier_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_subject_key_identifier_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_subject_key_identifier_missing_ca.go
+++ b/lints/lint_ext_subject_key_identifier_missing_ca.go
@@ -48,7 +48,7 @@ func (l *subjectKeyIdMissingCA) RunTest(cert *x509.Certificate) (ResultStruct, e
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_subject_key_identifier_missing_ca",
+		Name:          "e_ext_subject_key_identifier_missing_ca",
 		Description:   "CAs must include ski in all CA certificates.",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.2",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_subject_key_identifier_missing_ca_test.go
+++ b/lints/lint_ext_subject_key_identifier_missing_ca_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCaSkiMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCANoSKI.cer"
 	desEnum := Error
-	out, _ := Lints["ext_subject_key_identifier_missing_ca"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_subject_key_identifier_missing_ca"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCaSkiMissing(t *testing.T) {
 func TestSubCaSkiPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/skiNotCriticalCA.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_subject_key_identifier_missing_ca"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ext_subject_key_identifier_missing_ca"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ext_subject_key_identifier_missing_sub_cert.go
+++ b/lints/lint_ext_subject_key_identifier_missing_sub_cert.go
@@ -48,7 +48,7 @@ func (l *subjectKeyIdMissingSubscriber) RunTest(cert *x509.Certificate) (ResultS
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_subject_key_identifier_missing_sub_cert",
+		Name:          "w_ext_subject_key_identifier_missing_sub_cert",
 		Description:   "Sub certs should include ski in end entity certs",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.2",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_ext_subject_key_identifier_missing_sub_cert_test.go
+++ b/lints/lint_ext_subject_key_identifier_missing_sub_cert_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCertSkiMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertNoSKI.cer"
 	desEnum := Warn
-	out, _ := Lints["ext_subject_key_identifier_missing_sub_cert"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_subject_key_identifier_missing_sub_cert"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCertSkiMissing(t *testing.T) {
 func TestSubCertSkiPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["ext_subject_key_identifier_missing_sub_cert"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ext_subject_key_identifier_missing_sub_cert"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_generalized_time_does_not_include_seconds.go
+++ b/lints/lint_generalized_time_does_not_include_seconds.go
@@ -71,7 +71,7 @@ func checkSeconds(r *ResultEnum, t asn1.RawValue) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "generalized_time_does_not_include_seconds",
+		Name:          "e_generalized_time_does_not_include_seconds",
 		Description:   "Generalized time values must include seconds",
 		Providence:    "RFC 5280: 4.1.2.5.2",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_generalized_time_includes_fraction_seconds.go
+++ b/lints/lint_generalized_time_includes_fraction_seconds.go
@@ -71,7 +71,7 @@ func checkFraction(r *ResultEnum, t asn1.RawValue) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "generalized_time_includes_fraction_seconds",
+		Name:          "e_generalized_time_includes_fraction_seconds",
 		Description:   "Generalized time values must not include fraction seconds",
 		Providence:    "RFC 5280: 4.1.2.5.2",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_generalized_time_not_in_zulu.go
+++ b/lints/lint_generalized_time_not_in_zulu.go
@@ -53,7 +53,7 @@ func (l *generalizedNotZulu) RunTest(c *x509.Certificate) (ResultStruct, error) 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "generalized_time_not_in_zulu",
+		Name:          "e_generalized_time_not_in_zulu",
 		Description:   "Generalized time values must be expressed in Greenwich Mean Time (Zulu)",
 		Providence:    "RFC 5280: 4.1.2.5.2",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_generalized_time_not_in_zulu_test.go
+++ b/lints/lint_generalized_time_not_in_zulu_test.go
@@ -8,7 +8,7 @@ import (
 func TestGenralizedNotZulu(t *testing.T) {
 	inputPath := "../testlint/testCerts/generalizedNotZulu.cer"
 	desEnum := Error
-	out, _ := Lints["generalized_time_not_in_zulu"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_generalized_time_not_in_zulu"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestGenralizedNotZulu(t *testing.T) {
 func TestGenralizedZulu(t *testing.T) {
 	inputPath := "../testlint/testCerts/generalizedHasSeconds.cer"
 	desEnum := Pass
-	out, _ := Lints["generalized_time_not_in_zulu"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_generalized_time_not_in_zulu"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_gtld_under_consideration.go
+++ b/lints/lint_gtld_under_consideration.go
@@ -46,7 +46,7 @@ func (l *gtldUnderConsideration) RunTest(c *x509.Certificate) (ResultStruct, err
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "gtld_under_consideration",
+		Name:          "w_gtld_under_consideration",
 		Description:   "CAs SHOULD NOT issue Certificates containing a new gTLD under consideration by ICANN.",
 		Providence:    "CAB: 4.2.2",
 		EffectiveDate: util.CABV113Date,

--- a/lints/lint_gtld_under_consideration_test.go
+++ b/lints/lint_gtld_under_consideration_test.go
@@ -8,7 +8,7 @@ import (
 func TestGTLDCommonNameIP(t *testing.T) {
 	inputPath := "../testlint/testCerts/gtldcnip.cer"
 	desEnum := Pass
-	out, _ := Lints["gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -20,7 +20,7 @@ func TestGTLDCommonNameIP(t *testing.T) {
 func TestGTLDCommonNameNotDN(t *testing.T) {
 	inputPath := "../testlint/testCerts/gtldcnnotdn.cer"
 	desEnum := Pass
-	out, _ := Lints["gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -32,7 +32,7 @@ func TestGTLDCommonNameNotDN(t *testing.T) {
 func TestGTLDCommonNameValid(t *testing.T) {
 	inputPath := "../testlint/testCerts/gtldcnvalid.cer"
 	desEnum := Pass
-	out, _ := Lints["gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -44,7 +44,7 @@ func TestGTLDCommonNameValid(t *testing.T) {
 func TestGTLDCommonNameInvalid(t *testing.T) {
 	inputPath := "../testlint/testCerts/gtldcnbad.cer"
 	desEnum := Warn
-	out, _ := Lints["gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -57,7 +57,7 @@ func TestGTLDCommonNameInvalid(t *testing.T) {
 func TestGTLDDNSNamesIP(t *testing.T) {
 	inputPath := "../testlint/testCerts/gtlddnsip.cer"
 	desEnum := Pass
-	out, _ := Lints["gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -69,7 +69,7 @@ func TestGTLDDNSNamesIP(t *testing.T) {
 func TestGTLDDNSNamesValid(t *testing.T) {
 	inputPath := "../testlint/testCerts/gtlddnsvalid.cer"
 	desEnum := Pass
-	out, _ := Lints["gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -82,7 +82,7 @@ func TestGTLDDNSNamesValid(t *testing.T) {
 func TestGTLDDNSNamesNotDn(t *testing.T) {
 	inputPath := "../testlint/testCerts/gtlddnsnotdn.cer"
 	desEnum := Pass
-	out, _ := Lints["gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -95,7 +95,7 @@ func TestGTLDDNSNamesNotDn(t *testing.T) {
 func TestGTLDDNSNamesInvalid(t *testing.T) {
 	inputPath := "../testlint/testCerts/gtlddnsbad.cer"
 	desEnum := Warn
-	out, _ := Lints["gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_gtld_under_consideration"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ian_bare_wildcard.go
+++ b/lints/lint_ian_bare_wildcard.go
@@ -31,7 +31,7 @@ func (l *brIanBareWildcard) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ian_bare_wildcard",
+		Name:          "e_ian_bare_wildcard",
 		Description:   "Wildcard MUST be accompanied by other data to it's right (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ian_bare_wildcard_test.go
+++ b/lints/lint_ian_bare_wildcard_test.go
@@ -8,7 +8,7 @@ import (
 func TestBrIanBareWildcard(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianBareWildcard.cer"
 	desEnum := Error
-	out, _ := Lints["ian_bare_wildcard"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ian_bare_wildcard"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestBrIanBareWildcard(t *testing.T) {
 func TestBrIanNotBareWildcard(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["ian_bare_wildcard"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ian_bare_wildcard"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ian_dns_name_includes_null_char.go
+++ b/lints/lint_ian_dns_name_includes_null_char.go
@@ -32,7 +32,7 @@ func (l *ianDnsNull) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ian_dns_name_includes_null_char",
+		Name:          "e_ian_dns_name_includes_null_char",
 		Description:   "DNSNames MUST NOT include a null character ",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ian_dns_name_includes_null_char_test.go
+++ b/lints/lint_ian_dns_name_includes_null_char_test.go
@@ -8,7 +8,7 @@ import (
 func TestBrIanDnsNull(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianDnsNull.cer"
 	desEnum := Error
-	out, _ := Lints["ian_dns_name_includes_null_char"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ian_dns_name_includes_null_char"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestBrIanDnsNull(t *testing.T) {
 func TestBrIanDnsNotNull(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["ian_dns_name_includes_null_char"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ian_dns_name_includes_null_char"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ian_dns_name_starts_with_period.go
+++ b/lints/lint_ian_dns_name_starts_with_period.go
@@ -31,7 +31,7 @@ func (l *ianDnsPeriod) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ian_dns_name_starts_with_period",
+		Name:          "e_ian_dns_name_starts_with_period",
 		Description:   "DNSName MUST NOT start with a period",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ian_dns_name_starts_with_period_test.go
+++ b/lints/lint_ian_dns_name_starts_with_period_test.go
@@ -8,7 +8,7 @@ import (
 func TestBrIanDnsStartsWithPeriod(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianDnsPeriod.cer"
 	desEnum := Error
-	out, _ := Lints["ian_dns_name_starts_with_period"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ian_dns_name_starts_with_period"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestBrIanDnsStartsWithPeriod(t *testing.T) {
 func TestBrIanDnsNotPeriod(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["ian_dns_name_starts_with_period"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ian_dns_name_starts_with_period"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ian_iana_pub_suffix_empty.go
+++ b/lints/lint_ian_iana_pub_suffix_empty.go
@@ -31,7 +31,7 @@ func (l *ianPubSuffix) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ian_iana_pub_suffix_empty",
+		Name:          "w_ian_iana_pub_suffix_empty",
 		Description:   "Domain SHOULD NOT have bare public suffix",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ian_iana_pub_suffix_empty_test.go
+++ b/lints/lint_ian_iana_pub_suffix_empty_test.go
@@ -8,7 +8,7 @@ import (
 func TestIanBarePubSuffix(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianBareSuffix.cer"
 	desEnum := Warn
-	out, _ := Lints["ian_iana_pub_suffix_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ian_iana_pub_suffix_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestIanBarePubSuffix(t *testing.T) {
 func TestIanGoodPubSuffix(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianGoodSuffix.cer"
 	desEnum := Pass
-	out, _ := Lints["ian_iana_pub_suffix_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ian_iana_pub_suffix_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ian_wildcard_not_first.go
+++ b/lints/lint_ian_wildcard_not_first.go
@@ -32,7 +32,7 @@ func (l *brIanWildcardFirst) RunTest(c *x509.Certificate) (ResultStruct, error) 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ian_wildcard_not_first",
+		Name:          "e_ian_wildcard_not_first",
 		Description:   "Wildcard MUST be in the first label of FQDN, ie not: www.*.com (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ian_wildcard_not_first_test.go
+++ b/lints/lint_ian_wildcard_not_first_test.go
@@ -8,7 +8,7 @@ import (
 func TestBrIanWildcardFirst(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianWildcardFirst.cer"
 	desEnum := Error
-	out, _ := Lints["ian_wildcard_not_first"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ian_wildcard_not_first"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestBrIanWildcardFirst(t *testing.T) {
 func TestBrIanWildcardNotFirst(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["ian_wildcard_not_first"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_ian_wildcard_not_first"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_inhibit_any_policy_not_critical.go
+++ b/lints/lint_inhibit_any_policy_not_critical.go
@@ -42,7 +42,7 @@ func (l *InhibitAnyPolicyNotCritical) RunTest(cert *x509.Certificate) (ResultStr
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "inhibit_any_policy_not_critical",
+		Name:          "e_inhibit_any_policy_not_critical",
 		Description:   "CAs must mark the inhibitAnyPolicy extension as critical",
 		Providence:    "RFC 5280: 4.2.1.14",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_inhibit_any_policy_not_critical_test.go
+++ b/lints/lint_inhibit_any_policy_not_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestInhibitAnyPolicyNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/inhibitAnyNotCrit.cer"
 	desEnum := Error
-	out, _ := Lints["inhibit_any_policy_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_inhibit_any_policy_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestInhibitAnyPolicyNotCrit(t *testing.T) {
 func TestInhibitAnyPolicyCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/inhibitAnyCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["inhibit_any_policy_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_inhibit_any_policy_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_invalid_certificate_version.go
+++ b/lints/lint_invalid_certificate_version.go
@@ -32,7 +32,7 @@ func (l *InvalidCertificateVersion) RunTest(cert *x509.Certificate) (ResultStruc
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "invalid_certificate_version",
+		Name:          "e_invalid_certificate_version",
 		Description:   "Certificate must be version 3 (encoded as 2)",
 		Providence:    "CAB: 7.1.1",
 		EffectiveDate: util.CABV130Date,

--- a/lints/lint_invalid_certificate_version_test.go
+++ b/lints/lint_invalid_certificate_version_test.go
@@ -8,7 +8,7 @@ import (
 func TestCertVersion2(t *testing.T) {
 	inputPath := "../testlint/testCerts/certVersion2WithExtension.cer"
 	desEnum := Error
-	out, _ := Lints["invalid_certificate_version"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_invalid_certificate_version"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCertVersion2(t *testing.T) {
 func TestCertVersion3(t *testing.T) {
 	inputPath := "../testlint/testCerts/certVersion3NoExtensions.cer"
 	desEnum := Pass
-	out, _ := Lints["invalid_certificate_version"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_invalid_certificate_version"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_issuer_field_empty.go
+++ b/lints/lint_issuer_field_empty.go
@@ -37,7 +37,7 @@ func (l *issuerFieldEmpty) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "issuer_field_empty",
+		Name:          "e_issuer_field_empty",
 		Description:   "Certificates issuer field must not be empty and must have a non-empty distingushed name",
 		Providence:    "RFC 5280: 4.1.2.4",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_issuer_field_empty_test.go
+++ b/lints/lint_issuer_field_empty_test.go
@@ -8,7 +8,7 @@ import (
 func TestNoIssuerField(t *testing.T) {
 	inputPath := "../testlint/testCerts/issuerFieldMissing.cer"
 	desEnum := Error
-	out, _ := Lints["issuer_field_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_issuer_field_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestNoIssuerField(t *testing.T) {
 func TestHasIssuerField(t *testing.T) {
 	inputPath := "../testlint/testCerts/issuerFieldFilled.cer"
 	desEnum := Pass
-	out, _ := Lints["issuer_field_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_issuer_field_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_name_constraint_empty.go
+++ b/lints/lint_name_constraint_empty.go
@@ -53,7 +53,7 @@ func (l *nameConstraintEmpty) RunTest(c *x509.Certificate) (ResultStruct, error)
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "name_constraint_empty",
+		Name:          "e_name_constraint_empty",
 		Description:   "Conforming CAs must not issue certificates where name constraints is an empty sequence. That is, either the permittedSubtree or excludedSubtree fields must be present",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_name_constraint_empty_test.go
+++ b/lints/lint_name_constraint_empty_test.go
@@ -8,7 +8,7 @@ import (
 func TestNoNameConstraint(t *testing.T) {
 	inputPath := "../testlint/testCerts/noNameConstraint.cer"
 	desEnum := Error
-	out, _ := Lints["name_constraint_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_name_constraint_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestNoNameConstraint(t *testing.T) {
 func TestHasNameConstraint(t *testing.T) {
 	inputPath := "../testlint/testCerts/yesNameConstraint.cer"
 	desEnum := Pass
-	out, _ := Lints["name_constraint_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_name_constraint_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_name_constraint_maximum_not_absent.go
+++ b/lints/lint_name_constraint_maximum_not_absent.go
@@ -105,7 +105,7 @@ func (l *nameConstraintMax) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "name_constraint_maximum_not_absent",
+		Name:          "e_name_constraint_maximum_not_absent",
 		Description:   "In the name constraints name forms the maximum is not used and therefore MUST be absent",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_name_constraint_maximum_not_absent_test.go
+++ b/lints/lint_name_constraint_maximum_not_absent_test.go
@@ -8,7 +8,7 @@ import (
 func TestNcMaxPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/ncAllPres.cer"
 	desEnum := Error
-	out, _ := Lints["name_constraint_maximum_not_absent"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_name_constraint_maximum_not_absent"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestNcMaxPresent(t *testing.T) {
 func TestNcMinPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/ncMinPres.cer"
 	desEnum := Pass
-	out, _ := Lints["name_constraint_maximum_not_absent"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_name_constraint_maximum_not_absent"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestNcMinPresent(t *testing.T) {
 func TestNcEmptyValue(t *testing.T) {
 	inputPath := "../testlint/testCerts/ncEmptyValue.cer"
 	desEnum := Pass
-	out, _ := Lints["name_constraint_maximum_not_absent"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_name_constraint_maximum_not_absent"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_name_constraint_minimum_non_zero.go
+++ b/lints/lint_name_constraint_minimum_non_zero.go
@@ -105,7 +105,7 @@ func (l *nameConstMin) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "name_constraint_minimum_non_zero",
+		Name:          "e_name_constraint_minimum_non_zero",
 		Description:   "In the name constraints name forms the minimum is not used and therefore MUST be zero",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_name_constraint_minimum_non_zero_test.go
+++ b/lints/lint_name_constraint_minimum_non_zero_test.go
@@ -8,7 +8,7 @@ import (
 func TestNcMinZero(t *testing.T) {
 	inputPath := "../testlint/testCerts/ncMinZero.cer"
 	desEnum := Pass
-	out, _ := Lints["name_constraint_minimum_non_zero"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_name_constraint_minimum_non_zero"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestNcMinZero(t *testing.T) {
 func TestNcMinNotZero(t *testing.T) {
 	inputPath := "../testlint/testCerts/ncMinPres.cer"
 	desEnum := Error
-	out, _ := Lints["name_constraint_minimum_non_zero"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_name_constraint_minimum_non_zero"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_name_constraint_on_edi_party_name.go
+++ b/lints/lint_name_constraint_on_edi_party_name.go
@@ -40,7 +40,7 @@ func (l *ncOnEdi) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "name_constraint_on_edi_party_name",
+		Name:          "w_name_constraint_on_edi_party_name",
 		Description:   "The name constraints extension SHOULD NOT impose constraints on the ediPartyName name form",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_name_constraint_on_edi_party_name_test.go
+++ b/lints/lint_name_constraint_on_edi_party_name_test.go
@@ -8,7 +8,7 @@ import (
 func TestNcNoEdi(t *testing.T) {
 	inputPath := "../testlint/testCerts/ncMinZero.cer"
 	desEnum := Pass
-	out, _ := Lints["name_constraint_on_edi_party_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_name_constraint_on_edi_party_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestNcNoEdi(t *testing.T) {
 func TestNcEdi(t *testing.T) {
 	inputPath := "../testlint/testCerts/ncOnEdi.cer"
 	desEnum := Warn
-	out, _ := Lints["name_constraint_on_edi_party_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_name_constraint_on_edi_party_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_name_constraint_on_registered_id.go
+++ b/lints/lint_name_constraint_on_registered_id.go
@@ -40,7 +40,7 @@ func (l *ncOnRegisteredId) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "name_constraint_on_registered_id",
+		Name:          "w_name_constraint_on_registered_id",
 		Description:   "The name constraints extension SHOULD NOT impose constraints on the registeredID name form",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_name_constraint_on_registered_id_test.go
+++ b/lints/lint_name_constraint_on_registered_id_test.go
@@ -8,7 +8,7 @@ import (
 func TestNcNoRegId(t *testing.T) {
 	inputPath := "../testlint/testCerts/ncMinZero.cer"
 	desEnum := Pass
-	out, _ := Lints["name_constraint_on_registered_id"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_name_constraint_on_registered_id"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestNcNoRegId(t *testing.T) {
 func TestNcRegId(t *testing.T) {
 	inputPath := "../testlint/testCerts/ncOnRegId.cer"
 	desEnum := Warn
-	out, _ := Lints["name_constraint_on_registered_id"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_name_constraint_on_registered_id"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_name_constraint_on_x400.go
+++ b/lints/lint_name_constraint_on_x400.go
@@ -40,7 +40,7 @@ func (l *ncOnX400) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "name_constraint_on_x400",
+		Name:          "w_name_constraint_on_x400",
 		Description:   "The name constraints extension SHOULD NOT impose constraints on the x400Address name form",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC5280Date,

--- a/lints/lint_name_constraint_on_x400_test.go
+++ b/lints/lint_name_constraint_on_x400_test.go
@@ -8,7 +8,7 @@ import (
 func TestNcNoX400(t *testing.T) {
 	inputPath := "../testlint/testCerts/ncMinZero.cer"
 	desEnum := Pass
-	out, _ := Lints["name_constraint_on_x400"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_name_constraint_on_x400"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestNcNoX400(t *testing.T) {
 func TestNcX400(t *testing.T) {
 	inputPath := "../testlint/testCerts/ncOnX400.cer"
 	desEnum := Warn
-	out, _ := Lints["name_constraint_on_x400"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_name_constraint_on_x400"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
+++ b/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
@@ -38,7 +38,7 @@ func (l *rootCaModSize) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "old_root_ca_rsa_mod_less_than_2048_bits",
+		Name:          "e_old_root_ca_rsa_mod_less_than_2048_bits",
 		Description:   "In a validity period beginning on or before 31 dec 2010, root CA certificates using RSA public key algorithm must have 2048 bits of modulus",
 		Providence:    "CAB: 6.1.5",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits_test.go
+++ b/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits_test.go
@@ -8,7 +8,7 @@ import (
 func TestOldRootRsaModSizeSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/oldRootModTooSmall.cer"
 	desEnum := Error
-	out, _ := Lints["old_root_ca_rsa_mod_less_than_2048_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_old_root_ca_rsa_mod_less_than_2048_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestOldRootRsaModSizeSmall(t *testing.T) {
 func TestOldRootRsaModSizeNotSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/oldRootModSmall.cer"
 	desEnum := Pass
-	out, _ := Lints["old_root_ca_rsa_mod_less_than_2048_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_old_root_ca_rsa_mod_less_than_2048_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
+++ b/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
@@ -37,7 +37,7 @@ func (l *subCaModSize) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:        "old_sub_ca_rsa_mod_less_than_1024_bits",
+		Name:        "e_old_sub_ca_rsa_mod_less_than_1024_bits",
 		Description: "In a validity period beginning on or before 31 dec 2010 and ending on or before 31 dec 2013, subordinate CA certificates using RSA public key algorithm must have 1024 bits of modulus",
 		Providence:  "CAB: 6.1.5",
 		// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test

--- a/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits_test.go
+++ b/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits_test.go
@@ -8,7 +8,7 @@ import (
 func TestOldCaRsaModSizeSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/oldSubModTooSmall.cer"
 	desEnum := Error
-	out, _ := Lints["old_sub_ca_rsa_mod_less_than_1024_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_old_sub_ca_rsa_mod_less_than_1024_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestOldCaRsaModSizeSmall(t *testing.T) {
 func TestOldCaRsaModSizeNotSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/oldSubModSmall.cer"
 	desEnum := Pass
-	out, _ := Lints["old_sub_ca_rsa_mod_less_than_1024_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_old_sub_ca_rsa_mod_less_than_1024_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
+++ b/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
@@ -36,7 +36,7 @@ func (l *subModSize) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:        "old_sub_cert_rsa_mod_less_than_1024_bits",
+		Name:        "e_old_sub_cert_rsa_mod_less_than_1024_bits",
 		Description: "In a validity period ending on or before 31 dec 2013, subscriber certificates using RSA public key algorithm must have 1024 bits of modulus",
 		Providence:  "CAB: 6.1.5",
 		// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test

--- a/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits_test.go
+++ b/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits_test.go
@@ -8,7 +8,7 @@ import (
 func TestOldSubCertRsaModSizeSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/oldSubTooSmall.cer"
 	desEnum := Error
-	out, _ := Lints["old_sub_cert_rsa_mod_less_than_1024_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_old_sub_cert_rsa_mod_less_than_1024_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestOldSubCertRsaModSizeSmall(t *testing.T) {
 func TestOldSubCertRsaModSizeNotSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/oldSubSmall.cer"
 	desEnum := Pass
-	out, _ := Lints["old_sub_cert_rsa_mod_less_than_1024_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_old_sub_cert_rsa_mod_less_than_1024_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_path_len_constraint_improperly_included.go
+++ b/lints/lint_path_len_constraint_improperly_included.go
@@ -47,7 +47,7 @@ func (l *pathLenIncluded) RunTest(cert *x509.Certificate) (ResultStruct, error) 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "path_len_constraint_improperly_included",
+		Name:          "e_path_len_constraint_improperly_included",
 		Description:   "CAs MUST NOT include the pathLenConstraint field unless the CA boolean is asserted and the keyCertSign bit is set.",
 		Providence:    "RFC 5280: 4.2.1.9",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_path_len_constraint_improperly_included_test.go
+++ b/lints/lint_path_len_constraint_improperly_included_test.go
@@ -8,7 +8,7 @@ import (
 func TestCaMaxLenPresentNoCertSign(t *testing.T) {
 	inputPath := "../testlint/testCerts/caMaxPathLenPresentNoCertSign.cer"
 	desEnum := Error
-	out, _ := Lints["path_len_constraint_improperly_included"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_path_len_constraint_improperly_included"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCaMaxLenPresentNoCertSign(t *testing.T) {
 func TestCaMaxLenPresentGood(t *testing.T) {
 	inputPath := "../testlint/testCerts/caMaxPathLenPositive.cer"
 	desEnum := Pass
-	out, _ := Lints["path_len_constraint_improperly_included"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_path_len_constraint_improperly_included"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestCaMaxLenPresentGood(t *testing.T) {
 func TestCaMaxLenMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/caMaxPathLenMissing.cer"
 	desEnum := Pass
-	out, _ := Lints["path_len_constraint_improperly_included"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_path_len_constraint_improperly_included"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -47,7 +47,7 @@ func TestCaMaxLenMissing(t *testing.T) {
 func TestSubCertMaxLenPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertPathLenPositive.cer"
 	desEnum := Error
-	out, _ := Lints["path_len_constraint_improperly_included"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_path_len_constraint_improperly_included"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -60,7 +60,7 @@ func TestSubCertMaxLenPresent(t *testing.T) {
 func TestSubCertMaxLenNone(t *testing.T) {
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["path_len_constraint_improperly_included"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_path_len_constraint_improperly_included"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_path_len_constraint_zero_or_less.go
+++ b/lints/lint_path_len_constraint_zero_or_less.go
@@ -54,7 +54,7 @@ func (l *pathLenNonPositive) RunTest(cert *x509.Certificate) (ResultStruct, erro
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "path_len_constraint_zero_or_less",
+		Name:          "e_path_len_constraint_zero_or_less",
 		Description:   "Where it appears, the pathLenConstraint field must be greater than or equal to zero",
 		Providence:    "RFC 5280: 4.2.1.9",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_path_len_constraint_zero_or_less_test.go
+++ b/lints/lint_path_len_constraint_zero_or_less_test.go
@@ -8,7 +8,7 @@ import (
 func TestCaMaxLenNegative(t *testing.T) {
 	inputPath := "../testlint/testCerts/caMaxPathNegative.cer"
 	desEnum := Error
-	out, _ := Lints["path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCaMaxLenNegative(t *testing.T) {
 func TestSubCerMaxLenNegative(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertPathLenNegative.cer"
 	desEnum := Error
-	out, _ := Lints["path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSubCerMaxLenNegative(t *testing.T) {
 func TestCaMaxLenPositive(t *testing.T) {
 	inputPath := "../testlint/testCerts/caMaxPathLenPositive.cer"
 	desEnum := Pass
-	out, _ := Lints["path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -47,7 +47,7 @@ func TestCaMaxLenPositive(t *testing.T) {
 func TestSubCertMaxLenPositive(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertPathLenPositive.cer"
 	desEnum := Pass
-	out, _ := Lints["path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -60,7 +60,7 @@ func TestSubCertMaxLenPositive(t *testing.T) {
 func TestSubCertMaxLenMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/caBasicConstMissing.cer"
 	desEnum := NA
-	out, _ := Lints["path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -73,7 +73,7 @@ func TestSubCertMaxLenMissing(t *testing.T) {
 func TestCAMaxLenNone(t *testing.T) {
 	inputPath := "../testlint/testCerts/caMaxPathLenMissing.cer"
 	desEnum := Pass
-	out, _ := Lints["path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_path_len_constraint_zero_or_less"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_public_key_type_not_allowed.go
+++ b/lints/lint_public_key_type_not_allowed.go
@@ -30,7 +30,7 @@ func (l *publicKeyAllowed) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "public_key_type_not_allowed",
+		Name:          "e_public_key_type_not_allowed",
 		Description:   "Certificates must have RSA, DSA, or ECDSA public key type.",
 		Providence:    "CAB: 6.1.5",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_public_key_type_not_allowed_test.go
+++ b/lints/lint_public_key_type_not_allowed_test.go
@@ -9,7 +9,7 @@ func TestPKTypeUnknown(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/unknownpublickey.cer"
 	desEnum := Error
-	out, _ := Lints["public_key_type_not_allowed"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_public_key_type_not_allowed"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestPKTypeRSA(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/rsawithsha1before2016.cer"
 	desEnum := Pass
-	out, _ := Lints["public_key_type_not_allowed"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_public_key_type_not_allowed"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestPKTypeECDSA(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/ecdsaP256.cer"
 	desEnum := Pass
-	out, _ := Lints["public_key_type_not_allowed"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_public_key_type_not_allowed"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
+++ b/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
@@ -42,7 +42,7 @@ func (l *rootCaPathLenPresent) RunTest(c *x509.Certificate) (ResultStruct, error
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "root_ca_basic_constraints_path_len_constraint_field_present",
+		Name:          "w_root_ca_basic_constraints_path_len_constraint_field_present",
 		Description:   "Root CA certificate basicConstraint extension pathLenConstraint field should not be present",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present_test.go
+++ b/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present_test.go
@@ -8,7 +8,7 @@ import (
 func TestRootCaMaxLenPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/rootCaMaxPathLenPresent.cer"
 	desEnum := Warn
-	out, _ := Lints["root_ca_basic_constraints_path_len_constraint_field_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_root_ca_basic_constraints_path_len_constraint_field_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestRootCaMaxLenPresent(t *testing.T) {
 func TestRootCaMaxLenMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/rootCaMaxPathLenMissing.cer"
 	desEnum := Pass
-	out, _ := Lints["root_ca_basic_constraints_path_len_constraint_field_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_root_ca_basic_constraints_path_len_constraint_field_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_root_ca_contains_cert_policy.go
+++ b/lints/lint_root_ca_contains_cert_policy.go
@@ -34,7 +34,7 @@ func (l *rootCAContainsCertPolicy) RunTest(c *x509.Certificate) (ResultStruct, e
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "root_ca_contains_cert_policy",
+		Name:          "w_root_ca_contains_cert_policy",
 		Description:   "Root CA certs SHOULD NOT contain the certificat policies extension.",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_root_ca_contains_cert_policy_test.go
+++ b/lints/lint_root_ca_contains_cert_policy_test.go
@@ -9,7 +9,7 @@ func TestRootCACertPolicy(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/rootCAWithEKUCertPolicy.cer"
 	desEnum := Warn
-	out, _ := Lints["root_ca_contains_cert_policy"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_root_ca_contains_cert_policy"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestRootCANoCertPolicy(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/rootCAValid.cer"
 	desEnum := Pass
-	out, _ := Lints["root_ca_contains_cert_policy"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_root_ca_contains_cert_policy"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_root_ca_extended_key_usage_present.go
+++ b/lints/lint_root_ca_extended_key_usage_present.go
@@ -35,7 +35,7 @@ func (l *rootCAContainsEKU) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "root_ca_extended_key_usage_present",
+		Name:          "e_root_ca_extended_key_usage_present",
 		Description:   "Root CA certificates must not have the extendedKeyUsage extension present",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_root_ca_extended_key_usage_present_test.go
+++ b/lints/lint_root_ca_extended_key_usage_present_test.go
@@ -9,7 +9,7 @@ func TestRootCAEKU(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/rootCAWithEKUCertPolicy.cer"
 	desEnum := Error
-	out, _ := Lints["root_ca_extended_key_usage_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_root_ca_extended_key_usage_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestRootCANoEKU(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/rootCAValid.cer"
 	desEnum := Pass
-	out, _ := Lints["root_ca_extended_key_usage_present"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_root_ca_extended_key_usage_present"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_rsa_exp_negative.go
+++ b/lints/lint_rsa_exp_negative.go
@@ -33,7 +33,7 @@ func (l *rsaExpNegative) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "rsa_exp_negative",
+		Name:          "e_rsa_exp_negative",
 		Description:   "RSA public key exponent must be positive",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_rsa_exp_negative_test.go
+++ b/lints/lint_rsa_exp_negative_test.go
@@ -21,7 +21,7 @@ import (
 func TestRsaExpPositive(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["rsa_exp_negative"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_rsa_exp_negative"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_rsa_mod_factors_smaller_than_752_bits.go
+++ b/lints/lint_rsa_mod_factors_smaller_than_752_bits.go
@@ -37,7 +37,7 @@ func (l *rsaModSmallFactor) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "rsa_mod_factors_smaller_than_752",
+		Name:          "w_rsa_mod_factors_smaller_than_752",
 		Description:   "The modulus of a RSA public key should have no factors smaller than 752",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,

--- a/lints/lint_rsa_mod_factors_smaller_than_752_bits_test.go
+++ b/lints/lint_rsa_mod_factors_smaller_than_752_bits_test.go
@@ -8,7 +8,7 @@ import (
 func TestRsaModFactorTooSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/evenRsaMod.cer"
 	desEnum := Warn
-	out, _ := Lints["rsa_mod_factors_smaller_than_752"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_rsa_mod_factors_smaller_than_752"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestRsaModFactorTooSmall(t *testing.T) {
 func TestRsaModFactorNotTooSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/goodRsaExp.cer"
 	desEnum := Pass
-	out, _ := Lints["rsa_mod_factors_smaller_than_752"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_rsa_mod_factors_smaller_than_752"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_rsa_mod_less_than_2048_bits.go
+++ b/lints/lint_rsa_mod_less_than_2048_bits.go
@@ -37,7 +37,7 @@ func (l *rsaParsedTestsKeySize) RunTest(c *x509.Certificate) (ResultStruct, erro
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "rsa_mod_less_than_2048_bits",
+		Name:          "e_rsa_mod_less_than_2048_bits",
 		Description:   "in validity period beginning after 31 Dec 2010, all certificates using RSA public key algorithm must have 2048 bits of modulus",
 		Providence:    "CAB: 6.1.5",
 		EffectiveDate: util.RsaDate, // CA/B BR is retroactive here

--- a/lints/lint_rsa_mod_less_than_2048_bits_test.go
+++ b/lints/lint_rsa_mod_less_than_2048_bits_test.go
@@ -8,7 +8,7 @@ import (
 func TestRsaModSizeSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/noRsaLength.cer"
 	desEnum := Error
-	out, _ := Lints["rsa_mod_less_than_2048_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_rsa_mod_less_than_2048_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestRsaModSizeSmall(t *testing.T) {
 func TestRsaModSizeNotSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/yesRsaLength.cer"
 	desEnum := Pass
-	out, _ := Lints["rsa_mod_less_than_2048_bits"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_rsa_mod_less_than_2048_bits"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_rsa_mod_not_odd.go
+++ b/lints/lint_rsa_mod_not_odd.go
@@ -40,7 +40,7 @@ func (l *rsaParsedTestsKeyModOdd) RunTest(c *x509.Certificate) (ResultStruct, er
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "rsa_mod_not_odd",
+		Name:          "w_rsa_mod_not_odd",
 		Description:   "The modulus of a RSA public key should be an odd number",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,

--- a/lints/lint_rsa_mod_not_odd_test.go
+++ b/lints/lint_rsa_mod_not_odd_test.go
@@ -8,7 +8,7 @@ import (
 func TestRsaModEven(t *testing.T) {
 	inputPath := "../testlint/testCerts/evenRsaMod.cer"
 	desEnum := Warn
-	out, _ := Lints["rsa_mod_not_odd"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_rsa_mod_not_odd"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestRsaModEven(t *testing.T) {
 func TestRsaModOdd(t *testing.T) {
 	inputPath := "../testlint/testCerts/oddRsaMod.cer"
 	desEnum := Pass
-	out, _ := Lints["rsa_mod_not_odd"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_rsa_mod_not_odd"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_rsa_no_public_key.go
+++ b/lints/lint_rsa_no_public_key.go
@@ -30,7 +30,7 @@ func (l *rsaParsedPubKeyExist) RunTest(c *x509.Certificate) (ResultStruct, error
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "rsa_no_public_key",
+		Name:          "e_rsa_no_public_key",
 		Description:   "The RSA public key should be present",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_rsa_public_exponent_not_in_range.go
+++ b/lints/lint_rsa_public_exponent_not_in_range.go
@@ -46,7 +46,7 @@ func (l *rsaParsedTestsExpInRange) RunTest(c *x509.Certificate) (ResultStruct, e
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "rsa_public_exponent_not_in_range",
+		Name:          "w_rsa_public_exponent_not_in_range",
 		Description:   "The RSA public exponent SHOULD be in the range between 2^16 + 1 and 2^256 - 1",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,

--- a/lints/lint_rsa_public_exponent_not_in_range_test.go
+++ b/lints/lint_rsa_public_exponent_not_in_range_test.go
@@ -8,7 +8,7 @@ import (
 func TestRsaExpNotInRange(t *testing.T) {
 	inputPath := "../testlint/testCerts/badRsaExp.cer"
 	desEnum := Warn
-	out, _ := Lints["rsa_public_exponent_not_in_range"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_rsa_public_exponent_not_in_range"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestRsaExpNotInRange(t *testing.T) {
 func TestRsaExpInRange(t *testing.T) {
 	inputPath := "../testlint/testCerts/validRsaExpRange.cer"
 	desEnum := Pass
-	out, _ := Lints["rsa_public_exponent_not_in_range"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_rsa_public_exponent_not_in_range"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_rsa_public_exponent_not_odd.go
+++ b/lints/lint_rsa_public_exponent_not_odd.go
@@ -38,7 +38,7 @@ func (l *rsaParsedTestsKeyExpOdd) RunTest(c *x509.Certificate) (ResultStruct, er
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "rsa_public_exponent_not_odd",
+		Name:          "e_rsa_public_exponent_not_odd",
 		Description:   "RSA public key has to be an odd number",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,

--- a/lints/lint_rsa_public_exponent_not_odd_test.go
+++ b/lints/lint_rsa_public_exponent_not_odd_test.go
@@ -8,7 +8,7 @@ import (
 func TestRsaExpEven(t *testing.T) {
 	inputPath := "../testlint/testCerts/badRsaExp.cer"
 	desEnum := Error
-	out, _ := Lints["rsa_public_exponent_not_odd"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_rsa_public_exponent_not_odd"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestRsaExpEven(t *testing.T) {
 func TestRsaExpOdd(t *testing.T) {
 	inputPath := "../testlint/testCerts/goodRsaExp.cer"
 	desEnum := Pass
-	out, _ := Lints["rsa_public_exponent_not_odd"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_rsa_public_exponent_not_odd"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_rsa_public_exponent_too_small.go
+++ b/lints/lint_rsa_public_exponent_too_small.go
@@ -38,7 +38,7 @@ func (l *rsaParsedTestsExpBounds) RunTest(c *x509.Certificate) (ResultStruct, er
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "rsa_public_exponent_too_small",
+		Name:          "e_rsa_public_exponent_too_small",
 		Description:   "RSA public key has to be greater or equal to 3",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,

--- a/lints/lint_rsa_public_exponent_too_small_test.go
+++ b/lints/lint_rsa_public_exponent_too_small_test.go
@@ -8,7 +8,7 @@ import (
 func TestRsaExpTooSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/badRsaExpLength.cer"
 	desEnum := Error
-	out, _ := Lints["rsa_public_exponent_too_small"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_rsa_public_exponent_too_small"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestRsaExpTooSmall(t *testing.T) {
 func TestRsaExpNotTooSmall(t *testing.T) {
 	inputPath := "../testlint/testCerts/goodRsaExpLength.cer"
 	desEnum := Pass
-	out, _ := Lints["rsa_public_exponent_too_small"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_rsa_public_exponent_too_small"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_san_bare_wildcard.go
+++ b/lints/lint_san_bare_wildcard.go
@@ -31,7 +31,7 @@ func (l *brSanBareWildcard) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "san_bare_wildcard",
+		Name:          "e_san_bare_wildcard",
 		Description:   "Wildcard MUST be accompanied by other data to it's right (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_san_bare_wildcard_test.go
+++ b/lints/lint_san_bare_wildcard_test.go
@@ -8,7 +8,7 @@ import (
 func TestBrSanBareWildcard(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanBareWildcard.cer"
 	desEnum := Error
-	out, _ := Lints["san_bare_wildcard"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_san_bare_wildcard"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestBrSanBareWildcard(t *testing.T) {
 func TestBrSanNotBareWildcard(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["san_bare_wildcard"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_san_bare_wildcard"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_san_dns_name_includes_null_char.go
+++ b/lints/lint_san_dns_name_includes_null_char.go
@@ -32,7 +32,7 @@ func (l *sanDnsNull) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "san_dns_name_includes_null_char",
+		Name:          "e_san_dns_name_includes_null_char",
 		Description:   "DNSNames MUST NOT include a null character ",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_san_dns_name_includes_null_char_test.go
+++ b/lints/lint_san_dns_name_includes_null_char_test.go
@@ -8,7 +8,7 @@ import (
 func TestBrSanDnsNull(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanDnsNull.cer"
 	desEnum := Error
-	out, _ := Lints["san_dns_name_includes_null_char"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_san_dns_name_includes_null_char"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestBrSanDnsNull(t *testing.T) {
 func TestBrSanDnsNotNull(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["san_dns_name_includes_null_char"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_san_dns_name_includes_null_char"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_san_dns_name_starts_with_period.go
+++ b/lints/lint_san_dns_name_starts_with_period.go
@@ -31,7 +31,7 @@ func (l *sanDnsPeriod) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "san_dns_name_starts_with_period",
+		Name:          "e_san_dns_name_starts_with_period",
 		Description:   "DNSName MUST NOT start with a period",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_san_dns_name_starts_with_period_test.go
+++ b/lints/lint_san_dns_name_starts_with_period_test.go
@@ -8,7 +8,7 @@ import (
 func TestBrSanDnsStartsWithPeriod(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanDnsPeriod.cer"
 	desEnum := Error
-	out, _ := Lints["san_dns_name_starts_with_period"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_san_dns_name_starts_with_period"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestBrSanDnsStartsWithPeriod(t *testing.T) {
 func TestBrSanDnsNotPeriod(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["san_dns_name_starts_with_period"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_san_dns_name_starts_with_period"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_san_iana_pub_suffix_empty.go
+++ b/lints/lint_san_iana_pub_suffix_empty.go
@@ -31,7 +31,7 @@ func (l *pubSuffix) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "san_iana_pub_suffix_empty",
+		Name:          "w_san_iana_pub_suffix_empty",
 		Description:   "Domain SHOULD NOT have bare public suffix",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_san_iana_pub_suffix_empty_test.go
+++ b/lints/lint_san_iana_pub_suffix_empty_test.go
@@ -8,7 +8,7 @@ import (
 func TestSanBarePubSuffix(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanBareSuffix.cer"
 	desEnum := Warn
-	out, _ := Lints["san_iana_pub_suffix_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_san_iana_pub_suffix_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSanBarePubSuffix(t *testing.T) {
 func TestSanGoodPubSuffix(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanGoodSuffix.cer"
 	desEnum := Pass
-	out, _ := Lints["san_iana_pub_suffix_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_san_iana_pub_suffix_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_san_wildcard_not_first.go
+++ b/lints/lint_san_wildcard_not_first.go
@@ -32,7 +32,7 @@ func (l *sanWildCardFirst) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "san_wildcard_not_first",
+		Name:          "e_san_wildcard_not_first",
 		Description:   "Wildcard MUST be in the first label of FQDN, ie not: www.*.com (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_san_wildcard_not_first_test.go
+++ b/lints/lint_san_wildcard_not_first_test.go
@@ -8,7 +8,7 @@ import (
 func TestBrSanWildcardFirst(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanWildcardFirst.cer"
 	desEnum := Error
-	out, _ := Lints["san_wildcard_not_first"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_san_wildcard_not_first"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestBrSanWildcardFirst(t *testing.T) {
 func TestBrSanWildcardNotFirst(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["san_wildcard_not_first"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_san_wildcard_not_first"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_serial_number_longer_than_20_octets.go
+++ b/lints/lint_serial_number_longer_than_20_octets.go
@@ -46,7 +46,7 @@ func (l *serialNumberTooLong) RunTest(c *x509.Certificate) (ResultStruct, error)
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "serial_number_longer_than_20_octets",
+		Name:          "e_serial_number_longer_than_20_octets",
 		Description:   "Certificates must not have a serial number longer than 20 octets",
 		Providence:    "RFC 5280: 4.1.2.2",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_serial_number_longer_than_20_octets_test.go
+++ b/lints/lint_serial_number_longer_than_20_octets_test.go
@@ -8,7 +8,7 @@ import (
 func TestSnTooLarge(t *testing.T) {
 	inputPath := "../testlint/testCerts/serialNumberLarge.cer"
 	desEnum := Error
-	out, _ := Lints["serial_number_longer_than_20_octets"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_serial_number_longer_than_20_octets"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSnTooLarge(t *testing.T) {
 func TestSnNotTooLarge(t *testing.T) {
 	inputPath := "../testlint/testCerts/serialNumberValid.cer"
 	desEnum := Pass
-	out, _ := Lints["serial_number_longer_than_20_octets"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_serial_number_longer_than_20_octets"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_serial_number_not_positive.go
+++ b/lints/lint_serial_number_not_positive.go
@@ -45,7 +45,7 @@ func (l *SerialNumberNotPositive) RunTest(cert *x509.Certificate) (ResultStruct,
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "serial_number_not_positive",
+		Name:          "e_serial_number_not_positive",
 		Description:   "Certificates must have a positive serial number",
 		Providence:    "RFC 5280: 4.1.2.2",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_serial_number_not_positive_test.go
+++ b/lints/lint_serial_number_not_positive_test.go
@@ -8,7 +8,7 @@ import (
 func TestSnNeagtive(t *testing.T) {
 	inputPath := "../testlint/testCerts/serialNumberNegative.cer"
 	desEnum := Error
-	out, _ := Lints["serial_number_not_positive"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_serial_number_not_positive"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSnNeagtive(t *testing.T) {
 func TestSnNotNeagtive(t *testing.T) {
 	inputPath := "../testlint/testCerts/serialNumberValid.cer"
 	desEnum := Pass
-	out, _ := Lints["serial_number_not_positive"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_serial_number_not_positive"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
@@ -37,7 +37,7 @@ func (l *subCaIssuerUrl) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_aia_does_not_contain_issuing_ca_url",
+		Name:          "w_sub_ca_aia_does_not_contain_issuing_ca_url",
 		Description:   "Subordinate CA certificates authorityInformationAccess extension should contain the HTTP URL of the Issuing CA’s certificate",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url_test.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCaAiaNoIssuerUrl(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWOcspURL.cer"
 	desEnum := Warn
-	out, _ := Lints["sub_ca_aia_does_not_contain_issuing_ca_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_ca_aia_does_not_contain_issuing_ca_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCaAiaNoIssuerUrl(t *testing.T) {
 func TestSubCaAiaHasIssuerUrl(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWBothURL.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_aia_does_not_contain_issuing_ca_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_ca_aia_does_not_contain_issuing_ca_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_aia_does_not_contain_ocsp_url.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_ocsp_url.go
@@ -37,7 +37,7 @@ func (l *subCaOcspUrl) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_aia_does_not_contain_ocsp_url",
+		Name:          "e_sub_ca_aia_does_not_contain_ocsp_url",
 		Description:   "Subordinate CA certificates authorityInformationAccess extension must contain the HTTP URL of the Issuing CA’s OCSP responder",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_ca_aia_does_not_contain_ocsp_url_test.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_ocsp_url_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCaAiaNoOcsp(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWIssuerURL.cer"
 	desEnum := Error
-	out, _ := Lints["sub_ca_aia_does_not_contain_ocsp_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_aia_does_not_contain_ocsp_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCaAiaNoOcsp(t *testing.T) {
 func TestSubCaAiaHasOcsp(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWOcspURL.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_aia_does_not_contain_ocsp_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_aia_does_not_contain_ocsp_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_aia_missing.go
+++ b/lints/lint_sub_ca_aia_missing.go
@@ -37,7 +37,7 @@ func (l *caAiaMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_aia_missing",
+		Name:          "e_sub_ca_aia_missing",
 		Description:   "Subordinate CA certificates must have a authorityInformationAccess extension.",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_ca_aia_missing_test.go
+++ b/lints/lint_sub_ca_aia_missing_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCaAiaMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAAIAMissing.cer"
 	desEnum := Error
-	out, _ := Lints["sub_ca_aia_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_aia_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCaAiaMissing(t *testing.T) {
 func TestSubCaAiaPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAAIAValid.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_aia_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_aia_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_certificate_policies_marked_critical.go
+++ b/lints/lint_sub_ca_certificate_policies_marked_critical.go
@@ -35,7 +35,7 @@ func (l *subCACertPolicyCrit) RunTest(c *x509.Certificate) (ResultStruct, error)
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_certificate_policies_marked_critical",
+		Name:          "w_sub_ca_certificate_policies_marked_critical",
 		Description:   "Subordinate CA certificates certificatePolicies extension should not be marked as critical",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_ca_certificate_policies_marked_critical_test.go
+++ b/lints/lint_sub_ca_certificate_policies_marked_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCaPolicyCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWCertPolicyCrit.cer"
 	desEnum := Warn
-	out, _ := Lints["sub_ca_certificate_policies_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_ca_certificate_policies_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCaPolicyCrit(t *testing.T) {
 func TestSubCaPolicyNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWCertPolicyNoCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_certificate_policies_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_ca_certificate_policies_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_certificate_policies_missing.go
+++ b/lints/lint_sub_ca_certificate_policies_missing.go
@@ -34,7 +34,7 @@ func (l *subCACertPolicyMissing) RunTest(c *x509.Certificate) (ResultStruct, err
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_certificate_policies_missing",
+		Name:          "e_sub_ca_certificate_policies_missing",
 		Description:   "Subordinate CA certificates must have a certificatePolicies extension",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_ca_certificate_policies_missing_test.go
+++ b/lints/lint_sub_ca_certificate_policies_missing_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCaPolicyMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWNoCertPolicy.cer"
 	desEnum := Error
-	out, _ := Lints["sub_ca_certificate_policies_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_certificate_policies_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCaPolicyMissing(t *testing.T) {
 func TestSubCaPolicyPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWCertPolicyNoCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_certificate_policies_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_certificate_policies_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
@@ -36,7 +36,7 @@ func (l *subCACRLDistNoUrl) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_crl_distribution_points_does_not_contain_url",
+		Name:          "e_sub_ca_crl_distribution_points_does_not_contain_url",
 		Description:   "Subordinate CA certificates cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service.",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url_test.go
+++ b/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCaCrlNoUrl(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCaCrlMissing.cer"
 	desEnum := Error
-	out, _ := Lints["sub_ca_crl_distribution_points_does_not_contain_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_crl_distribution_points_does_not_contain_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCaCrlNoUrl(t *testing.T) {
 func TestSubCaCrlUrlPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCaCrlPresent.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_crl_distribution_points_does_not_contain_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_crl_distribution_points_does_not_contain_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_crl_distribution_points_marked_critical.go
+++ b/lints/lint_sub_ca_crl_distribution_points_marked_critical.go
@@ -35,7 +35,7 @@ func (l *subCACRLDistCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_crl_distribution_points_marked_critical",
+		Name:          "e_sub_ca_crl_distribution_points_marked_critical",
 		Description:   "Subordinate CA certificates must not mark the cRLDistributionPoints extension as critical",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_ca_crl_distribution_points_marked_critical_test.go
+++ b/lints/lint_sub_ca_crl_distribution_points_marked_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCaCrlCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWcrlDistCrit.cer"
 	desEnum := Error
-	out, _ := Lints["sub_ca_crl_distribution_points_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_crl_distribution_points_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCaCrlCrit(t *testing.T) {
 func TestSubCaCrlNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWcrlDistNoCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_crl_distribution_points_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_crl_distribution_points_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_crl_distribution_points_missing.go
+++ b/lints/lint_sub_ca_crl_distribution_points_missing.go
@@ -35,7 +35,7 @@ func (l *subCACRLDistMissing) RunTest(c *x509.Certificate) (ResultStruct, error)
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_crl_distribution_points_missing",
+		Name:          "e_sub_ca_crl_distribution_points_missing",
 		Description:   "Subordinate CA certificates must have a cRLDistributionPoints extension",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_ca_crl_distribution_points_missing_test.go
+++ b/lints/lint_sub_ca_crl_distribution_points_missing_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCaCrlMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWNocrlDist.cer"
 	desEnum := Error
-	out, _ := Lints["sub_ca_crl_distribution_points_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_crl_distribution_points_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCaCrlMissing(t *testing.T) {
 func TestSubCaCrlPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWcrlDistNoCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_crl_distribution_points_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_crl_distribution_points_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_eku_critical.go
+++ b/lints/lint_sub_ca_eku_critical.go
@@ -37,7 +37,7 @@ func (l *subCAEKUCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_eku_critical",
+		Name:          "w_sub_ca_eku_critical",
 		Description:   "Subordinate CA certificate extkeyUsage extension should be marked non-critical if present.",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABV116Date,

--- a/lints/lint_sub_ca_eku_critical_test.go
+++ b/lints/lint_sub_ca_eku_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCaEkuCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWEkuCrit.cer"
 	desEnum := Warn
-	out, _ := Lints["sub_ca_eku_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_ca_eku_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCaEkuCrit(t *testing.T) {
 func TestSubCaEkuNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWEkuNoCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_eku_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_ca_eku_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_name_constraints_not_critical.go
+++ b/lints/lint_sub_ca_name_constraints_not_critical.go
@@ -32,7 +32,7 @@ func (l *SubCANameConstraintsNotCritical) RunTest(cert *x509.Certificate) (Resul
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_name_constraints_not_critical",
+		Name:          "w_sub_ca_name_constraints_not_critical",
 		Description:   "Subordinate CA certificate nameConstraints extension should be marked critical if present",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABV102Date,

--- a/lints/lint_sub_ca_name_constraints_not_critical_test.go
+++ b/lints/lint_sub_ca_name_constraints_not_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCaNcNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWNameConstNoCrit.cer"
 	desEnum := Warn
-	out, _ := Lints["sub_ca_name_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_ca_name_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCaNcNotCrit(t *testing.T) {
 func TestSubCaNcCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWNameConstCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_name_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_ca_name_constraints_not_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_no_dns_name_contstraints.go
+++ b/lints/lint_sub_ca_no_dns_name_contstraints.go
@@ -39,7 +39,7 @@ func (l *subCaBadDnsConstraint) RunTest(c *x509.Certificate) (ResultStruct, erro
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_no_dns_name_contstraints",
+		Name:          "e_sub_ca_no_dns_name_constraints",
 		Description:   "Subordanate CA certs must include in the name contraints extension either premitted dns names or prohibit the empty DNS name.",
 		Providence:    "CAB: 7.1.5",
 		EffectiveDate: util.CABV116Date,

--- a/lints/lint_sub_ca_no_dns_name_contstraints_test.go
+++ b/lints/lint_sub_ca_no_dns_name_contstraints_test.go
@@ -8,7 +8,7 @@ import (
 func TestNonEmptyPermittedDns(t *testing.T) {
 	inputPath := "../testlint/testCerts/nonEmptyPermittedDns.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_no_dns_name_contstraints"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_no_dns_name_constraints"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestNonEmptyPermittedDns(t *testing.T) {
 func TestExcludeNonEmptyDns(t *testing.T) {
 	inputPath := "../testlint/testCerts/emptyPermittedDnsBadExcludedDns.cer"
 	desEnum := Error
-	out, _ := Lints["sub_ca_no_dns_name_contstraints"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_no_dns_name_constraints"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestExcludeNonEmptyDns(t *testing.T) {
 func TestExcludeEmptyDns(t *testing.T) {
 	inputPath := "../testlint/testCerts/emptyPermittedDnsGoodExcludedDns.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_no_dns_name_contstraints"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_no_dns_name_constraints"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_no_ip_name_contstraints.go
+++ b/lints/lint_sub_ca_no_ip_name_contstraints.go
@@ -55,7 +55,7 @@ func (l *subCaBadIpConstraint) RunTest(c *x509.Certificate) (ResultStruct, error
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_ca_no_ip_name_contstraints",
+		Name:          "e_sub_ca_no_ip_name_constraints",
 		Description:   "Subordanate CA certs must include in the name contraints extension either premitted ip ranges or prohibit all ip addresses.",
 		Providence:    "CAB: 7.1.5",
 		EffectiveDate: util.CABV116Date,

--- a/lints/lint_sub_ca_no_ip_name_contstraints_test.go
+++ b/lints/lint_sub_ca_no_ip_name_contstraints_test.go
@@ -8,7 +8,7 @@ import (
 func TestBadExclude(t *testing.T) {
 	inputPath := "../testlint/testCerts/emptyPermittedIpExcludedIPv4.cer"
 	desEnum := Error
-	out, _ := Lints["sub_ca_no_ip_name_contstraints"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_no_ip_name_contstraints"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestBadExclude(t *testing.T) {
 func TestBadExcludeV6(t *testing.T) {
 	inputPath := "../testlint/testCerts/emptyPermittedIpExcludedIPv6.cer"
 	desEnum := Error
-	out, _ := Lints["sub_ca_no_ip_name_contstraints"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_no_ip_name_constraints"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestBadExcludeV6(t *testing.T) {
 func TestGoodExclude(t *testing.T) {
 	inputPath := "../testlint/testCerts/emptyPermittedIpExcludedBoth.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_no_ip_name_contstraints"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_no_ip_name_constraints"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -47,7 +47,7 @@ func TestGoodExclude(t *testing.T) {
 func TestNonEmptyPermitted(t *testing.T) {
 	inputPath := "../testlint/testCerts/nonEmptyPermitted.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_ca_no_ip_name_contstraints"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_no_ip_name_constraints"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_ca_no_ip_name_contstraints_test.go
+++ b/lints/lint_sub_ca_no_ip_name_contstraints_test.go
@@ -8,7 +8,7 @@ import (
 func TestBadExclude(t *testing.T) {
 	inputPath := "../testlint/testCerts/emptyPermittedIpExcludedIPv4.cer"
 	desEnum := Error
-	out, _ := Lints["e_sub_ca_no_ip_name_contstraints"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_ca_no_ip_name_constraints"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
@@ -36,7 +36,7 @@ func (l *subCertIssuerUrl) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_aia_does_not_contain_issuing_ca_url",
+		Name:          "w_sub_cert_aia_does_not_contain_issuing_ca_url",
 		Description:   "Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the Issuing CA’s certificate",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url_test.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCertNoIssuerUrl(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertWOcspURL.cer"
 	desEnum := Warn
-	out, _ := Lints["sub_cert_aia_does_not_contain_issuing_ca_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_cert_aia_does_not_contain_issuing_ca_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCertNoIssuerUrl(t *testing.T) {
 func TestSubCertHasIssuerUrl(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertWIssuerURL.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_aia_does_not_contain_issuing_ca_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_cert_aia_does_not_contain_issuing_ca_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_aia_does_not_contain_ocsp_url.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_ocsp_url.go
@@ -38,7 +38,7 @@ func (l *subCertOcspUrl) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_aia_does_not_contain_ocsp_url",
+		Name:          "e_sub_cert_aia_does_not_contain_ocsp_url",
 		Description:   "Subscriber certificates authorityInformationAccess extension must contain the HTTP URL of the Issuing CA’s OCSP responder",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_aia_does_not_contain_ocsp_url_test.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_ocsp_url_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCertNoIssuerOcsp(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertWIssuerURL.cer"
 	desEnum := Error
-	out, _ := Lints["sub_cert_aia_does_not_contain_ocsp_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_aia_does_not_contain_ocsp_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCertNoIssuerOcsp(t *testing.T) {
 func TestSubCertHasIssuerOcsp(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertWOcspURL.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_aia_does_not_contain_ocsp_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_aia_does_not_contain_ocsp_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_aia_missing.go
+++ b/lints/lint_sub_cert_aia_missing.go
@@ -38,7 +38,7 @@ func (l *subCertAiaMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_aia_missing",
+		Name:          "e_sub_cert_aia_missing",
 		Description:   "Subscriber certificates must have a authorityInformationAccess extension.",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_aia_missing_test.go
+++ b/lints/lint_sub_cert_aia_missing_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCertAiaMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertWNoURL.cer"
 	desEnum := Error
-	out, _ := Lints["sub_cert_aia_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_aia_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCertAiaMissing(t *testing.T) {
 func TestSubCertAiaPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertWBothURL.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_aia_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_aia_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_cert_policy_empty.go
+++ b/lints/lint_sub_cert_cert_policy_empty.go
@@ -37,7 +37,7 @@ func (l *subCertPolicyEmpty) RunTest(c *x509.Certificate) (ResultStruct, error) 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_cert_policy_empty",
+		Name:          "w_sub_cert_cert_policy_empty",
 		Description:   "Subscriber certificates must contain at least one policy identifier that indicates adherance to CAB standards",
 		Providence:    "CAB: 7.1.6.4",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_cert_policy_empty_test.go
+++ b/lints/lint_sub_cert_cert_policy_empty_test.go
@@ -8,7 +8,7 @@ import (
 func TestCertPolicyMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertPolicyMissing.cer"
 	desEnum := Warn
-	out, _ := Lints["sub_cert_cert_policy_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_cert_cert_policy_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCertPolicyMissing(t *testing.T) {
 func TestCertPolicyPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertPolicyNoCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_cert_policy_empty"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_cert_cert_policy_empty"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_certificate_policies_marked_critical.go
+++ b/lints/lint_sub_cert_certificate_policies_marked_critical.go
@@ -34,7 +34,7 @@ func (l *subCertPolicyCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_certificate_policies_marked_critical",
+		Name:          "w_sub_cert_certificate_policies_marked_critical",
 		Description:   "Subscriber certificate should have policies extension marked non-critical",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_certificate_policies_marked_critical_test.go
+++ b/lints/lint_sub_cert_certificate_policies_marked_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCertPolicyCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertPolicyCrit.cer"
 	desEnum := Warn
-	out, _ := Lints["sub_cert_certificate_policies_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_cert_certificate_policies_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCertPolicyCrit(t *testing.T) {
 func TestSubCertPolicyNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertPolicyNoCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_certificate_policies_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_cert_certificate_policies_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_certificate_policies_missing.go
+++ b/lints/lint_sub_cert_certificate_policies_missing.go
@@ -36,7 +36,7 @@ func (l *subCertPolicy) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_certificate_policies_missing",
+		Name:          "e_sub_cert_certificate_policies_missing",
 		Description:   "Subscriber certificates should have certificates policies extension present",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_certificate_policies_missing_test.go
+++ b/lints/lint_sub_cert_certificate_policies_missing_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubCertPolicyMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertPolicyMissing.cer"
 	desEnum := Error
-	out, _ := Lints["sub_cert_certificate_policies_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_certificate_policies_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubCertPolicyMissing(t *testing.T) {
 func TestSubCertPolicyPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertPolicyNoCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_certificate_policies_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_certificate_policies_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
@@ -39,7 +39,7 @@ func (l *subCRLDistNoURL) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_crl_distribution_points_does_not_contain_url",
+		Name:          "e_sub_cert_crl_distribution_points_does_not_contain_url",
 		Description:   "Subscriber certificate cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service.",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url_test.go
+++ b/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url_test.go
@@ -8,7 +8,7 @@ import (
 func TestCrlNoUrl(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCrlDistNoURL.cer"
 	desEnum := Error
-	out, _ := Lints["sub_cert_crl_distribution_points_does_not_contain_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_crl_distribution_points_does_not_contain_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCrlNoUrl(t *testing.T) {
 func TestCrlContainsUrl(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCrlDistURL.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_crl_distribution_points_does_not_contain_url"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_crl_distribution_points_does_not_contain_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
+++ b/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
@@ -38,7 +38,7 @@ func (l *subCrlDistCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_crl_distribution_points_marked_critical",
+		Name:          "e_sub_cert_crl_distribution_points_marked_critical",
 		Description:   "Subscriber certificate cRLDistributionPoints extension must not be marked critical if present",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_crl_distribution_points_marked_critical_test.go
+++ b/lints/lint_sub_cert_crl_distribution_points_marked_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestCrlCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCrlDistCrit.cer"
 	desEnum := Error
-	out, _ := Lints["sub_cert_crl_distribution_points_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_crl_distribution_points_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCrlCrit(t *testing.T) {
 func TestCrlNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCrlDistNoCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_crl_distribution_points_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_crl_distribution_points_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_eku_extra_values.go
+++ b/lints/lint_sub_cert_eku_extra_values.go
@@ -44,7 +44,7 @@ func (l *subExtKeyUsageLegalUsage) RunTest(c *x509.Certificate) (ResultStruct, e
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_eku_extra_values",
+		Name:          "w_sub_cert_eku_extra_values",
 		Description:   "Subscriber certificates should have only id-kp-serverAuth, id-kp-clientAuth, or id-kp-emailProtection in extKeyUsage. Anything should not be included.",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_eku_extra_values_test.go
+++ b/lints/lint_sub_cert_eku_extra_values_test.go
@@ -8,7 +8,7 @@ import (
 func TestEkuExtra(t *testing.T) {
 	inputPath := "../testlint/testCerts/subExtKeyUsageServClientEmailCodeSign.cer"
 	desEnum := Warn
-	out, _ := Lints["sub_cert_eku_extra_values"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_cert_eku_extra_values"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestEkuExtra(t *testing.T) {
 func TestEkuNoExtra(t *testing.T) {
 	inputPath := "../testlint/testCerts/subExtKeyUsageServClientEmail.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_eku_extra_values"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_cert_eku_extra_values"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_eku_missing.go
+++ b/lints/lint_sub_cert_eku_missing.go
@@ -36,7 +36,7 @@ func (l *subExtKeyUsage) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_eku_missing",
+		Name:          "e_sub_cert_eku_missing",
 		Description:   "Subscriber certificates must have the extended key usage extension present",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_eku_missing_test.go
+++ b/lints/lint_sub_cert_eku_missing_test.go
@@ -8,7 +8,7 @@ import (
 func TestEkuMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/subExtKeyUsageMissing.cer"
 	desEnum := Error
-	out, _ := Lints["sub_cert_eku_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_eku_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestEkuMissing(t *testing.T) {
 func TestEkuPresent(t *testing.T) {
 	inputPath := "../testlint/testCerts/subExtKeyUsageServClient.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_eku_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_eku_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_eku_server_auth_client_auth_missing.go
+++ b/lints/lint_sub_cert_eku_server_auth_client_auth_missing.go
@@ -39,7 +39,7 @@ func (l *subExtKeyUsageClientOrServer) RunTest(c *x509.Certificate) (ResultStruc
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_eku_server_auth_client_auth_missing",
+		Name:          "e_sub_cert_eku_server_auth_client_auth_missing",
 		Description:   "Subscriber certificates must have have either id-kp-serverAuth or id-kp-clientAuth or both present in extKeyUsage",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_eku_server_auth_client_auth_missing_test.go
+++ b/lints/lint_sub_cert_eku_server_auth_client_auth_missing_test.go
@@ -8,7 +8,7 @@ import (
 func TestEkuBothPres(t *testing.T) {
 	inputPath := "../testlint/testCerts/subExtKeyUsageCodeSign.cer"
 	desEnum := Error
-	out, _ := Lints["sub_cert_eku_server_auth_client_auth_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_eku_server_auth_client_auth_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestEkuBothPres(t *testing.T) {
 func TestEkuNeitherPres(t *testing.T) {
 	inputPath := "../testlint/testCerts/subExtKeyUsageServClient.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_eku_server_auth_client_auth_missing"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_eku_server_auth_client_auth_missing"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
@@ -35,7 +35,7 @@ func (l *subCertKeyUsageBitSet) RunTest(c *x509.Certificate) (ResultStruct, erro
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_key_usage_cert_sign_bit_set",
+		Name:          "e_sub_cert_key_usage_cert_sign_bit_set",
 		Description:   "Subscriber certificates keyUsage extension keyCertSign bit must not be set",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_key_usage_cert_sign_bit_set_test.go
+++ b/lints/lint_sub_cert_key_usage_cert_sign_bit_set_test.go
@@ -8,7 +8,7 @@ import (
 func TestCertSignBitSet(t *testing.T) {
 	inputPath := "../testlint/testCerts/subKeyUsageInvalid.cer"
 	desEnum := Error
-	out, _ := Lints["sub_cert_key_usage_cert_sign_bit_set"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_key_usage_cert_sign_bit_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCertSignBitSet(t *testing.T) {
 func TestCertSignBitNotSet(t *testing.T) {
 	inputPath := "../testlint/testCerts/subKeyUsageValid.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_key_usage_cert_sign_bit_set"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_key_usage_cert_sign_bit_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
@@ -36,7 +36,7 @@ func (l *subCrlSignAllowed) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_key_usage_crl_sign_bit_set",
+		Name:          "e_sub_cert_key_usage_crl_sign_bit_set",
 		Description:   "Subscriber certificates keyUsage extension cRLSign bit must not be set",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_key_usage_crl_sign_bit_set_test.go
+++ b/lints/lint_sub_cert_key_usage_crl_sign_bit_set_test.go
@@ -8,7 +8,7 @@ import (
 func TestCrlSignBitSet(t *testing.T) {
 	inputPath := "../testlint/testCerts/subKeyUsageInvalid.cer"
 	desEnum := Error
-	out, _ := Lints["sub_cert_key_usage_crl_sign_bit_set"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_key_usage_crl_sign_bit_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCrlSignBitSet(t *testing.T) {
 func TestCrlSignBitNotSet(t *testing.T) {
 	inputPath := "../testlint/testCerts/subKeyUsageValid.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_key_usage_crl_sign_bit_set"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_key_usage_crl_sign_bit_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_or_sub_ca_using_sha1.go
+++ b/lints/lint_sub_cert_or_sub_ca_using_sha1.go
@@ -39,7 +39,7 @@ func (l *sigAlgTestsSHA1) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_or_sub_ca_using_sha1",
+		Name:          "e_sub_cert_or_sub_ca_using_sha1",
 		Description:   "Subscriber certificates and subordinate CA certificates must not use the SHA-1 hash algorithm on a certificate with a NotBefore date after 1 Jan 2016",
 		Providence:    "CAB: 7.1.3",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_cert_or_sub_ca_using_sha1_test.go
+++ b/lints/lint_sub_cert_or_sub_ca_using_sha1_test.go
@@ -13,7 +13,7 @@ func TestSHA1After2016(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/rsawithsha1after2016.cer"
 	desEnum := Error
-	out, _ := Lints["sub_cert_or_sub_ca_using_sha1"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_or_sub_ca_using_sha1"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -27,7 +27,7 @@ func TestSHA1Before2016(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/rsawithsha1before2016.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_or_sub_ca_using_sha1"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_sub_cert_or_sub_ca_using_sha1"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_sub_cert_sha1_expiration_too_long.go
+++ b/lints/lint_sub_cert_sha1_expiration_too_long.go
@@ -36,7 +36,7 @@ func (l *sha1ExpireLong) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "sub_cert_sha1_expiration_too_long",
+		Name:          "w_sub_cert_sha1_expiration_too_long",
 		Description:   "Subscriber certificates using the SHA1 algorithm should not have an expiration date greater than 1 Jan 2017",
 		Providence:    "CAB: 7.1.3",
 		EffectiveDate: time.Date(2015, time.January, 16, 0, 0, 0, 0, time.UTC),

--- a/lints/lint_sub_cert_sha1_expiration_too_long_test.go
+++ b/lints/lint_sub_cert_sha1_expiration_too_long_test.go
@@ -8,7 +8,7 @@ import (
 func TestRsaSha1TooLong(t *testing.T) {
 	inputPath := "../testlint/testCerts/sha1ExpireAfter2017.cer"
 	desEnum := Warn
-	out, _ := Lints["sub_cert_sha1_expiration_too_long"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_cert_sha1_expiration_too_long"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestRsaSha1TooLong(t *testing.T) {
 func TestRsaSha1NotTooLong(t *testing.T) {
 	inputPath := "../testlint/testCerts/sha1ExpirePrior2017.cer"
 	desEnum := Pass
-	out, _ := Lints["sub_cert_sha1_expiration_too_long"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_sub_cert_sha1_expiration_too_long"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_common_name_disallowed.go
+++ b/lints/lint_subject_common_name_disallowed.go
@@ -43,7 +43,7 @@ func (l *BadCommonName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_common_name_disallowed",
+		Name:          "e_subject_common_name_disallowed",
 		Description:   "If present Common name MUST contain a single IP address or Fully‐Qualified Domain Name that is one of the values contained in the Certificate’s subjectAltName extension",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_common_name_disallowed_test.go
+++ b/lints/lint_subject_common_name_disallowed_test.go
@@ -8,7 +8,7 @@ import (
 func TestCommonNameInSan(t *testing.T) {
 	inputPath := "../testlint/testCerts/commonNameInSan.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_common_name_disallowed"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_common_name_disallowed"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCommonNameInSan(t *testing.T) {
 func TestCommonNameNotInSan(t *testing.T) {
 	inputPath := "../testlint/testCerts/utcHasSeconds.cer"
 	desEnum := Error
-	out, _ := Lints["subject_common_name_disallowed"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_common_name_disallowed"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_common_name_included.go
+++ b/lints/lint_subject_common_name_included.go
@@ -33,7 +33,7 @@ func (l *commonNames) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_common_name_included",
+		Name:          "w_subject_common_name_included",
 		Description:   "Use of the common name field is discouraged.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_common_name_included_test.go
+++ b/lints/lint_subject_common_name_included_test.go
@@ -8,7 +8,7 @@ import (
 func TestCN(t *testing.T) {
 	inputPath := "../testlint/testCerts/commonNamesURL.cer"
 	desEnum := Warn
-	out, _ := Lints["subject_common_name_included"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_subject_common_name_included"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCN(t *testing.T) {
 func TestNoCN(t *testing.T) {
 	inputPath := "../testlint/testCerts/commonNamesGood.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_common_name_included"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_subject_common_name_included"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_common_name_not_from_san.go
+++ b/lints/lint_subject_common_name_not_from_san.go
@@ -45,7 +45,7 @@ func (l *subjectCommonNameNotFromSAN) RunTest(c *x509.Certificate) (ResultStruct
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_common_name_not_from_san",
+		Name:          "e_subject_common_name_not_from_san",
 		Description:   "The common name field must include only names from the SAN extension.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_common_name_not_from_san_test.go
+++ b/lints/lint_subject_common_name_not_from_san_test.go
@@ -8,7 +8,7 @@ import (
 func TestCnNotFromSan(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanWithMissingCN.cer"
 	desEnum := Error
-	out, _ := Lints["subject_common_name_not_from_san"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_common_name_not_from_san"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCnNotFromSan(t *testing.T) {
 func TestCnFromSan(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanRegisteredIdBeginning.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_common_name_not_from_san"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_common_name_not_from_san"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_contains_noninformational_value.go
+++ b/lints/lint_subject_contains_noninformational_value.go
@@ -56,7 +56,7 @@ func (l *illegalChar) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_contains_noninformational_value",
+		Name:          "e_subject_contains_noninformational_value",
 		Description:   "Subject name fields must not contain '.','-',' ' or any other indication that the field has been ommited.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_contains_noninformational_value_test.go
+++ b/lints/lint_subject_contains_noninformational_value_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubjectNotInformational(t *testing.T) {
 	inputPath := "../testlint/testCerts/illegalChar.cer"
 	desEnum := Error
-	out, _ := Lints["subject_contains_noninformational_value"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_contains_noninformational_value"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubjectNotInformational(t *testing.T) {
 func TestSubjectInformational(t *testing.T) {
 	inputPath := "../testlint/testCerts/legalChar.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_contains_noninformational_value"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_contains_noninformational_value"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_contains_reserved_ip.go
+++ b/lints/lint_subject_contains_reserved_ip.go
@@ -42,7 +42,7 @@ func (l *subjectReservedIP) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_contains_reserved_ip",
+		Name:          "e_subject_contains_reserved_ip",
 		Description:   "Certs and expiring after 2015-11-01 must not contain a reserved ip address in the common name field.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_contains_reserved_ip_test.go
+++ b/lints/lint_subject_contains_reserved_ip_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubjectIPReserved(t *testing.T) {
 	inputPath := "../testlint/testCerts/subjectReservedIP.cer"
 	desEnum := Error
-	out, _ := Lints["subject_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubjectIPReserved(t *testing.T) {
 func TestSubjectIPReserved6(t *testing.T) {
 	inputPath := "../testlint/testCerts/subjectReservedIP6.cer"
 	desEnum := Error
-	out, _ := Lints["subject_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestSubjectIPReserved6(t *testing.T) {
 func TestSubjectIPNotReserved(t *testing.T) {
 	inputPath := "../testlint/testCerts/subjectGoodIP.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_contains_reserved_ip"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_country_not_iso.go
+++ b/lints/lint_subject_country_not_iso.go
@@ -38,7 +38,7 @@ func (l *countryNotIso) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_country_not_iso",
+		Name:          "e_subject_country_not_iso",
 		Description:   "The country name field must contain the two-letter ISO code for the country or XX.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_country_not_iso_test.go
+++ b/lints/lint_subject_country_not_iso_test.go
@@ -8,7 +8,7 @@ import (
 func TestCountryNotIso(t *testing.T) {
 	inputPath := "../testlint/testCerts/subjectInvalidCountry.cer"
 	desEnum := Error
-	out, _ := Lints["subject_country_not_iso"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_country_not_iso"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestCountryNotIso(t *testing.T) {
 func TestCountryIsIso(t *testing.T) {
 	inputPath := "../testlint/testCerts/subjectValidCountry.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_country_not_iso"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_country_not_iso"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_empty_without_san.go
+++ b/lints/lint_subject_empty_without_san.go
@@ -47,7 +47,7 @@ func subjectIsEmpty(cert *x509.Certificate) bool {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_empty_without_san",
+		Name:          "e_subject_empty_without_san",
 		Description:   "CAs must support subject alternative name if the subject field is an empty sequence.",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_subject_empty_without_san_test.go
+++ b/lints/lint_subject_empty_without_san_test.go
@@ -8,7 +8,7 @@ import (
 func TestSubEmptyNoSan(t *testing.T) {
 	inputPath := "../testlint/testCerts/subjectEmptyNoSan.cer"
 	desEnum := Error
-	out, _ := Lints["subject_empty_without_san"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_empty_without_san"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSubEmptyNoSan(t *testing.T) {
 func TestSubEmptyYesSan(t *testing.T) {
 	inputPath := "../testlint/testCerts/sanSubjectEmptyNotCritical.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_empty_without_san"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_empty_without_san"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_info_access_marked_critical.go
+++ b/lints/lint_subject_info_access_marked_critical.go
@@ -31,7 +31,7 @@ func (l *siaCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_info_access_marked_critical",
+		Name:          "e_subject_info_access_marked_critical",
 		Description:   "Conforming CAs must mark the Subject Info Access extension as non-critical.",
 		Providence:    "RFC 5280: 4.2.2.2",
 		EffectiveDate: util.RFC3280Date,

--- a/lints/lint_subject_info_access_marked_critical_test.go
+++ b/lints/lint_subject_info_access_marked_critical_test.go
@@ -8,7 +8,7 @@ import (
 func TestSiaCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/siaCrit.cer"
 	desEnum := Error
-	out, _ := Lints["subject_info_access_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_info_access_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestSiaCrit(t *testing.T) {
 func TestSiaNotCrit(t *testing.T) {
 	inputPath := "../testlint/testCerts/siaNotCrit.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_info_access_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_info_access_marked_critical"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_locality_without_org.go
+++ b/lints/lint_subject_locality_without_org.go
@@ -37,7 +37,7 @@ func (l *localNoOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_locality_without_org",
+		Name:          "e_subject_locality_without_org",
 		Description:   "The locality field must not be included without an organization name.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_locality_without_org_test.go
+++ b/lints/lint_subject_locality_without_org_test.go
@@ -8,7 +8,7 @@ import (
 func TestLocalNoOrg(t *testing.T) {
 	inputPath := "../testlint/testCerts/localNoOrg.cer"
 	desEnum := Error
-	out, _ := Lints["subject_locality_without_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_locality_without_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestLocalNoOrg(t *testing.T) {
 func TestLocalYesOrg(t *testing.T) {
 	inputPath := "../testlint/testCerts/localYesOrg.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_locality_without_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_locality_without_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_not_dn.go
+++ b/lints/lint_subject_not_dn.go
@@ -38,7 +38,7 @@ func (l *subjectDN) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_not_dn",
+		Name:          "e_subject_not_dn",
 		Description:   "When not empty, the subject field must be a distinguished name",
 		Providence:    "RFC 5280: 4.1.2.6",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_subject_org_without_country.go
+++ b/lints/lint_subject_org_without_country.go
@@ -36,7 +36,7 @@ func (l *orgNoCountry) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_org_without_country",
+		Name:          "e_subject_org_without_country",
 		Description:   "The organization name field must not be included without a country name.",
 		Providence:    "CAB: 7.1.4.2.2 (d&e)",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_org_without_country_test.go
+++ b/lints/lint_subject_org_without_country_test.go
@@ -8,7 +8,7 @@ import (
 func TestOrgNoCoun(t *testing.T) {
 	inputPath := "../testlint/testCerts/orgNoCountry.cer"
 	desEnum := Error
-	out, _ := Lints["subject_org_without_country"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_org_without_country"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestOrgNoCoun(t *testing.T) {
 func TestOrgYesCoun(t *testing.T) {
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_org_without_country"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_org_without_country"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_org_without_locality_or_province.go
+++ b/lints/lint_subject_org_without_locality_or_province.go
@@ -32,7 +32,7 @@ func (l *orgNoLocalOrProvince) RunTest(cert *x509.Certificate) (ResultStruct, er
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_org_without_locality_or_province",
+		Name:          "e_subject_org_without_locality_or_province",
 		Description:   "If organiation is included, either stateOrProvince or locality must be included.",
 		Providence:    "CAB: 7.1.4.2.2 (d&e)",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_org_without_locality_or_province_test.go
+++ b/lints/lint_subject_org_without_locality_or_province_test.go
@@ -8,7 +8,7 @@ import (
 func TestOrgNoLoc(t *testing.T) {
 	inputPath := "../testlint/testCerts/orgNoLocal.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_org_without_locality_or_province"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_org_without_locality_or_province"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestOrgNoLoc(t *testing.T) {
 func TestOrgNoProv(t *testing.T) {
 	inputPath := "../testlint/testCerts/orgNoProv.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_org_without_locality_or_province"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_org_without_locality_or_province"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestOrgNoProv(t *testing.T) {
 func TestOrgNoBoth(t *testing.T) {
 	inputPath := "../testlint/testCerts/orgNoBoth.cer"
 	desEnum := Error
-	out, _ := Lints["subject_org_without_locality_or_province"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_org_without_locality_or_province"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_postal_without_org.go
+++ b/lints/lint_subject_postal_without_org.go
@@ -36,7 +36,7 @@ func (l *postalNoOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_postal_without_org",
+		Name:          "e_subject_postal_without_org",
 		Description:   "The postal code must not be included without an organization name.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_postal_without_org_test.go
+++ b/lints/lint_subject_postal_without_org_test.go
@@ -8,7 +8,7 @@ import (
 func TestPostalNoOrg(t *testing.T) {
 	inputPath := "../testlint/testCerts/postalNoOrg.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_postal_without_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_postal_without_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestPostalNoOrg(t *testing.T) {
 func TestPostalYesOrg(t *testing.T) {
 	inputPath := "../testlint/testCerts/postalYesOrg.cer"
 	desEnum := Error
-	out, _ := Lints["subject_postal_without_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_postal_without_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_province_without_org.go
+++ b/lints/lint_subject_province_without_org.go
@@ -36,7 +36,7 @@ func (l *provinceNoOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_province_without_org",
+		Name:          "e_subject_province_without_org",
 		Description:   "The stateOrProvince name must not be included without an organization name.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_province_without_org_test.go
+++ b/lints/lint_subject_province_without_org_test.go
@@ -8,7 +8,7 @@ import (
 func TestProvinceNoOrg(t *testing.T) {
 	inputPath := "../testlint/testCerts/provNoOrg.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_province_without_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_province_without_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestProvinceNoOrg(t *testing.T) {
 func TestProvinceYesOrg(t *testing.T) {
 	inputPath := "../testlint/testCerts/provYesOrg.cer"
 	desEnum := Error
-	out, _ := Lints["subject_province_without_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_province_without_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_subject_street_without_org.go
+++ b/lints/lint_subject_street_without_org.go
@@ -36,7 +36,7 @@ func (l *streetNoOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_street_without_org",
+		Name:          "e_subject_street_without_org",
 		Description:   "The street address field must not be included without an organization name.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_subject_street_without_org_test.go
+++ b/lints/lint_subject_street_without_org_test.go
@@ -8,7 +8,7 @@ import (
 func TestStreetNoOrg(t *testing.T) {
 	inputPath := "../testlint/testCerts/streetNoOrg.cer"
 	desEnum := Pass
-	out, _ := Lints["subject_street_without_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_street_without_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestStreetNoOrg(t *testing.T) {
 func TestStreetYesOrg(t *testing.T) {
 	inputPath := "../testlint/testCerts/streetYesOrg.cer"
 	desEnum := Error
-	out, _ := Lints["subject_street_without_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_subject_street_without_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_utc_time_does_not_include_seconds.go
+++ b/lints/lint_utc_time_does_not_include_seconds.go
@@ -58,7 +58,7 @@ func (l *utcNoSecond) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "utc_time_does_not_include_seconds",
+		Name:          "e_utc_time_does_not_include_seconds",
 		Description:   "UTCTime values must include seconds",
 		Providence:    "RFC 5280: 4.1.2.5.1",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_utc_time_does_not_include_seconds_test.go
+++ b/lints/lint_utc_time_does_not_include_seconds_test.go
@@ -8,7 +8,7 @@ import (
 func TestUtcHasSeconds(t *testing.T) {
 	inputPath := "../testlint/testCerts/utcHasSeconds.cer"
 	desEnum := Pass
-	out, _ := Lints["utc_time_does_not_include_seconds"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_utc_time_does_not_include_seconds"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestUtcHasSeconds(t *testing.T) {
 func TestUtcNoSeconds(t *testing.T) {
 	inputPath := "../testlint/testCerts/utcNoSeconds.cer"
 	desEnum := Error
-	out, _ := Lints["utc_time_does_not_include_seconds"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_utc_time_does_not_include_seconds"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_utc_time_not_in_zulu.go
+++ b/lints/lint_utc_time_not_in_zulu.go
@@ -70,7 +70,7 @@ func utcNotGmt(t time.Time, r *ResultEnum) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "utc_time_not_in_zulu",
+		Name:          "e_utc_time_not_in_zulu",
 		Description:   "UTCTime values MUST be expressed in Greenwich Mean Time (Zulu)",
 		Providence:    "RFC 5280: 4.1.2.5.1",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_utc_time_not_in_zulu_test.go
+++ b/lints/lint_utc_time_not_in_zulu_test.go
@@ -8,7 +8,7 @@ import (
 func TestUtcZulu(t *testing.T) {
 	inputPath := "../testlint/testCerts/utcHasSeconds.cer"
 	desEnum := Pass
-	out, _ := Lints["utc_time_not_in_zulu"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_utc_time_not_in_zulu"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestUtcZulu(t *testing.T) {
 func TestUtcNotZulu(t *testing.T) {
 	inputPath := "../testlint/testCerts/utcNotZulu.cer"
 	desEnum := Error
-	out, _ := Lints["utc_time_not_in_zulu"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_utc_time_not_in_zulu"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_validity_time_not_positive.go
+++ b/lints/lint_validity_time_not_positive.go
@@ -31,7 +31,7 @@ func (l *validityNegative) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "validity_time_not_positive",
+		Name:          "e_validity_time_not_positive",
 		Description:   "Certificates MUST have a positive time for which they are valid",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_validity_time_not_positive_test.go
+++ b/lints/lint_validity_time_not_positive_test.go
@@ -8,7 +8,7 @@ import (
 func TestValidityNegative(t *testing.T) {
 	inputPath := "../testlint/testCerts/validityNegative.cer"
 	desEnum := Error
-	out, _ := Lints["validity_time_not_positive"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_validity_time_not_positive"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestValidityNegative(t *testing.T) {
 func TestValidityPositive(t *testing.T) {
 	inputPath := "../testlint/testCerts/ianURIValid.cer"
 	desEnum := Pass
-	out, _ := Lints["validity_time_not_positive"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_validity_time_not_positive"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_wrong_time_format_pre2050.go
+++ b/lints/lint_wrong_time_format_pre2050.go
@@ -51,7 +51,7 @@ func (l *generalizedPre2050) RunTest(c *x509.Certificate) (ResultStruct, error) 
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "wrong_time_format_pre2050",
+		Name:          "e_wrong_time_format_pre2050",
 		Description:   "Certificates with validity through the year 2049 must be encoded in UTC time",
 		Providence:    "RFC 5280: 4.1.2.5",
 		EffectiveDate: util.RFC2459Date,

--- a/lints/lint_wrong_time_format_pre2050_test.go
+++ b/lints/lint_wrong_time_format_pre2050_test.go
@@ -8,7 +8,7 @@ import (
 func TestGeneralizedAfter2050(t *testing.T) {
 	inputPath := "../testlint/testCerts/generalizedAfter2050.cer"
 	desEnum := Pass
-	out, _ := Lints["wrong_time_format_pre2050"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_wrong_time_format_pre2050"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -21,7 +21,7 @@ func TestGeneralizedAfter2050(t *testing.T) {
 func TestUTCPrior2050(t *testing.T) {
 	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["wrong_time_format_pre2050"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_wrong_time_format_pre2050"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -34,7 +34,7 @@ func TestUTCPrior2050(t *testing.T) {
 func TestGeneralizedPrior2050(t *testing.T) {
 	inputPath := "../testlint/testCerts/generalizedPrior2050.cer"
 	desEnum := Error
-	out, _ := Lints["wrong_time_format_pre2050"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_wrong_time_format_pre2050"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/result.go
+++ b/lints/result.go
@@ -3,13 +3,14 @@ package lints
 type ResultEnum int
 
 const (
-	NA    ResultEnum = iota // 0
-	NE                      // 1
-	Pass                    // 2
-	Info                    // 3
-	Warn                    // 4
-	Error                   // 5
-	Fatal                   // 6
+	Reserved ResultEnum = iota //0
+	NA    			// 1
+	NE                      // 2
+	Pass                    // 3
+	Info                    // 4
+	Warn                    // 5
+	Error                   // 6
+	Fatal                   // 7
 )
 
 type ResultStruct struct {
@@ -18,8 +19,8 @@ type ResultStruct struct {
 }
 
 type FinalResult struct {
-	Result string `json:"result"`
-	//Details string `json:"details,omitempty"`
+	Result 	ResultEnum 	`json:"result"`
+	Details string 		`json:"details,omitempty"`
 }
 
 func EnumToString(e ResultEnum) string {

--- a/main.go
+++ b/main.go
@@ -99,10 +99,10 @@ func multiMode() (err error) {
 	//main computation
 	var done bool = false
 	for !done { //loops until read error, consider reworking this
-		certs := make([]string, 0, CHUNKSIZE)                         //input buffer
-		reports := make([]map[string]lints.FinalResult, 0, CHUNKSIZE) //output buffer
-		var readIn, lintOut int = 0, 0                                //reading and processing counters
-		for ; readIn < CHUNKSIZE && !done; readIn++ {                 //read in CHUNKSIZE # certs
+		certs := make([]string, 0, CHUNKSIZE)              //input buffer
+		reports := make([]map[string]string, 0, CHUNKSIZE) //output buffer
+		var readIn, lintOut int = 0, 0                     //reading and processing counters
+		for ; readIn < CHUNKSIZE && !done; readIn++ {      //read in CHUNKSIZE # certs
 			lineIn, err := buffReader.ReadString('\n')
 			if err != nil { //read error, stop reading and process anything that was read
 				done = true

--- a/main.go
+++ b/main.go
@@ -99,10 +99,10 @@ func multiMode() (err error) {
 	//main computation
 	var done bool = false
 	for !done { //loops until read error, consider reworking this
-		certs := make([]string, 0, CHUNKSIZE)              //input buffer
-		reports := make([]map[string]string, 0, CHUNKSIZE) //output buffer
-		var readIn, lintOut int = 0, 0                     //reading and processing counters
-		for ; readIn < CHUNKSIZE && !done; readIn++ {      //read in CHUNKSIZE # certs
+		certs := make([]string, 0, CHUNKSIZE)                         //input buffer
+		reports := make([]map[string]lints.FinalResult, 0, CHUNKSIZE) //output buffer
+		var readIn, lintOut int = 0, 0                                //reading and processing counters
+		for ; readIn < CHUNKSIZE && !done; readIn++ {                 //read in CHUNKSIZE # certs
 			lineIn, err := buffReader.ReadString('\n')
 			if err != nil { //read error, stop reading and process anything that was read
 				done = true

--- a/zlint/zlint.go
+++ b/zlint/zlint.go
@@ -12,27 +12,25 @@ import (
 )
 
 //Calls all other checks on parsed certs
-func ParsedTestHandler(cert *x509.Certificate) (map[string]lints.FinalResult, error) {
+func ParsedTestHandler(cert *x509.Certificate) (map[string]string, error) {
 	if cert == nil {
 		return nil, errors.New("zlint: nil pointer passed in, no data returned")
 	}
 	//run all tests
-	var out map[string]lints.FinalResult = make(map[string]lints.FinalResult)
+	var out map[string]string = make(map[string]string)
 	for _, l := range lints.Lints {
 		result, err := l.ExecuteTest(cert)
-		finalResult := lints.FinalResult{}
-		finalResult.Result = result.Result
 		if err != nil {
 			return out, err
 		}
-		out[l.Name] = finalResult
+		out[l.Name] = lints.EnumToString(result.Result)
 	}
 
 	return out, nil
 }
 
 //expects Base64 encoded ASN.1 DER string, wrapper for ParsedTestHandler
-func Lint64(certIn string) (map[string]lints.FinalResult, error) {
+func Lint64(certIn string) (map[string]string, error) {
 
 	der, err := base64.StdEncoding.DecodeString(certIn) //decode string
 	if err != nil {

--- a/zlint/zlint.go
+++ b/zlint/zlint.go
@@ -12,25 +12,27 @@ import (
 )
 
 //Calls all other checks on parsed certs
-func ParsedTestHandler(cert *x509.Certificate) (map[string]string, error) {
+func ParsedTestHandler(cert *x509.Certificate) (map[string]lints.FinalResult, error) {
 	if cert == nil {
 		return nil, errors.New("zlint: nil pointer passed in, no data returned")
 	}
 	//run all tests
-	var out map[string]string = make(map[string]string)
+	var out map[string]lints.FinalResult = make(map[string]lints.FinalResult)
 	for _, l := range lints.Lints {
 		result, err := l.ExecuteTest(cert)
+		finalResult := lints.FinalResult{}
+		finalResult.Result = result.Result
 		if err != nil {
 			return out, err
 		}
-		out[l.Name] = lints.EnumToString(result.Result)
+		out[l.Name] = finalResult
 	}
 
 	return out, nil
 }
 
 //expects Base64 encoded ASN.1 DER string, wrapper for ParsedTestHandler
-func Lint64(certIn string) (map[string]string, error) {
+func Lint64(certIn string) (map[string]lints.FinalResult, error) {
 
 	der, err := base64.StdEncoding.DecodeString(certIn) //decode string
 	if err != nil {


### PR DESCRIPTION
Modifying each lint name to prepend "e" or "w" for easier querying, and to match protobuf names.