### PR TITLE
Kumarde/rename lints

### DIFF
--- a/lints/lint_ca_digital_signature_not_set.go
+++ b/lints/lint_ca_digital_signature_not_set.go
@@ -35,7 +35,7 @@ func (l *caDigSignNotSet) RunTest(c *x509.Certificate) (ResultStruct, error) {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "w_ca_dig_sign_not_set",
+		Name:          "w_ca_digital_signature_not_set",
 		Description:   "Root & Subordinate CA Certificates that wish to use their private key for signing OCSP responses will not be able to with out digital signature set",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_ca_digital_signature_not_set_test.go
+++ b/lints/lint_ca_digital_signature_not_set_test.go
@@ -1,15 +1,15 @@
-// lint_cert_policy_conflicts_with_org_test.go
+// lint_ca_dig_sign_not_set_test.go
 package lints
 
 import (
 	"testing"
 )
 
-func TestCertPolicyNotConflictWithOrg(t *testing.T) {
+func TestCaKeyUsageNoDigSign(t *testing.T) {
 	// Only need to change these two values and the lint name
-	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
-	desEnum := Pass
-	out, _ := Lints["e_cert_policy_conflicts_with_org"].ExecuteTest(ReadCertificate(inputPath))
+	inputPath := "../testlint/testCerts/caKeyUsageNoCertSign.cer"
+	desEnum := Warn
+	out, _ := Lints["w_ca_digital_signature_not_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -19,11 +19,11 @@ func TestCertPolicyNotConflictWithOrg(t *testing.T) {
 	}
 }
 
-func TestCertPolicyConflictsWithOrg(t *testing.T) {
+func TestKeyUsageDigSign(t *testing.T) {
 	// Only need to change these two values and the lint name
-	inputPath := "../testlint/testCerts/domainValWithOrg.cer"
-	desEnum := Error
-	out, _ := Lints["e_cert_policy_conflicts_with_org"].ExecuteTest(ReadCertificate(inputPath))
+	inputPath := "../testlint/testCerts/caKeyUsageWDigSign.cer"
+	desEnum := Pass
+	out, _ := Lints["w_ca_digitial_signature_not_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_ca_digital_signature_not_set_test.go
+++ b/lints/lint_ca_digital_signature_not_set_test.go
@@ -23,7 +23,7 @@ func TestKeyUsageDigSign(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/caKeyUsageWDigSign.cer"
 	desEnum := Pass
-	out, _ := Lints["w_ca_digitial_signature_not_set"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["w_ca_digital_signature_not_set"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cab_dv_conflicts_with_locality.go
+++ b/lints/lint_cab_dv_conflicts_with_locality.go
@@ -33,7 +33,7 @@ func (l *certPolicyConflictsWithLocality) RunTest(cert *x509.Certificate) (Resul
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "e_cert_policy_conflicts_with_locality",
+		Name:          "e_cab_dv_conflicts_with_locality",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, locality name must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cab_dv_conflicts_with_locality_test.go
+++ b/lints/lint_cab_dv_conflicts_with_locality_test.go
@@ -1,15 +1,15 @@
-// lint_cert_policy_requires_org_test.go
+// lint_cert_policy_conflicts_with_locality_test.go
 package lints
 
 import (
 	"testing"
 )
 
-func TestCertPolicyOvHasOrg(t *testing.T) {
+func TestCertPolicyNotConflictWithLocal(t *testing.T) {
 	// Only need to change these two values and the lint name
-	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
+	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
 	desEnum := Pass
-	out, _ := Lints["e_cert_policy_requires_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_dv_conflicts_with_locality"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -19,11 +19,11 @@ func TestCertPolicyOvHasOrg(t *testing.T) {
 	}
 }
 
-func TestCertPolicyOvNoOrg(t *testing.T) {
+func TestCertPolicyConflictsWithLocal(t *testing.T) {
 	// Only need to change these two values and the lint name
-	inputPath := "../testlint/testCerts/orgValNoOrg.cer"
+	inputPath := "../testlint/testCerts/domainValWithLocal.cer"
 	desEnum := Error
-	out, _ := Lints["e_cert_policy_requires_org"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_dv_conflicts_with_locality"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cab_dv_conflicts_with_org.go
+++ b/lints/lint_cab_dv_conflicts_with_org.go
@@ -33,7 +33,7 @@ func (l *certPolicyConflictsWithOrg) RunTest(cert *x509.Certificate) (ResultStru
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "e_cert_policy_conflicts_with_org",
+		Name:          "e_cab_dv_conflicts_with_org",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, organization name must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cab_dv_conflicts_with_org_test.go
+++ b/lints/lint_cab_dv_conflicts_with_org_test.go
@@ -1,15 +1,15 @@
-// lint_cert_policy_conflicts_with_postal_test.go
+// lint_cert_policy_conflicts_with_org_test.go
 package lints
 
 import (
 	"testing"
 )
 
-func TestCertPolicyNotConflictWithPostal(t *testing.T) {
+func TestCertPolicyNotConflictWithOrg(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
 	desEnum := Pass
-	out, _ := Lints["e_cert_policy_conflicts_with_postal"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_dv_conflicts_with_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -19,11 +19,11 @@ func TestCertPolicyNotConflictWithPostal(t *testing.T) {
 	}
 }
 
-func TestCertPolicyConflictsWithPostal(t *testing.T) {
+func TestCertPolicyConflictsWithOrg(t *testing.T) {
 	// Only need to change these two values and the lint name
-	inputPath := "../testlint/testCerts/domainValWithPostal.cer"
+	inputPath := "../testlint/testCerts/domainValWithOrg.cer"
 	desEnum := Error
-	out, _ := Lints["e_cert_policy_conflicts_with_postal"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_dv_conflicts_with_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cab_dv_conflicts_with_postal.go
+++ b/lints/lint_cab_dv_conflicts_with_postal.go
@@ -33,7 +33,7 @@ func (l *certPolicyConflictsWithPostal) RunTest(cert *x509.Certificate) (ResultS
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "e_cert_policy_conflicts_with_postal",
+		Name:          "e_cab_dv_conflicts_with_postal",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, postalCode must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cab_dv_conflicts_with_postal_test.go
+++ b/lints/lint_cab_dv_conflicts_with_postal_test.go
@@ -1,15 +1,15 @@
-// lint_ca_dig_sign_not_set_test.go
+// lint_cert_policy_conflicts_with_postal_test.go
 package lints
 
 import (
 	"testing"
 )
 
-func TestCaKeyUsageNoDigSign(t *testing.T) {
+func TestCertPolicyNotConflictWithPostal(t *testing.T) {
 	// Only need to change these two values and the lint name
-	inputPath := "../testlint/testCerts/caKeyUsageNoCertSign.cer"
-	desEnum := Warn
-	out, _ := Lints["w_ca_dig_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
+	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
+	desEnum := Pass
+	out, _ := Lints["e_cab_dv_conflicts_with_postal"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -19,11 +19,11 @@ func TestCaKeyUsageNoDigSign(t *testing.T) {
 	}
 }
 
-func TestKeyUsageDigSign(t *testing.T) {
+func TestCertPolicyConflictsWithPostal(t *testing.T) {
 	// Only need to change these two values and the lint name
-	inputPath := "../testlint/testCerts/caKeyUsageWDigSign.cer"
-	desEnum := Pass
-	out, _ := Lints["w_ca_dig_sign_not_set"].ExecuteTest(ReadCertificate(inputPath))
+	inputPath := "../testlint/testCerts/domainValWithPostal.cer"
+	desEnum := Error
+	out, _ := Lints["e_cab_dv_conflicts_with_postal"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cab_dv_conflicts_with_province.go
+++ b/lints/lint_cab_dv_conflicts_with_province.go
@@ -33,7 +33,7 @@ func (l *certPolicyConflictsWithProvince) RunTest(cert *x509.Certificate) (Resul
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "e_cert_policy_conflicts_with_province",
+		Name:          "e_cab_dv_conflicts_with_province",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, stateOrProvinceName must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cab_dv_conflicts_with_province_test.go
+++ b/lints/lint_cab_dv_conflicts_with_province_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyNotConflictWithProv(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
 	desEnum := Pass
-	out, _ := Lints["e_cert_policy_conflicts_with_province"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_dv_conflicts_with_province"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyConflictsWithProv(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValWithProvince.cer"
 	desEnum := Error
-	out, _ := Lints["e_cert_policy_conflicts_with_province"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_dv_conflicts_with_province"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cab_dv_conflicts_with_street.go
+++ b/lints/lint_cab_dv_conflicts_with_street.go
@@ -33,7 +33,7 @@ func (l *certPolicyConflictsWithStreet) RunTest(cert *x509.Certificate) (ResultS
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "e_cert_policy_conflicts_with_street",
+		Name:          "e_cab_dv_conflicts_with_street",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, streetAddress must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cab_dv_conflicts_with_street_test.go
+++ b/lints/lint_cab_dv_conflicts_with_street_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyNotConflictWithStreet(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
 	desEnum := Pass
-	out, _ := Lints["e_cert_policy_conflicts_with_street"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_dv_conflicts_with_street"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyConflictsWithStreet(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/domainValWithStreet.cer"
 	desEnum := Error
-	out, _ := Lints["e_cert_policy_conflicts_with_street"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_dv_conflicts_with_street"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cab_iv_requires_personal_name.go
+++ b/lints/lint_cab_iv_requires_personal_name.go
@@ -32,7 +32,7 @@ func (l *CertPolicyRequiresPersonalName) RunTest(cert *x509.Certificate) (Result
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "e_cert_policy_requires_personal_name",
+		Name:          "e_cab_iv_requires_personal_name",
 		Description:   "If certificate policy 2.23.140.1.2.3 is included, either organizationName or givenName and surname must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,

--- a/lints/lint_cab_iv_requires_personal_name_test.go
+++ b/lints/lint_cab_iv_requires_personal_name_test.go
@@ -9,7 +9,7 @@ func TestCertPolicyIvHasPerson(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["e_cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_iv_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -23,7 +23,7 @@ func TestCertPolicyIvHasSurname(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValSurnameOnly.cer"
 	desEnum := Error
-	out, _ := Lints["e_cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_iv_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -37,7 +37,7 @@ func TestCertPolicyIvHasLastName(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValGivenNameOnly.cer"
 	desEnum := Error
-	out, _ := Lints["e_cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_iv_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -51,7 +51,7 @@ func TestCertPolicyIvNoPerson(t *testing.T) {
 	// Only need to change these two values and the lint name
 	inputPath := "../testlint/testCerts/indivValNoOrgOrPersonalNames.cer"
 	desEnum := Error
-	out, _ := Lints["e_cert_policy_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_iv_requires_personal_name"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/

--- a/lints/lint_cab_ov_requires_org.go
+++ b/lints/lint_cab_ov_requires_org.go
@@ -32,7 +32,7 @@ func (l *CertPolicyRequiresOrg) RunTest(cert *x509.Certificate) (ResultStruct, e
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "e_cert_policy_requires_org",
+		Name:          "e_cab_ov_requires_org",
 		Description:   "If certificate policy 2.23.140.1.2.2 is included, organizationName must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_cab_ov_requires_org_test.go
+++ b/lints/lint_cab_ov_requires_org_test.go
@@ -1,15 +1,15 @@
-// lint_cert_policy_conflicts_with_locality_test.go
+// lint_cert_policy_requires_org_test.go
 package lints
 
 import (
 	"testing"
 )
 
-func TestCertPolicyNotConflictWithLocal(t *testing.T) {
+func TestCertPolicyOvHasOrg(t *testing.T) {
 	// Only need to change these two values and the lint name
-	inputPath := "../testlint/testCerts/domainValGoodSubject.cer"
+	inputPath := "../testlint/testCerts/orgValGoodAllFields.cer"
 	desEnum := Pass
-	out, _ := Lints["e_cert_policy_conflicts_with_locality"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_ov_requires_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/
@@ -19,11 +19,11 @@ func TestCertPolicyNotConflictWithLocal(t *testing.T) {
 	}
 }
 
-func TestCertPolicyConflictsWithLocal(t *testing.T) {
+func TestCertPolicyOvNoOrg(t *testing.T) {
 	// Only need to change these two values and the lint name
-	inputPath := "../testlint/testCerts/domainValWithLocal.cer"
+	inputPath := "../testlint/testCerts/orgValNoOrg.cer"
 	desEnum := Error
-	out, _ := Lints["e_cert_policy_conflicts_with_locality"].ExecuteTest(ReadCertificate(inputPath))
+	out, _ := Lints["e_cab_ov_requires_org"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(
 			"For", inputPath, /* input path*/


### PR DESCRIPTION
pass through lints to rename the ones that didn't have good, explicit names.