### PR TITLE
fixing bug in ip checking for common names

### DIFF
--- a/lints/lint_subject_common_name_not_from_san.go
+++ b/lints/lint_subject_common_name_not_from_san.go
@@ -35,7 +35,7 @@ func (l *subjectCommonNameNotFromSAN) RunTest(c *x509.Certificate) (ResultStruct
 	}
 
 	for _, ip := range c.IPAddresses {
-		if cn == string(ip) {
+		if cn == ip.String() {
 			return ResultStruct{Result: Pass}, nil
 		}
 	}


### PR DESCRIPTION
string(net.IP) is not correct.