### PR TITLE
Kumarde/zlint refactor

### DIFF
--- a/lints/base.go
+++ b/lints/base.go
@@ -10,12 +10,12 @@ var (
 	Lints map[string]*Lint = make(map[string]*Lint)
 )
 
-const ZLintVersion = 1;
+const ZLintVersion = 1
 
 type ZLintResult struct {
-	ZLintVersion	int64
-	ZLints		map[string]string
-	Timestamp 	int64
+	ZLintVersion int64
+	ZLints       map[string]string
+	Timestamp    int64
 }
 
 type LintTest interface {

--- a/lints/base.go
+++ b/lints/base.go
@@ -10,201 +10,214 @@ var (
 	Lints map[string]*Lint = make(map[string]*Lint)
 )
 
-type ZLints struct {
-	EBasicConstraintsNotCritical                         *ResultStruct `json:"e_basic_constraints_not_critical,omitempty"`
-	EIanBareWildcard                                     *ResultStruct `json:"e_ian_bare_wildcard,omitempty"`
-	EIanWildcardNotFirst                                 *ResultStruct `json:"e_ian_wildcard_not_first,omitempty"`
-	ESanBareWildcard                                     *ResultStruct `json:"e_san_bare_wildcard,omitempty"`
-	ESanWildcardNotFirst                                 *ResultStruct `json:"e_san_wildcard_not_first,omitempty"`
-	ECaCountryNameInvalid                                *ResultStruct `json:"e_ca_country_name_invalid,omitempty"`
-	ECaCountryNameMissing                                *ResultStruct `json:"e_ca_country_name_missing,omitempty"`
-	ECaCrlSignNotSet                                     *ResultStruct `json:"e_ca_crl_sign_not_set,omitempty"`
-	ICaDigitalSignatureNotSet                            *ResultStruct `json:"i_ca_digital_signature_not_set,omitempty"`
-	ECaKeyCertSignNotSet                                 *ResultStruct `json:"e_ca_key_cert_sign_not_set,omitempty"`
-	ECaKeyUsageMissing                                   *ResultStruct `json:"e_ca_key_usage_missing,omitempty"`
-	ECaKeyUsageNotCritical                               *ResultStruct `json:"e_ca_key_usage_not_critical,omitempty"`
-	ECaOrganizationNameMissing                           *ResultStruct `json:"e_ca_organization_name_missing,omitempty"`
-	ECaSubjectFieldEmpty                                 *ResultStruct `json:"e_ca_subject_field_empty,omitempty"`
-	ECertContainsUniqueIdentifier                        *ResultStruct `json:"e_cert_contains_unique_identifier,omitempty"`
-	ECertExtensionsVersionNot_3                          *ResultStruct `json:"e_cert_extensions_version_not_3,omitempty"`
-	ECabDvConflictsWithLocality                          *ResultStruct `json:"e_cab_dv_conflicts_with_locality,omitempty"`
-	ECabDvConflictsWithOrg                               *ResultStruct `json:"e_cab_dv_conflicts_with_org,omitempty"`
-	ECabDvConflictsWithPostal                            *ResultStruct `json:"e_cab_dv_conflicts_with_postal,omitempty"`
-	ECabDvConflictsWithProvince                          *ResultStruct `json:"e_cab_dv_conflicts_with_province,omitempty"`
-	ECabDvConflictsWithStreet                            *ResultStruct `json:"e_cab_dv_conflicts_with_street,omitempty"`
-	ECertPolicyIvRequiresCountry                         *ResultStruct `json:"e_cert_policy_iv_requires_country,omitempty"`
-	ECertPolicyIvRequiresProvinceOrLocality              *ResultStruct `json:"e_cert_policy_iv_requires_province_or_locality,omitempty"`
-	ECertPolicyOvRequiresCountry                         *ResultStruct `json:"e_cert_policy_ov_requires_country,omitempty"`
-	ECertPolicyOvRequiresProvinceOrLocality              *ResultStruct `json:"e_cert_policy_ov_requires_province_or_locality,omitempty"`
-	ECabOvRequiresOrg                                    *ResultStruct `json:"e_cab_ov_requires_org,omitempty"`
-	ECabIvRequiresPersonalName                           *ResultStruct `json:"e_cab_iv_requires_personal_name,omitempty"`
-	ECertUniqueIdentifierVersionNot_2Or_3                *ResultStruct `json:"e_cert_unique_identifier_version_not_2_or_3,omitempty"`
-	EDhParamsMissing                                     *ResultStruct `json:"e_dh_params_missing,omitempty"`
-	EDistributionPointIncomplete                         *ResultStruct `json:"e_distribution_point_incomplete,omitempty"`
-	WDistributionPointMissingLdapOrUri                   *ResultStruct `json:"w_distribution_point_missing_ldap_or_uri,omitempty"`
-	EDsaImproperModulusOrDivisorSize                     *ResultStruct `json:"e_dsa_improper_modulus_or_divisor_size,omitempty"`
-	EDsaShorterThan_2048Bits                             *ResultStruct `json:"e_dsa_shorter_than_2048_bits,omitempty"`
-	EEcImproperCurves                                    *ResultStruct `json:"e_ec_improper_curves,omitempty"`
-	WEkuCriticalImproperly                               *ResultStruct `json:"w_eku_critical_improperly,omitempty"`
-	EEvBusinessCategoryMissing                           *ResultStruct `json:"e_ev_business_category_missing,omitempty"`
-	EEvCountryNameMissing                                *ResultStruct `json:"e_ev_country_name_missing,omitempty"`
-	EEvLocalityNameMissing                               *ResultStruct `json:"e_ev_locality_name_missing,omitempty"`
-	EEvOrganizationNameMissing                           *ResultStruct `json:"e_ev_organization_name_missing,omitempty"`
-	EEvSerialNumberMissing                               *ResultStruct `json:"e_ev_serial_number_missing,omitempty"`
-	EEvValidTimeTooLong                                  *ResultStruct `json:"e_ev_valid_time_too_long,omitempty"`
-	WExtAiaAccessLocationMissing                         *ResultStruct `json:"w_ext_aia_access_location_missing,omitempty"`
-	EExtAiaMarkedCritical                                *ResultStruct `json:"e_ext_aia_marked_critical,omitempty"`
-	EExtAuthorityKeyIdentifierCritical                   *ResultStruct `json:"e_ext_authority_key_identifier_critical,omitempty"`
-	EExtAuthorityKeyIdentifierMissing                    *ResultStruct `json:"e_ext_authority_key_identifier_missing,omitempty"`
-	EExtAuthorityKeyIdentifierNoKeyIdentifier            *ResultStruct `json:"e_ext_authority_key_identifier_no_key_identifier,omitempty"`
-	WExtCertPolicyContainsNoticeref                      *ResultStruct `json:"w_ext_cert_policy_contains_noticeref,omitempty"`
-	EExtCertPolicyDisallowedAnyPolicyQualifier           *ResultStruct `json:"e_ext_cert_policy_disallowed_any_policy_qualifier,omitempty"`
-	EExtCertPolicyDuplicate                              *ResultStruct `json:"e_ext_cert_policy_duplicate,omitempty"`
-	EExtCertPolicyExplicitTextIa5String                  *ResultStruct `json:"e_ext_cert_policy_explicit_text_ia5_string,omitempty"`
-	WExtCertPolicyExplicitTextIncludesControl            *ResultStruct `json:"w_ext_cert_policy_explicit_text_includes_control,omitempty"`
-	WExtCertPolicyExplicitTextNotNfc                     *ResultStruct `json:"w_ext_cert_policy_explicit_text_not_nfc,omitempty"`
-	WExtCertPolicyExplicitTextNotUtf8                    *ResultStruct `json:"w_ext_cert_policy_explicit_text_not_utf8,omitempty"`
-	EExtCertPolicyExplicitTextTooLong                    *ResultStruct `json:"e_ext_cert_policy_explicit_text_too_long,omitempty"`
-	WExtCrlDistributionMarkedCritical                    *ResultStruct `json:"w_ext_crl_distribution_marked_critical,omitempty"`
-	EExtDuplicateExtension                               *ResultStruct `json:"e_ext_duplicate_extension,omitempty"`
-	EExtFreshestCrlMarkedCritical                        *ResultStruct `json:"e_ext_freshest_crl_marked_critical,omitempty"`
-	WExtIanCritical                                      *ResultStruct `json:"w_ext_ian_critical,omitempty"`
-	EExtIanDnsNotIa5String                               *ResultStruct `json:"e_ext_ian_dns_not_ia5_string,omitempty"`
-	EExtIanEmptyName                                     *ResultStruct `json:"e_ext_ian_empty_name,omitempty"`
-	EExtIanNoEntries                                     *ResultStruct `json:"e_ext_ian_no_entries,omitempty"`
-	EExtIanRfc822FormatInvalid                           *ResultStruct `json:"e_ext_ian_rfc822_format_invalid,omitempty"`
-	EExtIanSpaceDnsName                                  *ResultStruct `json:"e_ext_ian_space_dns_name,omitempty"`
-	EExtIanUriFormatInvalid                              *ResultStruct `json:"e_ext_ian_uri_format_invalid,omitempty"`
-	EExtIanUriHostNotFqdnOrIp                            *ResultStruct `json:"e_ext_ian_uri_host_not_fqdn_or_ip,omitempty"`
-	EExtIanUriNotIa5                                     *ResultStruct `json:"e_ext_ian_uri_not_ia5,omitempty"`
-	EExtIanUriRelative                                   *ResultStruct `json:"e_ext_ian_uri_relative,omitempty"`
-	EExtKeyUsageCertSignWithoutCa                        *ResultStruct `json:"e_ext_key_usage_cert_sign_without_ca,omitempty"`
-	WExtKeyUsageNotCritical                              *ResultStruct `json:"w_ext_key_usage_not_critical,omitempty"`
-	EExtKeyUsageWithoutBits                              *ResultStruct `json:"e_ext_key_usage_without_bits,omitempty"`
-	EExtNameConstraintsNotCritical                       *ResultStruct `json:"e_ext_name_constraints_not_critical,omitempty"`
-	EExtNameConstraintsNotInCa                           *ResultStruct `json:"e_ext_name_constraints_not_in_ca,omitempty"`
-	EExtPolicyConstraintsEmpty                           *ResultStruct `json:"e_ext_policy_constraints_empty,omitempty"`
-	EExtPolicyConstraintsNotCritical                     *ResultStruct `json:"e_ext_policy_constraints_not_critical,omitempty"`
-	EExtPolicyMapAnyPolicy                               *ResultStruct `json:"e_ext_policy_map_any_policy,omitempty"`
-	WExtPolicyMapNotCritical                             *ResultStruct `json:"w_ext_policy_map_not_critical,omitempty"`
-	WExtPolicyMapNotInCertPolicy                         *ResultStruct `json:"w_ext_policy_map_not_in_cert_policy,omitempty"`
-	EExtSanContainsReservedIp                            *ResultStruct `json:"e_ext_san_contains_reserved_ip,omitempty"`
-	WExtSanCriticalWithSubjectDn                         *ResultStruct `json:"w_ext_san_critical_with_subject_dn,omitempty"`
-	EExtSanDirectoryNamePresent                          *ResultStruct `json:"e_ext_san_directory_name_present,omitempty"`
-	EExtSanDnsNotIa5String                               *ResultStruct `json:"e_ext_san_dns_not_ia5_string,omitempty"`
-	EExtSanDnsSyntaxIncorrect                            *ResultStruct `json:"e_ext_san_dns_syntax_incorrect,omitempty"`
-	EExtSanDnsnameNotFqdn                                *ResultStruct `json:"e_ext_san_dnsname_not_fqdn,omitempty"`
-	EExtSanEdiPartyNamePresent                           *ResultStruct `json:"e_ext_san_edi_party_name_present,omitempty"`
-	EExtSanEmptyName                                     *ResultStruct `json:"e_ext_san_empty_name,omitempty"`
-	EExtSanMissing                                       *ResultStruct `json:"e_ext_san_missing,omitempty"`
-	EExtSanNoEntries                                     *ResultStruct `json:"e_ext_san_no_entries,omitempty"`
-	EExtSanNotCriticalWithoutSubject                     *ResultStruct `json:"e_ext_san_not_critical_without_subject,omitempty"`
-	EExtSanOtherNamePresent                              *ResultStruct `json:"e_ext_san_other_name_present,omitempty"`
-	EExtSanRegisteredIdPresent                           *ResultStruct `json:"e_ext_san_registered_id_present,omitempty"`
-	EExtSanRfc822FormatInvalid                           *ResultStruct `json:"e_ext_san_rfc822_format_invalid,omitempty"`
-	EExtSanRfc822NamePresent                             *ResultStruct `json:"e_ext_san_rfc822_name_present,omitempty"`
-	EExtSanSpaceDnsName                                  *ResultStruct `json:"e_ext_san_space_dns_name,omitempty"`
-	EExtSanUniformResourceIdentifierPresent              *ResultStruct `json:"e_ext_san_uniform_resource_identifier_present,omitempty"`
-	EExtSanUriFormatInvalid                              *ResultStruct `json:"e_ext_san_uri_format_invalid,omitempty"`
-	EExtSanUriHostNotFqdnOrIp                            *ResultStruct `json:"e_ext_san_uri_host_not_fqdn_or_ip,omitempty"`
-	EExtSanUriNotIa5                                     *ResultStruct `json:"e_ext_san_uri_not_ia5,omitempty"`
-	EExtSanUriRelative                                   *ResultStruct `json:"e_ext_san_uri_relative,omitempty"`
-	EExtSubjectDirectoryAttrCritical                     *ResultStruct `json:"e_ext_subject_directory_attr_critical,omitempty"`
-	EExtSubjectKeyIdentifierCritical                     *ResultStruct `json:"e_ext_subject_key_identifier_critical,omitempty"`
-	EExtSubjectKeyIdentifierMissingCa                    *ResultStruct `json:"e_ext_subject_key_identifier_missing_ca,omitempty"`
-	WExtSubjectKeyIdentifierMissingSubCert               *ResultStruct `json:"w_ext_subject_key_identifier_missing_sub_cert,omitempty"`
-	EGeneralizedTimeDoesNotIncludeSeconds                *ResultStruct `json:"e_generalized_time_does_not_include_seconds,omitempty"`
-	EGeneralizedTimeIncludesFractionSeconds              *ResultStruct `json:"e_generalized_time_includes_fraction_seconds,omitempty"`
-	EGeneralizedTimeNotInZulu                            *ResultStruct `json:"e_generalized_time_not_in_zulu,omitempty"`
-	WGtldUnderConsideration                              *ResultStruct `json:"w_gtld_under_consideration,omitempty"`
-	EIanDnsNameIncludesNullChar                          *ResultStruct `json:"e_ian_dns_name_includes_null_char,omitempty"`
-	EIanDnsNameStartsWithPeriod                          *ResultStruct `json:"e_ian_dns_name_starts_with_period,omitempty"`
-	WIanIanaPubSuffixEmpty                               *ResultStruct `json:"w_ian_iana_pub_suffix_empty,omitempty"`
-	EInhibitAnyPolicyNotCritical                         *ResultStruct `json:"e_inhibit_any_policy_not_critical,omitempty"`
-	EInvalidCertificateVersion                           *ResultStruct `json:"e_invalid_certificate_version,omitempty"`
-	EIssuerFieldEmpty                                    *ResultStruct `json:"e_issuer_field_empty,omitempty"`
-	ENameConstraintEmpty                                 *ResultStruct `json:"e_name_constraint_empty,omitempty"`
-	ENameConstraintMaximumNotAbsent                      *ResultStruct `son:"e_name_constraint_maximum_not_absent,omitempty"`
-	ENameConstraintMinimumNonZero                        *ResultStruct `json:"e_name_constraint_minimum_non_zero,omitempty"`
-	WNameConstraintOnEdiPartyName                        *ResultStruct `json:"w_name_constraint_on_edi_party_name,omitempty"`
-	WNameConstraintOnRegisteredId                        *ResultStruct `json:"w_name_constraint_on_registered_id,omitempty"`
-	WNameConstraintOnX400                                *ResultStruct `json:"w_name_constraint_on_x400,omitempty"`
-	EOldRootCaRsaModLessThan_2048Bits                    *ResultStruct `json:"e_old_root_ca_rsa_mod_less_than_2048_bits,omitempty"`
-	EOldSubCaRsaModLessThan_1024Bits                     *ResultStruct `json:"e_old_sub_ca_rsa_mod_less_than_1024_bits,omitempty"`
-	EOldSubCertRsaModLessThan_1024Bits                   *ResultStruct `json:"e_old_sub_cert_rsa_mod_less_than_1024_bits,omitempty"`
-	EPathLenConstraintImproperlyIncluded                 *ResultStruct `json:"e_path_len_constraint_improperly_included,omitempty"`
-	EPathLenConstraintZeroOrLess                         *ResultStruct `json:"e_path_len_constraint_zero_or_less,omitempty"`
-	EPublicKeyTypeNotAllowed                             *ResultStruct `json:"e_public_key_type_not_allowed,omitempty"`
-	WRootCaBasicConstraintsPathLenConstraintFieldPresent *ResultStruct `json:"w_root_ca_basic_constraints_path_len_constraint_field_present,omitempty"`
-	WRootCaContainsCertPolicy                            *ResultStruct `json:"w_root_ca_contains_cert_policy,omitempty"`
-	ERootCaExtendedKeyUsagePresent                       *ResultStruct `json:"e_root_ca_extended_key_usage_present,omitempty"`
-	ERsaExpNegative                                      *ResultStruct `json:"e_rsa_exp_negative,omitempty"`
-	WRsaModFactorsSmallerThan_752                        *ResultStruct `json:"w_rsa_mod_factors_smaller_than_752,omitempty"`
-	ERsaModLessThan_2048Bits                             *ResultStruct `json:"e_rsa_mod_less_than_2048_bits,omitempty"`
-	WRsaModNotOdd                                        *ResultStruct `json:"w_rsa_mod_not_odd,omitempty"`
-	WRsaPublicExponentNotInRange                         *ResultStruct `json:"w_rsa_public_exponent_not_in_range,omitempty"`
-	ERsaPublicExponentNotOdd                             *ResultStruct `json:"e_rsa_public_exponent_not_odd,omitempty"`
-	ERsaPublicExponentTooSmall                           *ResultStruct `json:"e_rsa_public_exponent_too_small,omitempty"`
-	ESanDnsNameIncludesNullChar                          *ResultStruct `json:"e_san_dns_name_includes_null_char,omitempty"`
-	ESanDnsNameStartsWithPeriod                          *ResultStruct `json:"e_san_dns_name_starts_with_period,omitempty"`
-	WSanIanaPubSuffixEmpty                               *ResultStruct `json:"w_san_iana_pub_suffix_empty,omitempty"`
-	ESerialNumberLongerThan_20Octets                     *ResultStruct `json:"e_serial_number_longer_than_20_octets,omitempty"`
-	ESerialNumberNotPositive                             *ResultStruct `json:"e_serial_number_not_positive,omitempty"`
-	WSubCaAiaDoesNotContainIssuingCaUrl                  *ResultStruct `json:"w_sub_ca_aia_does_not_contain_issuing_ca_url,omitempty"`
-	ESubCaAiaDoesNotContainOcspUrl                       *ResultStruct `json:"e_sub_ca_aia_does_not_contain_ocsp_url,omitempty"`
-	ESubCaAiaMissing                                     *ResultStruct `json:"e_sub_ca_aia_missing,omitempty"`
-	WSubCaCertificatePoliciesMarkedCritical              *ResultStruct `json:"w_sub_ca_certificate_policies_marked_critical,omitempty"`
-	ESubCaCertificatePoliciesMissing                     *ResultStruct `json:"e_sub_ca_certificate_policies_missing,omitempty"`
-	ESubCaCrlDistributionPointsDoesNotContainUrl         *ResultStruct `json:"e_sub_ca_crl_distribution_points_does_not_contain_url,omitempty"`
-	ESubCaCrlDistributionPointsMarkedCritical            *ResultStruct `json:"e_sub_ca_crl_distribution_points_marked_critical,omitempty"`
-	ESubCaCrlDistributionPointsMissing                   *ResultStruct `json:"e_sub_ca_crl_distribution_points_missing,omitempty"`
-	WSubCaEkuCritical                                    *ResultStruct `json:"w_sub_ca_eku_critical,omitempty"`
-	WSubCaNameConstraintsNotCritical                     *ResultStruct `json:"w_sub_ca_name_constraints_not_critical,omitempty"`
-	ESubCaNoDnsNameConstraints                           *ResultStruct `json:"e_sub_ca_no_dns_name_constraints,omitempty"`
-	ESubCaNoIpNameConstraints                            *ResultStruct `json:"e_sub_ca_no_ip_name_constraints,omitempty"`
-	ESubCertAiaDoesNotContainIssuingCaUrl                *ResultStruct `json:"e_sub_cert_aia_does_not_contain_issuing_ca_url,omitempty"`
-	ESubCertAiaDoesNotContainOcspUrl                     *ResultStruct `json:"e_sub_cert_aia_does_not_contain_ocsp_url,omitempty"`
-	ESubCertAiaMissing                                   *ResultStruct `json:"e_sub_cert_aia_missing,omitempty"`
-	ESubCertCertPolicyEmpty                              *ResultStruct `json:"e_sub_cert_cert_policy_empty,omitempty"`
-	WSubCertCertificatePoliciesMarkedCritical            *ResultStruct `json:"w_sub_cert_certificate_policies_marked_critical,omitempty"`
-	ESubCertCrlDistributionPointsDoesNotContainUrl       *ResultStruct `json:"e_sub_cert_crl_distribution_points_does_not_contain_url,omitempty"`
-	ESubCertCrlDistributionPointsMarkedCritical          *ResultStruct `json:"e_sub_cert_crl_distribution_points_marked_critical,omitempty"`
-	WSubCertEkuExtraValues                               *ResultStruct `json:"w_sub_cert_eku_extra_values,omitempty"`
-	ESubCertEkuMissing                                   *ResultStruct `json:"e_sub_cert_eku_missing,omitempty"`
-	ESubCertEkuServerAuthClientAuthMissing               *ResultStruct `json:"e_sub_cert_eku_server_auth_client_auth_missing,omitempty"`
-	ESubCertKeyUsageCertSignBitSet                       *ResultStruct `json:"e_sub_cert_key_usage_cert_sign_bit_set,omitempty"`
-	ESubCertOrSubCaUsingSha1                             *ResultStruct `json:"e_sub_cert_or_sub_ca_using_sha1,omitempty"`
-	WSubCertSha1ExpirationTooLong                        *ResultStruct `json:"w_sub_cert_sha1_expiration_too_long,omitempty"`
-	ESubjectCommonNameDisallowed                         *ResultStruct `json:"e_subject_common_name_disallowed,omitempty"`
-	ISubjectCommonNameIncluded                           *ResultStruct `json:"i_subject_common_name_included,omitempty"`
-	ESubjectCommonNameNotFromSan                         *ResultStruct `json:"e_subject_common_name_not_from_san,omitempty"`
-	ESubjectContainsNoninformationalValue                *ResultStruct `json:"e_subject_contains_noninformational_value,omitempty"`
-	ESubjectContainsReservedIp                           *ResultStruct `json:"e_subject_contains_reserved_ip,omitempty"`
-	ESubjectCountryNotIso                                *ResultStruct `json:"e_subject_country_not_iso,omitempty"`
-	ESubjectEmptyWithoutSan                              *ResultStruct `json:"e_subject_empty_without_san,omitempty"`
-	ESubjectInfoAccessMarkedCritical                     *ResultStruct `json:"e_subject_info_access_marked_critical,omitempty"`
-	ESubjectLocalityWithoutOrg                           *ResultStruct `json:"e_subject_locality_without_org,omitempty"`
-	ESubjectNotDn                                        *ResultStruct `json:"e_subject_not_dn,omitempty"`
-	ESubjectOrgWithoutCountry                            *ResultStruct `json:"e_subject_org_without_country,omitempty"`
-	ESubjectOrgWithoutLocalityOrProvince                 *ResultStruct `json:"e_subject_org_without_locality_or_province,omitempty"`
-	ESubjectPostalWithoutOrg                             *ResultStruct `json:"e_subject_postal_without_org,omitempty"`
-	ESubjectProvinceWithoutOrg                           *ResultStruct `json:"e_subject_province_without_org,omitempty"`
-	ESubjectStreetWithoutOrg                             *ResultStruct `json:"e_subject_street_without_org,omitempty"`
-	EUtcTimeDoesNotIncludeSeconds                        *ResultStruct `json:"e_utc_time_does_not_include_seconds,omitempty"`
-	EUtcTimeNotInZulu                                    *ResultStruct `json:"e_utc_time_not_in_zulu,omitempty"`
-	EValidityTimeNotPositive                             *ResultStruct `json:"e_validity_time_not_positive,omitempty"`
-	EWrongTimeFormatPre2050                              *ResultStruct `json:"e_wrong_time_format_pre2050,omitempty"`
-	ERsaNoPublicKey                                      *ResultStruct `json:"e_rsa_no_public_key,omitempty"`
-	ESubCertCertificatePoliciesMissing                   *ResultStruct `json:"e_sub_cert_certificate_policies_missing,omitempty"`
-	ESubCertKeyUsageCrlSignBitSet                        *ResultStruct `json:"e_sub_cert_key_usage_crl_sign_bit_set,omitempty"`
-}
+type lintReportUpdater func(*LintReport, ResultStruct)
 
 const ZLintVersion = 1
 
 type ZLintResult struct {
 	ZLintVersion int64
 	Timestamp    int64
-	ZLints       *ZLints
+	ZLints       *LintReport
+}
+
+type LintReport struct {
+	EBasicConstraintsNotCritical                         ResultStruct `json:"e_basic_constraints_not_critical,omitempty"`
+	EIanBareWildcard                                     ResultStruct `json:"e_ian_bare_wildcard,omitempty"`
+	EIanWildcardNotFirst                                 ResultStruct `json:"e_ian_wildcard_not_first,omitempty"`
+	ESanBareWildcard                                     ResultStruct `json:"e_san_bare_wildcard,omitempty"`
+	ESanWildcardNotFirst                                 ResultStruct `json:"e_san_wildcard_not_first,omitempty"`
+	ECaCountryNameInvalid                                ResultStruct `json:"e_ca_country_name_invalid,omitempty"`
+	ECaCountryNameMissing                                ResultStruct `json:"e_ca_country_name_missing,omitempty"`
+	ECaCrlSignNotSet                                     ResultStruct `json:"e_ca_crl_sign_not_set,omitempty"`
+	ICaDigitalSignatureNotSet                            ResultStruct `json:"i_ca_digital_signature_not_set,omitempty"`
+	ECaKeyCertSignNotSet                                 ResultStruct `json:"e_ca_key_cert_sign_not_set,omitempty"`
+	ECaKeyUsageMissing                                   ResultStruct `json:"e_ca_key_usage_missing,omitempty"`
+	ECaKeyUsageNotCritical                               ResultStruct `json:"e_ca_key_usage_not_critical,omitempty"`
+	ECaOrganizationNameMissing                           ResultStruct `json:"e_ca_organization_name_missing,omitempty"`
+	ECaSubjectFieldEmpty                                 ResultStruct `json:"e_ca_subject_field_empty,omitempty"`
+	ECertContainsUniqueIdentifier                        ResultStruct `json:"e_cert_contains_unique_identifier,omitempty"`
+	ECertExtensionsVersionNot_3                          ResultStruct `json:"e_cert_extensions_version_not_3,omitempty"`
+	ECabDvConflictsWithLocality                          ResultStruct `json:"e_cab_dv_conflicts_with_locality,omitempty"`
+	ECabDvConflictsWithOrg                               ResultStruct `json:"e_cab_dv_conflicts_with_org,omitempty"`
+	ECabDvConflictsWithPostal                            ResultStruct `json:"e_cab_dv_conflicts_with_postal,omitempty"`
+	ECabDvConflictsWithProvince                          ResultStruct `json:"e_cab_dv_conflicts_with_province,omitempty"`
+	ECabDvConflictsWithStreet                            ResultStruct `json:"e_cab_dv_conflicts_with_street,omitempty"`
+	ECertPolicyIvRequiresCountry                         ResultStruct `json:"e_cert_policy_iv_requires_country,omitempty"`
+	ECertPolicyIvRequiresProvinceOrLocality              ResultStruct `json:"e_cert_policy_iv_requires_province_or_locality,omitempty"`
+	ECertPolicyOvRequiresCountry                         ResultStruct `json:"e_cert_policy_ov_requires_country,omitempty"`
+	ECertPolicyOvRequiresProvinceOrLocality              ResultStruct `json:"e_cert_policy_ov_requires_province_or_locality,omitempty"`
+	ECabOvRequiresOrg                                    ResultStruct `json:"e_cab_ov_requires_org,omitempty"`
+	ECabIvRequiresPersonalName                           ResultStruct `json:"e_cab_iv_requires_personal_name,omitempty"`
+	ECertUniqueIdentifierVersionNot_2Or_3                ResultStruct `json:"e_cert_unique_identifier_version_not_2_or_3,omitempty"`
+	EDhParamsMissing                                     ResultStruct `json:"e_dh_params_missing,omitempty"`
+	EDistributionPointIncomplete                         ResultStruct `json:"e_distribution_point_incomplete,omitempty"`
+	WDistributionPointMissingLdapOrUri                   ResultStruct `json:"w_distribution_point_missing_ldap_or_uri,omitempty"`
+	EDsaImproperModulusOrDivisorSize                     ResultStruct `json:"e_dsa_improper_modulus_or_divisor_size,omitempty"`
+	EDsaShorterThan_2048Bits                             ResultStruct `json:"e_dsa_shorter_than_2048_bits,omitempty"`
+	EEcImproperCurves                                    ResultStruct `json:"e_ec_improper_curves,omitempty"`
+	WEkuCriticalImproperly                               ResultStruct `json:"w_eku_critical_improperly,omitempty"`
+	EEvBusinessCategoryMissing                           ResultStruct `json:"e_ev_business_category_missing,omitempty"`
+	EEvCountryNameMissing                                ResultStruct `json:"e_ev_country_name_missing,omitempty"`
+	EEvLocalityNameMissing                               ResultStruct `json:"e_ev_locality_name_missing,omitempty"`
+	EEvOrganizationNameMissing                           ResultStruct `json:"e_ev_organization_name_missing,omitempty"`
+	EEvSerialNumberMissing                               ResultStruct `json:"e_ev_serial_number_missing,omitempty"`
+	EEvValidTimeTooLong                                  ResultStruct `json:"e_ev_valid_time_too_long,omitempty"`
+	WExtAiaAccessLocationMissing                         ResultStruct `json:"w_ext_aia_access_location_missing,omitempty"`
+	EExtAiaMarkedCritical                                ResultStruct `json:"e_ext_aia_marked_critical,omitempty"`
+	EExtAuthorityKeyIdentifierCritical                   ResultStruct `json:"e_ext_authority_key_identifier_critical,omitempty"`
+	EExtAuthorityKeyIdentifierMissing                    ResultStruct `json:"e_ext_authority_key_identifier_missing,omitempty"`
+	EExtAuthorityKeyIdentifierNoKeyIdentifier            ResultStruct `json:"e_ext_authority_key_identifier_no_key_identifier,omitempty"`
+	WExtCertPolicyContainsNoticeref                      ResultStruct `json:"w_ext_cert_policy_contains_noticeref,omitempty"`
+	EExtCertPolicyDisallowedAnyPolicyQualifier           ResultStruct `json:"e_ext_cert_policy_disallowed_any_policy_qualifier,omitempty"`
+	EExtCertPolicyDuplicate                              ResultStruct `json:"e_ext_cert_policy_duplicate,omitempty"`
+	EExtCertPolicyExplicitTextIa5String                  ResultStruct `json:"e_ext_cert_policy_explicit_text_ia5_string,omitempty"`
+	WExtCertPolicyExplicitTextIncludesControl            ResultStruct `json:"w_ext_cert_policy_explicit_text_includes_control,omitempty"`
+	WExtCertPolicyExplicitTextNotNfc                     ResultStruct `json:"w_ext_cert_policy_explicit_text_not_nfc,omitempty"`
+	WExtCertPolicyExplicitTextNotUtf8                    ResultStruct `json:"w_ext_cert_policy_explicit_text_not_utf8,omitempty"`
+	EExtCertPolicyExplicitTextTooLong                    ResultStruct `json:"e_ext_cert_policy_explicit_text_too_long,omitempty"`
+	WExtCrlDistributionMarkedCritical                    ResultStruct `json:"w_ext_crl_distribution_marked_critical,omitempty"`
+	EExtDuplicateExtension                               ResultStruct `json:"e_ext_duplicate_extension,omitempty"`
+	EExtFreshestCrlMarkedCritical                        ResultStruct `json:"e_ext_freshest_crl_marked_critical,omitempty"`
+	WExtIanCritical                                      ResultStruct `json:"w_ext_ian_critical,omitempty"`
+	EExtIanDnsNotIa5String                               ResultStruct `json:"e_ext_ian_dns_not_ia5_string,omitempty"`
+	EExtIanEmptyName                                     ResultStruct `json:"e_ext_ian_empty_name,omitempty"`
+	EExtIanNoEntries                                     ResultStruct `json:"e_ext_ian_no_entries,omitempty"`
+	EExtIanRfc822FormatInvalid                           ResultStruct `json:"e_ext_ian_rfc822_format_invalid,omitempty"`
+	EExtIanSpaceDnsName                                  ResultStruct `json:"e_ext_ian_space_dns_name,omitempty"`
+	EExtIanUriFormatInvalid                              ResultStruct `json:"e_ext_ian_uri_format_invalid,omitempty"`
+	EExtIanUriHostNotFqdnOrIp                            ResultStruct `json:"e_ext_ian_uri_host_not_fqdn_or_ip,omitempty"`
+	EExtIanUriNotIa5                                     ResultStruct `json:"e_ext_ian_uri_not_ia5,omitempty"`
+	EExtIanUriRelative                                   ResultStruct `json:"e_ext_ian_uri_relative,omitempty"`
+	EExtKeyUsageCertSignWithoutCa                        ResultStruct `json:"e_ext_key_usage_cert_sign_without_ca,omitempty"`
+	WExtKeyUsageNotCritical                              ResultStruct `json:"w_ext_key_usage_not_critical,omitempty"`
+	EExtKeyUsageWithoutBits                              ResultStruct `json:"e_ext_key_usage_without_bits,omitempty"`
+	EExtNameConstraintsNotCritical                       ResultStruct `json:"e_ext_name_constraints_not_critical,omitempty"`
+	EExtNameConstraintsNotInCa                           ResultStruct `json:"e_ext_name_constraints_not_in_ca,omitempty"`
+	EExtPolicyConstraintsEmpty                           ResultStruct `json:"e_ext_policy_constraints_empty,omitempty"`
+	EExtPolicyConstraintsNotCritical                     ResultStruct `json:"e_ext_policy_constraints_not_critical,omitempty"`
+	EExtPolicyMapAnyPolicy                               ResultStruct `json:"e_ext_policy_map_any_policy,omitempty"`
+	WExtPolicyMapNotCritical                             ResultStruct `json:"w_ext_policy_map_not_critical,omitempty"`
+	WExtPolicyMapNotInCertPolicy                         ResultStruct `json:"w_ext_policy_map_not_in_cert_policy,omitempty"`
+	EExtSanContainsReservedIp                            ResultStruct `json:"e_ext_san_contains_reserved_ip,omitempty"`
+	WExtSanCriticalWithSubjectDn                         ResultStruct `json:"w_ext_san_critical_with_subject_dn,omitempty"`
+	EExtSanDirectoryNamePresent                          ResultStruct `json:"e_ext_san_directory_name_present,omitempty"`
+	EExtSanDnsNotIa5String                               ResultStruct `json:"e_ext_san_dns_not_ia5_string,omitempty"`
+	EExtSanDnsSyntaxIncorrect                            ResultStruct `json:"e_ext_san_dns_syntax_incorrect,omitempty"`
+	EExtSanDnsnameNotFqdn                                ResultStruct `json:"e_ext_san_dnsname_not_fqdn,omitempty"`
+	EExtSanEdiPartyNamePresent                           ResultStruct `json:"e_ext_san_edi_party_name_present,omitempty"`
+	EExtSanEmptyName                                     ResultStruct `json:"e_ext_san_empty_name,omitempty"`
+	EExtSanMissing                                       ResultStruct `json:"e_ext_san_missing,omitempty"`
+	EExtSanNoEntries                                     ResultStruct `json:"e_ext_san_no_entries,omitempty"`
+	EExtSanNotCriticalWithoutSubject                     ResultStruct `json:"e_ext_san_not_critical_without_subject,omitempty"`
+	EExtSanOtherNamePresent                              ResultStruct `json:"e_ext_san_other_name_present,omitempty"`
+	EExtSanRegisteredIdPresent                           ResultStruct `json:"e_ext_san_registered_id_present,omitempty"`
+	EExtSanRfc822FormatInvalid                           ResultStruct `json:"e_ext_san_rfc822_format_invalid,omitempty"`
+	EExtSanRfc822NamePresent                             ResultStruct `json:"e_ext_san_rfc822_name_present,omitempty"`
+	EExtSanSpaceDnsName                                  ResultStruct `json:"e_ext_san_space_dns_name,omitempty"`
+	EExtSanUniformResourceIdentifierPresent              ResultStruct `json:"e_ext_san_uniform_resource_identifier_present,omitempty"`
+	EExtSanUriFormatInvalid                              ResultStruct `json:"e_ext_san_uri_format_invalid,omitempty"`
+	EExtSanUriHostNotFqdnOrIp                            ResultStruct `json:"e_ext_san_uri_host_not_fqdn_or_ip,omitempty"`
+	EExtSanUriNotIa5                                     ResultStruct `json:"e_ext_san_uri_not_ia5,omitempty"`
+	EExtSanUriRelative                                   ResultStruct `json:"e_ext_san_uri_relative,omitempty"`
+	EExtSubjectDirectoryAttrCritical                     ResultStruct `json:"e_ext_subject_directory_attr_critical,omitempty"`
+	EExtSubjectKeyIdentifierCritical                     ResultStruct `json:"e_ext_subject_key_identifier_critical,omitempty"`
+	EExtSubjectKeyIdentifierMissingCa                    ResultStruct `json:"e_ext_subject_key_identifier_missing_ca,omitempty"`
+	WExtSubjectKeyIdentifierMissingSubCert               ResultStruct `json:"w_ext_subject_key_identifier_missing_sub_cert,omitempty"`
+	EGeneralizedTimeDoesNotIncludeSeconds                ResultStruct `json:"e_generalized_time_does_not_include_seconds,omitempty"`
+	EGeneralizedTimeIncludesFractionSeconds              ResultStruct `json:"e_generalized_time_includes_fraction_seconds,omitempty"`
+	EGeneralizedTimeNotInZulu                            ResultStruct `json:"e_generalized_time_not_in_zulu,omitempty"`
+	WGtldUnderConsideration                              ResultStruct `json:"w_gtld_under_consideration,omitempty"`
+	EIanDnsNameIncludesNullChar                          ResultStruct `json:"e_ian_dns_name_includes_null_char,omitempty"`
+	EIanDnsNameStartsWithPeriod                          ResultStruct `json:"e_ian_dns_name_starts_with_period,omitempty"`
+	WIanIanaPubSuffixEmpty                               ResultStruct `json:"w_ian_iana_pub_suffix_empty,omitempty"`
+	EInhibitAnyPolicyNotCritical                         ResultStruct `json:"e_inhibit_any_policy_not_critical,omitempty"`
+	EInvalidCertificateVersion                           ResultStruct `json:"e_invalid_certificate_version,omitempty"`
+	EIssuerFieldEmpty                                    ResultStruct `json:"e_issuer_field_empty,omitempty"`
+	ENameConstraintEmpty                                 ResultStruct `json:"e_name_constraint_empty,omitempty"`
+	ENameConstraintMaximumNotAbsent                      ResultStruct `son:"e_name_constraint_maximum_not_absent,omitempty"`
+	ENameConstraintMinimumNonZero                        ResultStruct `json:"e_name_constraint_minimum_non_zero,omitempty"`
+	WNameConstraintOnEdiPartyName                        ResultStruct `json:"w_name_constraint_on_edi_party_name,omitempty"`
+	WNameConstraintOnRegisteredId                        ResultStruct `json:"w_name_constraint_on_registered_id,omitempty"`
+	WNameConstraintOnX400                                ResultStruct `json:"w_name_constraint_on_x400,omitempty"`
+	EOldRootCaRsaModLessThan_2048Bits                    ResultStruct `json:"e_old_root_ca_rsa_mod_less_than_2048_bits,omitempty"`
+	EOldSubCaRsaModLessThan_1024Bits                     ResultStruct `json:"e_old_sub_ca_rsa_mod_less_than_1024_bits,omitempty"`
+	EOldSubCertRsaModLessThan_1024Bits                   ResultStruct `json:"e_old_sub_cert_rsa_mod_less_than_1024_bits,omitempty"`
+	EPathLenConstraintImproperlyIncluded                 ResultStruct `json:"e_path_len_constraint_improperly_included,omitempty"`
+	EPathLenConstraintZeroOrLess                         ResultStruct `json:"e_path_len_constraint_zero_or_less,omitempty"`
+	EPublicKeyTypeNotAllowed                             ResultStruct `json:"e_public_key_type_not_allowed,omitempty"`
+	WRootCaBasicConstraintsPathLenConstraintFieldPresent ResultStruct `json:"w_root_ca_basic_constraints_path_len_constraint_field_present,omitempty"`
+	WRootCaContainsCertPolicy                            ResultStruct `json:"w_root_ca_contains_cert_policy,omitempty"`
+	ERootCaExtendedKeyUsagePresent                       ResultStruct `json:"e_root_ca_extended_key_usage_present,omitempty"`
+	ERsaExpNegative                                      ResultStruct `json:"e_rsa_exp_negative,omitempty"`
+	WRsaModFactorsSmallerThan_752                        ResultStruct `json:"w_rsa_mod_factors_smaller_than_752,omitempty"`
+	ERsaModLessThan_2048Bits                             ResultStruct `json:"e_rsa_mod_less_than_2048_bits,omitempty"`
+	WRsaModNotOdd                                        ResultStruct `json:"w_rsa_mod_not_odd,omitempty"`
+	WRsaPublicExponentNotInRange                         ResultStruct `json:"w_rsa_public_exponent_not_in_range,omitempty"`
+	ERsaPublicExponentNotOdd                             ResultStruct `json:"e_rsa_public_exponent_not_odd,omitempty"`
+	ERsaPublicExponentTooSmall                           ResultStruct `json:"e_rsa_public_exponent_too_small,omitempty"`
+	ESanDnsNameIncludesNullChar                          ResultStruct `json:"e_san_dns_name_includes_null_char,omitempty"`
+	ESanDnsNameStartsWithPeriod                          ResultStruct `json:"e_san_dns_name_starts_with_period,omitempty"`
+	WSanIanaPubSuffixEmpty                               ResultStruct `json:"w_san_iana_pub_suffix_empty,omitempty"`
+	ESerialNumberLongerThan_20Octets                     ResultStruct `json:"e_serial_number_longer_than_20_octets,omitempty"`
+	ESerialNumberNotPositive                             ResultStruct `json:"e_serial_number_not_positive,omitempty"`
+	WSubCaAiaDoesNotContainIssuingCaUrl                  ResultStruct `json:"w_sub_ca_aia_does_not_contain_issuing_ca_url,omitempty"`
+	ESubCaAiaDoesNotContainOcspUrl                       ResultStruct `json:"e_sub_ca_aia_does_not_contain_ocsp_url,omitempty"`
+	ESubCaAiaMissing                                     ResultStruct `json:"e_sub_ca_aia_missing,omitempty"`
+	WSubCaCertificatePoliciesMarkedCritical              ResultStruct `json:"w_sub_ca_certificate_policies_marked_critical,omitempty"`
+	ESubCaCertificatePoliciesMissing                     ResultStruct `json:"e_sub_ca_certificate_policies_missing,omitempty"`
+	ESubCaCrlDistributionPointsDoesNotContainUrl         ResultStruct `json:"e_sub_ca_crl_distribution_points_does_not_contain_url,omitempty"`
+	ESubCaCrlDistributionPointsMarkedCritical            ResultStruct `json:"e_sub_ca_crl_distribution_points_marked_critical,omitempty"`
+	ESubCaCrlDistributionPointsMissing                   ResultStruct `json:"e_sub_ca_crl_distribution_points_missing,omitempty"`
+	WSubCaEkuCritical                                    ResultStruct `json:"w_sub_ca_eku_critical,omitempty"`
+	WSubCaNameConstraintsNotCritical                     ResultStruct `json:"w_sub_ca_name_constraints_not_critical,omitempty"`
+	ESubCaNoDnsNameConstraints                           ResultStruct `json:"e_sub_ca_no_dns_name_constraints,omitempty"`
+	ESubCaNoIpNameConstraints                            ResultStruct `json:"e_sub_ca_no_ip_name_constraints,omitempty"`
+	ESubCertAiaDoesNotContainIssuingCaUrl                ResultStruct `json:"e_sub_cert_aia_does_not_contain_issuing_ca_url,omitempty"`
+	ESubCertAiaDoesNotContainOcspUrl                     ResultStruct `json:"e_sub_cert_aia_does_not_contain_ocsp_url,omitempty"`
+	ESubCertAiaMissing                                   ResultStruct `json:"e_sub_cert_aia_missing,omitempty"`
+	ESubCertCertPolicyEmpty                              ResultStruct `json:"e_sub_cert_cert_policy_empty,omitempty"`
+	WSubCertCertificatePoliciesMarkedCritical            ResultStruct `json:"w_sub_cert_certificate_policies_marked_critical,omitempty"`
+	ESubCertCrlDistributionPointsDoesNotContainUrl       ResultStruct `json:"e_sub_cert_crl_distribution_points_does_not_contain_url,omitempty"`
+	ESubCertCrlDistributionPointsMarkedCritical          ResultStruct `json:"e_sub_cert_crl_distribution_points_marked_critical,omitempty"`
+	WSubCertEkuExtraValues                               ResultStruct `json:"w_sub_cert_eku_extra_values,omitempty"`
+	ESubCertEkuMissing                                   ResultStruct `json:"e_sub_cert_eku_missing,omitempty"`
+	ESubCertEkuServerAuthClientAuthMissing               ResultStruct `json:"e_sub_cert_eku_server_auth_client_auth_missing,omitempty"`
+	ESubCertKeyUsageCertSignBitSet                       ResultStruct `json:"e_sub_cert_key_usage_cert_sign_bit_set,omitempty"`
+	ESubCertOrSubCaUsingSha1                             ResultStruct `json:"e_sub_cert_or_sub_ca_using_sha1,omitempty"`
+	WSubCertSha1ExpirationTooLong                        ResultStruct `json:"w_sub_cert_sha1_expiration_too_long,omitempty"`
+	ESubjectCommonNameDisallowed                         ResultStruct `json:"e_subject_common_name_disallowed,omitempty"`
+	ISubjectCommonNameIncluded                           ResultStruct `json:"i_subject_common_name_included,omitempty"`
+	ESubjectCommonNameNotFromSan                         ResultStruct `json:"e_subject_common_name_not_from_san,omitempty"`
+	ESubjectContainsNoninformationalValue                ResultStruct `json:"e_subject_contains_noninformational_value,omitempty"`
+	ESubjectContainsReservedIp                           ResultStruct `json:"e_subject_contains_reserved_ip,omitempty"`
+	ESubjectCountryNotIso                                ResultStruct `json:"e_subject_country_not_iso,omitempty"`
+	ESubjectEmptyWithoutSan                              ResultStruct `json:"e_subject_empty_without_san,omitempty"`
+	ESubjectInfoAccessMarkedCritical                     ResultStruct `json:"e_subject_info_access_marked_critical,omitempty"`
+	ESubjectLocalityWithoutOrg                           ResultStruct `json:"e_subject_locality_without_org,omitempty"`
+	ESubjectNotDn                                        ResultStruct `json:"e_subject_not_dn,omitempty"`
+	ESubjectOrgWithoutCountry                            ResultStruct `json:"e_subject_org_without_country,omitempty"`
+	ESubjectOrgWithoutLocalityOrProvince                 ResultStruct `json:"e_subject_org_without_locality_or_province,omitempty"`
+	ESubjectPostalWithoutOrg                             ResultStruct `json:"e_subject_postal_without_org,omitempty"`
+	ESubjectProvinceWithoutOrg                           ResultStruct `json:"e_subject_province_without_org,omitempty"`
+	ESubjectStreetWithoutOrg                             ResultStruct `json:"e_subject_street_without_org,omitempty"`
+	EUtcTimeDoesNotIncludeSeconds                        ResultStruct `json:"e_utc_time_does_not_include_seconds,omitempty"`
+	EUtcTimeNotInZulu                                    ResultStruct `json:"e_utc_time_not_in_zulu,omitempty"`
+	EValidityTimeNotPositive                             ResultStruct `json:"e_validity_time_not_positive,omitempty"`
+	EWrongTimeFormatPre2050                              ResultStruct `json:"e_wrong_time_format_pre2050,omitempty"`
+	ERsaNoPublicKey                                      ResultStruct `json:"e_rsa_no_public_key,omitempty"`
+	ESubCertCertificatePoliciesMissing                   ResultStruct `json:"e_sub_cert_certificate_policies_missing,omitempty"`
+	ESubCertKeyUsageCrlSignBitSet                        ResultStruct `json:"e_sub_cert_key_usage_crl_sign_bit_set,omitempty"`
+}
+
+func (report *LintReport) Execute(cert *x509.Certificate) error {
+	for _, l := range Lints {
+		res, err := l.ExecuteTest(cert)
+		if err != nil {
+			return err
+		}
+		l.updateReport(report, res)
+	}
+	return nil
 }
 
 type LintTest interface {
@@ -220,6 +233,7 @@ type Lint struct {
 	Providence    string
 	EffectiveDate time.Time
 	Test          LintTest
+	updateReport  lintReportUpdater
 }
 
 func (l *Lint) ExecuteTest(cert *x509.Certificate) (ResultStruct, error) {
@@ -238,381 +252,4 @@ func RegisterLint(l *Lint) {
 	}
 	l.Test.Initialize()
 	Lints[l.Name] = l
-}
-
-func UpdateLintStruct(lintName string, result *ResultStruct, zlints *ZLints) {
-	switch lintName {
-	case "e_basic_constraints_not_critical":
-		zlints.EBasicConstraintsNotCritical = result
-	case "e_ian_bare_wildcard":
-		zlints.EIanBareWildcard = result
-	case "e_ian_wildcard_not_first":
-		zlints.EIanWildcardNotFirst = result
-	case "e_san_bare_wildcard":
-		zlints.ESanBareWildcard = result
-	case "e_san_wildcard_not_first":
-		zlints.ESanWildcardNotFirst = result
-	case "e_ca_country_name_invalid":
-		zlints.ECaCountryNameInvalid = result
-	case "e_ca_country_name_missing":
-		zlints.ECaCountryNameMissing = result
-	case "e_ca_crl_sign_not_set":
-		zlints.ECaCrlSignNotSet = result
-	case "i_ca_digital_signature_not_set":
-		zlints.ICaDigitalSignatureNotSet = result
-	case "e_ca_key_cert_sign_not_set":
-		zlints.ECaKeyCertSignNotSet = result
-	case "e_ca_key_usage_missing":
-		zlints.ECaKeyUsageMissing = result
-	case "e_ca_key_usage_not_critical":
-		zlints.ECaKeyUsageNotCritical = result
-	case "e_ca_organization_name_missing":
-		zlints.ECaOrganizationNameMissing = result
-	case "e_ca_subject_field_empty":
-		zlints.ECaSubjectFieldEmpty = result
-	case "e_cert_contains_unique_identifier":
-		zlints.ECertContainsUniqueIdentifier = result
-	case "e_cert_extensions_version_not_3":
-		zlints.ECertExtensionsVersionNot_3 = result
-	case "e_cab_dv_conflicts_with_locality":
-		zlints.ECabDvConflictsWithLocality = result
-	case "e_cab_dv_conflicts_with_org":
-		zlints.ECabDvConflictsWithOrg = result
-	case "e_cab_dv_conflicts_with_postal":
-		zlints.ECabDvConflictsWithPostal = result
-	case "e_cab_dv_conflicts_with_province":
-		zlints.ECabDvConflictsWithProvince = result
-	case "e_cab_dv_conflicts_with_street":
-		zlints.ECabDvConflictsWithStreet = result
-	case "e_cert_policy_iv_requires_country":
-		zlints.ECertPolicyIvRequiresCountry = result
-	case "e_cert_policy_iv_requires_province_or_locality":
-		zlints.ECertPolicyIvRequiresProvinceOrLocality = result
-	case "e_cert_policy_ov_requires_country":
-		zlints.ECertPolicyOvRequiresCountry = result
-	case "e_cert_policy_ov_requires_province_or_locality":
-		zlints.ECertPolicyOvRequiresProvinceOrLocality = result
-	case "e_cab_ov_requires_org":
-		zlints.ECabOvRequiresOrg = result
-	case "e_cab_iv_requires_personal_name":
-		zlints.ECabIvRequiresPersonalName = result
-	case "e_cert_unique_identifier_version_not_2_or_3":
-		zlints.ECertUniqueIdentifierVersionNot_2Or_3 = result
-	case "e_dh_params_missing":
-		zlints.EDhParamsMissing = result
-	case "e_distribution_point_incomplete":
-		zlints.EDistributionPointIncomplete = result
-	case "w_distribution_point_missing_ldap_or_uri":
-		zlints.WDistributionPointMissingLdapOrUri = result
-	case "e_dsa_improper_modulus_or_divisor_size":
-		zlints.EDsaImproperModulusOrDivisorSize = result
-	case "e_dsa_shorter_than_2048_bits":
-		zlints.EDsaShorterThan_2048Bits = result
-	case "e_ec_improper_curves":
-		zlints.EEcImproperCurves = result
-	case "w_eku_critical_improperly":
-		zlints.WEkuCriticalImproperly = result
-	case "e_ev_business_category_missing":
-		zlints.EEvBusinessCategoryMissing = result
-	case "e_ev_country_name_missing":
-		zlints.EEvCountryNameMissing = result
-	case "e_ev_locality_name_missing":
-		zlints.EEvLocalityNameMissing = result
-	case "e_ev_organization_name_missing":
-		zlints.EEvOrganizationNameMissing = result
-	case "e_ev_serial_number_missing":
-		zlints.EEvSerialNumberMissing = result
-	case "e_ev_valid_time_too_long":
-		zlints.EEvValidTimeTooLong = result
-	case "w_ext_aia_access_location_missing":
-		zlints.WExtAiaAccessLocationMissing = result
-	case "e_ext_aia_marked_critical":
-		zlints.EExtAiaMarkedCritical = result
-	case "e_ext_authority_key_identifier_critical":
-		zlints.EExtAuthorityKeyIdentifierCritical = result
-	case "e_ext_authority_key_identifier_missing":
-		zlints.EExtAuthorityKeyIdentifierMissing = result
-	case "e_ext_authority_key_identifier_no_key_identifier":
-		zlints.EExtAuthorityKeyIdentifierNoKeyIdentifier = result
-	case "w_ext_cert_policy_contains_noticeref":
-		zlints.WExtCertPolicyContainsNoticeref = result
-	case "e_ext_cert_policy_disallowed_any_policy_qualifier":
-		zlints.EExtCertPolicyDisallowedAnyPolicyQualifier = result
-	case "e_ext_cert_policy_duplicate":
-		zlints.EExtCertPolicyDuplicate = result
-	case "e_ext_cert_policy_explicit_text_ia5_string":
-		zlints.EExtCertPolicyExplicitTextIa5String = result
-	case "w_ext_cert_policy_explicit_text_includes_control":
-		zlints.WExtCertPolicyExplicitTextIncludesControl = result
-	case "w_ext_cert_policy_explicit_text_not_nfc":
-		zlints.WExtCertPolicyExplicitTextNotNfc = result
-	case "w_ext_cert_policy_explicit_text_not_utf8":
-		zlints.WExtCertPolicyExplicitTextNotUtf8 = result
-	case "e_ext_cert_policy_explicit_text_too_long":
-		zlints.EExtCertPolicyExplicitTextTooLong = result
-	case "w_ext_crl_distribution_marked_critical":
-		zlints.WExtCrlDistributionMarkedCritical = result
-	case "e_ext_duplicate_extension":
-		zlints.EExtDuplicateExtension = result
-	case "e_ext_freshest_crl_marked_critical":
-		zlints.EExtFreshestCrlMarkedCritical = result
-	case "w_ext_ian_critical":
-		zlints.WExtIanCritical = result
-	case "e_ext_ian_dns_not_ia5_string":
-		zlints.EExtIanDnsNotIa5String = result
-	case "e_ext_ian_empty_name":
-		zlints.EExtIanEmptyName = result
-	case "e_ext_ian_no_entries":
-		zlints.EExtIanNoEntries = result
-	case "e_ext_ian_rfc822_format_invalid":
-		zlints.EExtIanRfc822FormatInvalid = result
-	case "e_ext_ian_space_dns_name":
-		zlints.EExtIanSpaceDnsName = result
-	case "e_ext_ian_uri_format_invalid":
-		zlints.EExtIanUriFormatInvalid = result
-	case "e_ext_ian_uri_host_not_fqdn_or_ip":
-		zlints.EExtIanUriHostNotFqdnOrIp = result
-	case "e_ext_ian_uri_not_ia5":
-		zlints.EExtIanUriNotIa5 = result
-	case "e_ext_ian_uri_relative":
-		zlints.EExtIanUriRelative = result
-	case "e_ext_key_usage_cert_sign_without_ca":
-		zlints.EExtKeyUsageCertSignWithoutCa = result
-	case "w_ext_key_usage_not_critical":
-		zlints.WExtKeyUsageNotCritical = result
-	case "e_ext_key_usage_without_bits":
-		zlints.EExtKeyUsageWithoutBits = result
-	case "e_ext_name_constraints_not_critical":
-		zlints.EExtNameConstraintsNotCritical = result
-	case "e_ext_name_constraints_not_in_ca":
-		zlints.EExtNameConstraintsNotInCa = result
-	case "e_ext_policy_constraints_empty":
-		zlints.EExtPolicyConstraintsEmpty = result
-	case "e_ext_policy_constraints_not_critical":
-		zlints.EExtPolicyConstraintsNotCritical = result
-	case "e_ext_policy_map_any_policy":
-		zlints.EExtPolicyMapAnyPolicy = result
-	case "w_ext_policy_map_not_critical":
-		zlints.WExtPolicyMapNotCritical = result
-	case "w_ext_policy_map_not_in_cert_policy":
-		zlints.WExtPolicyMapNotInCertPolicy = result
-	case "e_ext_san_contains_reserved_ip":
-		zlints.EExtSanContainsReservedIp = result
-	case "w_ext_san_critical_with_subject_dn":
-		zlints.WExtSanCriticalWithSubjectDn = result
-	case "e_ext_san_directory_name_present":
-		zlints.EExtSanDirectoryNamePresent = result
-	case "e_ext_san_dns_not_ia5_string":
-		zlints.EExtSanDnsNotIa5String = result
-	case "e_ext_san_dns_syntax_incorrect":
-		zlints.EExtSanDnsSyntaxIncorrect = result
-	case "e_ext_san_dnsname_not_fqdn":
-		zlints.EExtSanDnsnameNotFqdn = result
-	case "e_ext_san_edi_party_name_present":
-		zlints.EExtSanEdiPartyNamePresent = result
-	case "e_ext_san_empty_name":
-		zlints.EExtSanEmptyName = result
-	case "e_ext_san_missing":
-		zlints.EExtSanMissing = result
-	case "e_ext_san_no_entries":
-		zlints.EExtSanNoEntries = result
-	case "e_ext_san_not_critical_without_subject":
-		zlints.EExtSanNotCriticalWithoutSubject = result
-	case "e_ext_san_other_name_present":
-		zlints.EExtSanOtherNamePresent = result
-	case "e_ext_san_registered_id_present":
-		zlints.EExtSanRegisteredIdPresent = result
-	case "e_ext_san_rfc822_format_invalid":
-		zlints.EExtSanRfc822FormatInvalid = result
-	case "e_ext_san_rfc822_name_present":
-		zlints.EExtSanRfc822NamePresent = result
-	case "e_ext_san_space_dns_name":
-		zlints.EExtSanSpaceDnsName = result
-	case "e_ext_san_uniform_resource_identifier_present":
-		zlints.EExtSanUniformResourceIdentifierPresent = result
-	case "e_ext_san_uri_format_invalid":
-		zlints.EExtSanUriFormatInvalid = result
-	case "e_ext_san_uri_host_not_fqdn_or_ip":
-		zlints.EExtSanUriHostNotFqdnOrIp = result
-	case "e_ext_san_uri_not_ia5":
-		zlints.EExtSanUriNotIa5 = result
-	case "e_ext_san_uri_relative":
-		zlints.EExtSanUriRelative = result
-	case "e_ext_subject_directory_attr_critical":
-		zlints.EExtSubjectDirectoryAttrCritical = result
-	case "e_ext_subject_key_identifier_critical":
-		zlints.EExtSubjectKeyIdentifierCritical = result
-	case "e_ext_subject_key_identifier_missing_ca":
-		zlints.EExtSubjectKeyIdentifierMissingCa = result
-	case "w_ext_subject_key_identifier_missing_sub_cert":
-		zlints.WExtSubjectKeyIdentifierMissingSubCert = result
-	case "e_generalized_time_does_not_include_seconds":
-		zlints.EGeneralizedTimeDoesNotIncludeSeconds = result
-	case "e_generalized_time_includes_fraction_seconds":
-		zlints.EGeneralizedTimeIncludesFractionSeconds = result
-	case "e_generalized_time_not_in_zulu":
-		zlints.EGeneralizedTimeNotInZulu = result
-	case "w_gtld_under_consideration":
-		zlints.WGtldUnderConsideration = result
-	case "e_ian_dns_name_includes_null_char":
-		zlints.EIanDnsNameIncludesNullChar = result
-	case "e_ian_dns_name_starts_with_period":
-		zlints.EIanDnsNameStartsWithPeriod = result
-	case "w_ian_iana_pub_suffix_empty":
-		zlints.WIanIanaPubSuffixEmpty = result
-	case "e_inhibit_any_policy_not_critical":
-		zlints.EInhibitAnyPolicyNotCritical = result
-	case "e_invalid_certificate_version":
-		zlints.EInvalidCertificateVersion = result
-	case "e_issuer_field_empty":
-		zlints.EIssuerFieldEmpty = result
-	case "e_name_constraint_empty":
-		zlints.ENameConstraintEmpty = result
-	case "e_name_constraint_maximum_not_absent":
-		zlints.ENameConstraintMaximumNotAbsent = result
-	case "e_name_constraint_minimum_non_zero":
-		zlints.ENameConstraintMinimumNonZero = result
-	case "w_name_constraint_on_edi_party_name":
-		zlints.WNameConstraintOnEdiPartyName = result
-	case "w_name_constraint_on_registered_id":
-		zlints.WNameConstraintOnRegisteredId = result
-	case "w_name_constraint_on_x400":
-		zlints.WNameConstraintOnX400 = result
-	case "e_old_root_ca_rsa_mod_less_than_2048_bits":
-		zlints.EOldRootCaRsaModLessThan_2048Bits = result
-	case "e_old_sub_ca_rsa_mod_less_than_1024_bits":
-		zlints.EOldSubCaRsaModLessThan_1024Bits = result
-	case "e_old_sub_cert_rsa_mod_less_than_1024_bits":
-		zlints.EOldSubCertRsaModLessThan_1024Bits = result
-	case "e_path_len_constraint_improperly_included":
-		zlints.EPathLenConstraintImproperlyIncluded = result
-	case "e_path_len_constraint_zero_or_less":
-		zlints.EPathLenConstraintZeroOrLess = result
-	case "e_public_key_type_not_allowed":
-		zlints.EPublicKeyTypeNotAllowed = result
-	case "w_root_ca_basic_constraints_path_len_constraint_field_present":
-		zlints.WRootCaBasicConstraintsPathLenConstraintFieldPresent = result
-	case "w_root_ca_contains_cert_policy":
-		zlints.WRootCaContainsCertPolicy = result
-	case "e_root_ca_extended_key_usage_present":
-		zlints.ERootCaExtendedKeyUsagePresent = result
-	case "e_rsa_exp_negative":
-		zlints.ERsaExpNegative = result
-	case "w_rsa_mod_factors_smaller_than_752":
-		zlints.WRsaModFactorsSmallerThan_752 = result
-	case "e_rsa_mod_less_than_2048_bits":
-		zlints.ERsaModLessThan_2048Bits = result
-	case "w_rsa_mod_not_odd":
-		zlints.WRsaModNotOdd = result
-	case "w_rsa_public_exponent_not_in_range":
-		zlints.WRsaPublicExponentNotInRange = result
-	case "e_rsa_public_exponent_not_odd":
-		zlints.ERsaPublicExponentNotOdd = result
-	case "e_rsa_public_exponent_too_small":
-		zlints.ERsaPublicExponentTooSmall = result
-	case "e_san_dns_name_includes_null_char":
-		zlints.ESanDnsNameIncludesNullChar = result
-	case "e_san_dns_name_starts_with_period":
-		zlints.ESanDnsNameStartsWithPeriod = result
-	case "w_san_iana_pub_suffix_empty":
-		zlints.WSanIanaPubSuffixEmpty = result
-	case "e_serial_number_longer_than_20_octets":
-		zlints.ESerialNumberLongerThan_20Octets = result
-	case "e_serial_number_not_positive":
-		zlints.ESerialNumberNotPositive = result
-	case "w_sub_ca_aia_does_not_contain_issuing_ca_url":
-		zlints.WSubCaAiaDoesNotContainIssuingCaUrl = result
-	case "e_sub_ca_aia_does_not_contain_ocsp_url":
-		zlints.ESubCaAiaDoesNotContainOcspUrl = result
-	case "e_sub_ca_aia_missing":
-		zlints.ESubCaAiaMissing = result
-	case "w_sub_ca_certificate_policies_marked_critical":
-		zlints.WSubCaCertificatePoliciesMarkedCritical = result
-	case "e_sub_ca_certificate_policies_missing":
-		zlints.ESubCaCertificatePoliciesMissing = result
-	case "e_sub_ca_crl_distribution_points_does_not_contain_url":
-		zlints.ESubCaCrlDistributionPointsDoesNotContainUrl = result
-	case "e_sub_ca_crl_distribution_points_marked_critical":
-		zlints.ESubCaCrlDistributionPointsMarkedCritical = result
-	case "e_sub_ca_crl_distribution_points_missing":
-		zlints.ESubCaCrlDistributionPointsMissing = result
-	case "w_sub_ca_eku_critical":
-		zlints.WSubCaEkuCritical = result
-	case "w_sub_ca_name_constraints_not_critical":
-		zlints.WSubCaNameConstraintsNotCritical = result
-	case "e_sub_ca_no_dns_name_constraints":
-		zlints.ESubCaNoDnsNameConstraints = result
-	case "e_sub_ca_no_ip_name_constraints":
-		zlints.ESubCaNoIpNameConstraints = result
-	case "e_sub_cert_aia_does_not_contain_issuing_ca_url":
-		zlints.ESubCertAiaDoesNotContainIssuingCaUrl = result
-	case "e_sub_cert_aia_does_not_contain_ocsp_url":
-		zlints.ESubCertAiaDoesNotContainOcspUrl = result
-	case "e_sub_cert_aia_missing":
-		zlints.ESubCertAiaMissing = result
-	case "e_sub_cert_cert_policy_empty":
-		zlints.ESubCertCertPolicyEmpty = result
-	case "w_sub_cert_certificate_policies_marked_critical":
-		zlints.WSubCertCertificatePoliciesMarkedCritical = result
-	case "e_sub_cert_crl_distribution_points_does_not_contain_url":
-		zlints.ESubCertCrlDistributionPointsDoesNotContainUrl = result
-	case "e_sub_cert_crl_distribution_points_marked_critical":
-		zlints.ESubCertCrlDistributionPointsMarkedCritical = result
-	case "w_sub_cert_eku_extra_values":
-		zlints.WSubCertEkuExtraValues = result
-	case "e_sub_cert_eku_missing":
-		zlints.ESubCertEkuMissing = result
-	case "e_sub_cert_eku_server_auth_client_auth_missing":
-		zlints.ESubCertEkuServerAuthClientAuthMissing = result
-	case "e_sub_cert_key_usage_cert_sign_bit_set":
-		zlints.ESubCertKeyUsageCertSignBitSet = result
-	case "e_sub_cert_or_sub_ca_using_sha1":
-		zlints.ESubCertOrSubCaUsingSha1 = result
-	case "w_sub_cert_sha1_expiration_too_long":
-		zlints.WSubCertSha1ExpirationTooLong = result
-	case "e_subject_common_name_disallowed":
-		zlints.ESubjectCommonNameDisallowed = result
-	case "i_subject_common_name_included":
-		zlints.ISubjectCommonNameIncluded = result
-	case "e_subject_common_name_not_from_san":
-		zlints.ESubjectCommonNameNotFromSan = result
-	case "e_subject_contains_noninformational_value":
-		zlints.ESubjectContainsNoninformationalValue = result
-	case "e_subject_contains_reserved_ip":
-		zlints.ESubjectContainsReservedIp = result
-	case "e_subject_country_not_iso":
-		zlints.ESubjectCountryNotIso = result
-	case "e_subject_empty_without_san":
-		zlints.ESubjectEmptyWithoutSan = result
-	case "e_subject_info_access_marked_critical":
-		zlints.ESubjectInfoAccessMarkedCritical = result
-	case "e_subject_locality_without_org":
-		zlints.ESubjectLocalityWithoutOrg = result
-	case "e_subject_not_dn":
-		zlints.ESubjectNotDn = result
-	case "e_subject_org_without_country":
-		zlints.ESubjectOrgWithoutCountry = result
-	case "e_subject_org_without_locality_or_province":
-		zlints.ESubjectOrgWithoutLocalityOrProvince = result
-	case "e_subject_postal_without_org":
-		zlints.ESubjectPostalWithoutOrg = result
-	case "e_subject_province_without_org":
-		zlints.ESubjectProvinceWithoutOrg = result
-	case "e_subject_street_without_org":
-		zlints.ESubjectStreetWithoutOrg = result
-	case "e_utc_time_does_not_include_seconds":
-		zlints.EUtcTimeDoesNotIncludeSeconds = result
-	case "e_utc_time_not_in_zulu":
-		zlints.EUtcTimeNotInZulu = result
-	case "e_validity_time_not_positive":
-		zlints.EValidityTimeNotPositive = result
-	case "e_wrong_time_format_pre2050":
-		zlints.EWrongTimeFormatPre2050 = result
-	case "e_rsa_no_public_key":
-		zlints.ERsaNoPublicKey = result
-	case "e_sub_cert_certificate_policies_missing":
-		zlints.ESubCertCertificatePoliciesMissing = result
-	case "e_sub_cert_key_usage_crl_sign_bit_set":
-		zlints.ESubCertKeyUsageCrlSignBitSet = result
-	}
 }

--- a/lints/base.go
+++ b/lints/base.go
@@ -10,6 +10,14 @@ var (
 	Lints map[string]*Lint = make(map[string]*Lint)
 )
 
+const ZLintVersion = 1;
+
+type ZLintResult struct {
+	ZLintVersion	int64
+	ZLints		map[string]string
+	Timestamp 	int64
+}
+
 type LintTest interface {
 	// runs once globally
 	Initialize() error

--- a/lints/base.go
+++ b/lints/base.go
@@ -10,12 +10,201 @@ var (
 	Lints map[string]*Lint = make(map[string]*Lint)
 )
 
+type ZLints struct {
+	EBasicConstraintsNotCritical                         *ResultStruct `json:"e_basic_constraints_not_critical,omitempty"`
+	EIanBareWildcard                                     *ResultStruct `json:"e_ian_bare_wildcard,omitempty"`
+	EIanWildcardNotFirst                                 *ResultStruct `json:"e_ian_wildcard_not_first,omitempty"`
+	ESanBareWildcard                                     *ResultStruct `json:"e_san_bare_wildcard,omitempty"`
+	ESanWildcardNotFirst                                 *ResultStruct `json:"e_san_wildcard_not_first,omitempty"`
+	ECaCountryNameInvalid                                *ResultStruct `json:"e_ca_country_name_invalid,omitempty"`
+	ECaCountryNameMissing                                *ResultStruct `json:"e_ca_country_name_missing,omitempty"`
+	ECaCrlSignNotSet                                     *ResultStruct `json:"e_ca_crl_sign_not_set,omitempty"`
+	ICaDigitalSignatureNotSet                            *ResultStruct `json:"i_ca_digital_signature_not_set,omitempty"`
+	ECaKeyCertSignNotSet                                 *ResultStruct `json:"e_ca_key_cert_sign_not_set,omitempty"`
+	ECaKeyUsageMissing                                   *ResultStruct `json:"e_ca_key_usage_missing,omitempty"`
+	ECaKeyUsageNotCritical                               *ResultStruct `json:"e_ca_key_usage_not_critical,omitempty"`
+	ECaOrganizationNameMissing                           *ResultStruct `json:"e_ca_organization_name_missing,omitempty"`
+	ECaSubjectFieldEmpty                                 *ResultStruct `json:"e_ca_subject_field_empty,omitempty"`
+	ECertContainsUniqueIdentifier                        *ResultStruct `json:"e_cert_contains_unique_identifier,omitempty"`
+	ECertExtensionsVersionNot_3                          *ResultStruct `json:"e_cert_extensions_version_not_3,omitempty"`
+	ECabDvConflictsWithLocality                          *ResultStruct `json:"e_cab_dv_conflicts_with_locality,omitempty"`
+	ECabDvConflictsWithOrg                               *ResultStruct `json:"e_cab_dv_conflicts_with_org,omitempty"`
+	ECabDvConflictsWithPostal                            *ResultStruct `json:"e_cab_dv_conflicts_with_postal,omitempty"`
+	ECabDvConflictsWithProvince                          *ResultStruct `json:"e_cab_dv_conflicts_with_province,omitempty"`
+	ECabDvConflictsWithStreet                            *ResultStruct `json:"e_cab_dv_conflicts_with_street,omitempty"`
+	ECertPolicyIvRequiresCountry                         *ResultStruct `json:"e_cert_policy_iv_requires_country,omitempty"`
+	ECertPolicyIvRequiresProvinceOrLocality              *ResultStruct `json:"e_cert_policy_iv_requires_province_or_locality,omitempty"`
+	ECertPolicyOvRequiresCountry                         *ResultStruct `json:"e_cert_policy_ov_requires_country,omitempty"`
+	ECertPolicyOvRequiresProvinceOrLocality              *ResultStruct `json:"e_cert_policy_ov_requires_province_or_locality,omitempty"`
+	ECabOvRequiresOrg                                    *ResultStruct `json:"e_cab_ov_requires_org,omitempty"`
+	ECabIvRequiresPersonalName                           *ResultStruct `json:"e_cab_iv_requires_personal_name,omitempty"`
+	ECertUniqueIdentifierVersionNot_2Or_3                *ResultStruct `json:"e_cert_unique_identifier_version_not_2_or_3,omitempty"`
+	EDhParamsMissing                                     *ResultStruct `json:"e_dh_params_missing,omitempty"`
+	EDistributionPointIncomplete                         *ResultStruct `json:"e_distribution_point_incomplete,omitempty"`
+	WDistributionPointMissingLdapOrUri                   *ResultStruct `json:"w_distribution_point_missing_ldap_or_uri,omitempty"`
+	EDsaImproperModulusOrDivisorSize                     *ResultStruct `json:"e_dsa_improper_modulus_or_divisor_size,omitempty"`
+	EDsaShorterThan_2048Bits                             *ResultStruct `json:"e_dsa_shorter_than_2048_bits,omitempty"`
+	EEcImproperCurves                                    *ResultStruct `json:"e_ec_improper_curves,omitempty"`
+	WEkuCriticalImproperly                               *ResultStruct `json:"w_eku_critical_improperly,omitempty"`
+	EEvBusinessCategoryMissing                           *ResultStruct `json:"e_ev_business_category_missing,omitempty"`
+	EEvCountryNameMissing                                *ResultStruct `json:"e_ev_country_name_missing,omitempty"`
+	EEvLocalityNameMissing                               *ResultStruct `json:"e_ev_locality_name_missing,omitempty"`
+	EEvOrganizationNameMissing                           *ResultStruct `json:"e_ev_organization_name_missing,omitempty"`
+	EEvSerialNumberMissing                               *ResultStruct `json:"e_ev_serial_number_missing,omitempty"`
+	EEvValidTimeTooLong                                  *ResultStruct `json:"e_ev_valid_time_too_long,omitempty"`
+	WExtAiaAccessLocationMissing                         *ResultStruct `json:"w_ext_aia_access_location_missing,omitempty"`
+	EExtAiaMarkedCritical                                *ResultStruct `json:"e_ext_aia_marked_critical,omitempty"`
+	EExtAuthorityKeyIdentifierCritical                   *ResultStruct `json:"e_ext_authority_key_identifier_critical,omitempty"`
+	EExtAuthorityKeyIdentifierMissing                    *ResultStruct `json:"e_ext_authority_key_identifier_missing,omitempty"`
+	EExtAuthorityKeyIdentifierNoKeyIdentifier            *ResultStruct `json:"e_ext_authority_key_identifier_no_key_identifier,omitempty"`
+	WExtCertPolicyContainsNoticeref                      *ResultStruct `json:"w_ext_cert_policy_contains_noticeref,omitempty"`
+	EExtCertPolicyDisallowedAnyPolicyQualifier           *ResultStruct `json:"e_ext_cert_policy_disallowed_any_policy_qualifier,omitempty"`
+	EExtCertPolicyDuplicate                              *ResultStruct `json:"e_ext_cert_policy_duplicate,omitempty"`
+	EExtCertPolicyExplicitTextIa5String                  *ResultStruct `json:"e_ext_cert_policy_explicit_text_ia5_string,omitempty"`
+	WExtCertPolicyExplicitTextIncludesControl            *ResultStruct `json:"w_ext_cert_policy_explicit_text_includes_control,omitempty"`
+	WExtCertPolicyExplicitTextNotNfc                     *ResultStruct `json:"w_ext_cert_policy_explicit_text_not_nfc,omitempty"`
+	WExtCertPolicyExplicitTextNotUtf8                    *ResultStruct `json:"w_ext_cert_policy_explicit_text_not_utf8,omitempty"`
+	EExtCertPolicyExplicitTextTooLong                    *ResultStruct `json:"e_ext_cert_policy_explicit_text_too_long,omitempty"`
+	WExtCrlDistributionMarkedCritical                    *ResultStruct `json:"w_ext_crl_distribution_marked_critical,omitempty"`
+	EExtDuplicateExtension                               *ResultStruct `json:"e_ext_duplicate_extension,omitempty"`
+	EExtFreshestCrlMarkedCritical                        *ResultStruct `json:"e_ext_freshest_crl_marked_critical,omitempty"`
+	WExtIanCritical                                      *ResultStruct `json:"w_ext_ian_critical,omitempty"`
+	EExtIanDnsNotIa5String                               *ResultStruct `json:"e_ext_ian_dns_not_ia5_string,omitempty"`
+	EExtIanEmptyName                                     *ResultStruct `json:"e_ext_ian_empty_name,omitempty"`
+	EExtIanNoEntries                                     *ResultStruct `json:"e_ext_ian_no_entries,omitempty"`
+	EExtIanRfc822FormatInvalid                           *ResultStruct `json:"e_ext_ian_rfc822_format_invalid,omitempty"`
+	EExtIanSpaceDnsName                                  *ResultStruct `json:"e_ext_ian_space_dns_name,omitempty"`
+	EExtIanUriFormatInvalid                              *ResultStruct `json:"e_ext_ian_uri_format_invalid,omitempty"`
+	EExtIanUriHostNotFqdnOrIp                            *ResultStruct `json:"e_ext_ian_uri_host_not_fqdn_or_ip,omitempty"`
+	EExtIanUriNotIa5                                     *ResultStruct `json:"e_ext_ian_uri_not_ia5,omitempty"`
+	EExtIanUriRelative                                   *ResultStruct `json:"e_ext_ian_uri_relative,omitempty"`
+	EExtKeyUsageCertSignWithoutCa                        *ResultStruct `json:"e_ext_key_usage_cert_sign_without_ca,omitempty"`
+	WExtKeyUsageNotCritical                              *ResultStruct `json:"w_ext_key_usage_not_critical,omitempty"`
+	EExtKeyUsageWithoutBits                              *ResultStruct `json:"e_ext_key_usage_without_bits,omitempty"`
+	EExtNameConstraintsNotCritical                       *ResultStruct `json:"e_ext_name_constraints_not_critical,omitempty"`
+	EExtNameConstraintsNotInCa                           *ResultStruct `json:"e_ext_name_constraints_not_in_ca,omitempty"`
+	EExtPolicyConstraintsEmpty                           *ResultStruct `json:"e_ext_policy_constraints_empty,omitempty"`
+	EExtPolicyConstraintsNotCritical                     *ResultStruct `json:"e_ext_policy_constraints_not_critical,omitempty"`
+	EExtPolicyMapAnyPolicy                               *ResultStruct `json:"e_ext_policy_map_any_policy,omitempty"`
+	WExtPolicyMapNotCritical                             *ResultStruct `json:"w_ext_policy_map_not_critical,omitempty"`
+	WExtPolicyMapNotInCertPolicy                         *ResultStruct `json:"w_ext_policy_map_not_in_cert_policy,omitempty"`
+	EExtSanContainsReservedIp                            *ResultStruct `json:"e_ext_san_contains_reserved_ip,omitempty"`
+	WExtSanCriticalWithSubjectDn                         *ResultStruct `json:"w_ext_san_critical_with_subject_dn,omitempty"`
+	EExtSanDirectoryNamePresent                          *ResultStruct `json:"e_ext_san_directory_name_present,omitempty"`
+	EExtSanDnsNotIa5String                               *ResultStruct `json:"e_ext_san_dns_not_ia5_string,omitempty"`
+	EExtSanDnsSyntaxIncorrect                            *ResultStruct `json:"e_ext_san_dns_syntax_incorrect,omitempty"`
+	EExtSanDnsnameNotFqdn                                *ResultStruct `json:"e_ext_san_dnsname_not_fqdn,omitempty"`
+	EExtSanEdiPartyNamePresent                           *ResultStruct `json:"e_ext_san_edi_party_name_present,omitempty"`
+	EExtSanEmptyName                                     *ResultStruct `json:"e_ext_san_empty_name,omitempty"`
+	EExtSanMissing                                       *ResultStruct `json:"e_ext_san_missing,omitempty"`
+	EExtSanNoEntries                                     *ResultStruct `json:"e_ext_san_no_entries,omitempty"`
+	EExtSanNotCriticalWithoutSubject                     *ResultStruct `json:"e_ext_san_not_critical_without_subject,omitempty"`
+	EExtSanOtherNamePresent                              *ResultStruct `json:"e_ext_san_other_name_present,omitempty"`
+	EExtSanRegisteredIdPresent                           *ResultStruct `json:"e_ext_san_registered_id_present,omitempty"`
+	EExtSanRfc822FormatInvalid                           *ResultStruct `json:"e_ext_san_rfc822_format_invalid,omitempty"`
+	EExtSanRfc822NamePresent                             *ResultStruct `json:"e_ext_san_rfc822_name_present,omitempty"`
+	EExtSanSpaceDnsName                                  *ResultStruct `json:"e_ext_san_space_dns_name,omitempty"`
+	EExtSanUniformResourceIdentifierPresent              *ResultStruct `json:"e_ext_san_uniform_resource_identifier_present,omitempty"`
+	EExtSanUriFormatInvalid                              *ResultStruct `json:"e_ext_san_uri_format_invalid,omitempty"`
+	EExtSanUriHostNotFqdnOrIp                            *ResultStruct `json:"e_ext_san_uri_host_not_fqdn_or_ip,omitempty"`
+	EExtSanUriNotIa5                                     *ResultStruct `json:"e_ext_san_uri_not_ia5,omitempty"`
+	EExtSanUriRelative                                   *ResultStruct `json:"e_ext_san_uri_relative,omitempty"`
+	EExtSubjectDirectoryAttrCritical                     *ResultStruct `json:"e_ext_subject_directory_attr_critical,omitempty"`
+	EExtSubjectKeyIdentifierCritical                     *ResultStruct `json:"e_ext_subject_key_identifier_critical,omitempty"`
+	EExtSubjectKeyIdentifierMissingCa                    *ResultStruct `json:"e_ext_subject_key_identifier_missing_ca,omitempty"`
+	WExtSubjectKeyIdentifierMissingSubCert               *ResultStruct `json:"w_ext_subject_key_identifier_missing_sub_cert,omitempty"`
+	EGeneralizedTimeDoesNotIncludeSeconds                *ResultStruct `json:"e_generalized_time_does_not_include_seconds,omitempty"`
+	EGeneralizedTimeIncludesFractionSeconds              *ResultStruct `json:"e_generalized_time_includes_fraction_seconds,omitempty"`
+	EGeneralizedTimeNotInZulu                            *ResultStruct `json:"e_generalized_time_not_in_zulu,omitempty"`
+	WGtldUnderConsideration                              *ResultStruct `json:"w_gtld_under_consideration,omitempty"`
+	EIanDnsNameIncludesNullChar                          *ResultStruct `json:"e_ian_dns_name_includes_null_char,omitempty"`
+	EIanDnsNameStartsWithPeriod                          *ResultStruct `json:"e_ian_dns_name_starts_with_period,omitempty"`
+	WIanIanaPubSuffixEmpty                               *ResultStruct `json:"w_ian_iana_pub_suffix_empty,omitempty"`
+	EInhibitAnyPolicyNotCritical                         *ResultStruct `json:"e_inhibit_any_policy_not_critical,omitempty"`
+	EInvalidCertificateVersion                           *ResultStruct `json:"e_invalid_certificate_version,omitempty"`
+	EIssuerFieldEmpty                                    *ResultStruct `json:"e_issuer_field_empty,omitempty"`
+	ENameConstraintEmpty                                 *ResultStruct `json:"e_name_constraint_empty,omitempty"`
+	ENameConstraintMaximumNotAbsent                      *ResultStruct `son:"e_name_constraint_maximum_not_absent,omitempty"`
+	ENameConstraintMinimumNonZero                        *ResultStruct `json:"e_name_constraint_minimum_non_zero,omitempty"`
+	WNameConstraintOnEdiPartyName                        *ResultStruct `json:"w_name_constraint_on_edi_party_name,omitempty"`
+	WNameConstraintOnRegisteredId                        *ResultStruct `json:"w_name_constraint_on_registered_id,omitempty"`
+	WNameConstraintOnX400                                *ResultStruct `json:"w_name_constraint_on_x400,omitempty"`
+	EOldRootCaRsaModLessThan_2048Bits                    *ResultStruct `json:"e_old_root_ca_rsa_mod_less_than_2048_bits,omitempty"`
+	EOldSubCaRsaModLessThan_1024Bits                     *ResultStruct `json:"e_old_sub_ca_rsa_mod_less_than_1024_bits,omitempty"`
+	EOldSubCertRsaModLessThan_1024Bits                   *ResultStruct `json:"e_old_sub_cert_rsa_mod_less_than_1024_bits,omitempty"`
+	EPathLenConstraintImproperlyIncluded                 *ResultStruct `json:"e_path_len_constraint_improperly_included,omitempty"`
+	EPathLenConstraintZeroOrLess                         *ResultStruct `json:"e_path_len_constraint_zero_or_less,omitempty"`
+	EPublicKeyTypeNotAllowed                             *ResultStruct `json:"e_public_key_type_not_allowed,omitempty"`
+	WRootCaBasicConstraintsPathLenConstraintFieldPresent *ResultStruct `json:"w_root_ca_basic_constraints_path_len_constraint_field_present,omitempty"`
+	WRootCaContainsCertPolicy                            *ResultStruct `json:"w_root_ca_contains_cert_policy,omitempty"`
+	ERootCaExtendedKeyUsagePresent                       *ResultStruct `json:"e_root_ca_extended_key_usage_present,omitempty"`
+	ERsaExpNegative                                      *ResultStruct `json:"e_rsa_exp_negative,omitempty"`
+	WRsaModFactorsSmallerThan_752                        *ResultStruct `json:"w_rsa_mod_factors_smaller_than_752,omitempty"`
+	ERsaModLessThan_2048Bits                             *ResultStruct `json:"e_rsa_mod_less_than_2048_bits,omitempty"`
+	WRsaModNotOdd                                        *ResultStruct `json:"w_rsa_mod_not_odd,omitempty"`
+	WRsaPublicExponentNotInRange                         *ResultStruct `json:"w_rsa_public_exponent_not_in_range,omitempty"`
+	ERsaPublicExponentNotOdd                             *ResultStruct `json:"e_rsa_public_exponent_not_odd,omitempty"`
+	ERsaPublicExponentTooSmall                           *ResultStruct `json:"e_rsa_public_exponent_too_small,omitempty"`
+	ESanDnsNameIncludesNullChar                          *ResultStruct `json:"e_san_dns_name_includes_null_char,omitempty"`
+	ESanDnsNameStartsWithPeriod                          *ResultStruct `json:"e_san_dns_name_starts_with_period,omitempty"`
+	WSanIanaPubSuffixEmpty                               *ResultStruct `json:"w_san_iana_pub_suffix_empty,omitempty"`
+	ESerialNumberLongerThan_20Octets                     *ResultStruct `json:"e_serial_number_longer_than_20_octets,omitempty"`
+	ESerialNumberNotPositive                             *ResultStruct `json:"e_serial_number_not_positive,omitempty"`
+	WSubCaAiaDoesNotContainIssuingCaUrl                  *ResultStruct `json:"w_sub_ca_aia_does_not_contain_issuing_ca_url,omitempty"`
+	ESubCaAiaDoesNotContainOcspUrl                       *ResultStruct `json:"e_sub_ca_aia_does_not_contain_ocsp_url,omitempty"`
+	ESubCaAiaMissing                                     *ResultStruct `json:"e_sub_ca_aia_missing,omitempty"`
+	WSubCaCertificatePoliciesMarkedCritical              *ResultStruct `json:"w_sub_ca_certificate_policies_marked_critical,omitempty"`
+	ESubCaCertificatePoliciesMissing                     *ResultStruct `json:"e_sub_ca_certificate_policies_missing,omitempty"`
+	ESubCaCrlDistributionPointsDoesNotContainUrl         *ResultStruct `json:"e_sub_ca_crl_distribution_points_does_not_contain_url,omitempty"`
+	ESubCaCrlDistributionPointsMarkedCritical            *ResultStruct `json:"e_sub_ca_crl_distribution_points_marked_critical,omitempty"`
+	ESubCaCrlDistributionPointsMissing                   *ResultStruct `json:"e_sub_ca_crl_distribution_points_missing,omitempty"`
+	WSubCaEkuCritical                                    *ResultStruct `json:"w_sub_ca_eku_critical,omitempty"`
+	WSubCaNameConstraintsNotCritical                     *ResultStruct `json:"w_sub_ca_name_constraints_not_critical,omitempty"`
+	ESubCaNoDnsNameConstraints                           *ResultStruct `json:"e_sub_ca_no_dns_name_constraints,omitempty"`
+	ESubCaNoIpNameConstraints                            *ResultStruct `json:"e_sub_ca_no_ip_name_constraints,omitempty"`
+	ESubCertAiaDoesNotContainIssuingCaUrl                *ResultStruct `json:"e_sub_cert_aia_does_not_contain_issuing_ca_url,omitempty"`
+	ESubCertAiaDoesNotContainOcspUrl                     *ResultStruct `json:"e_sub_cert_aia_does_not_contain_ocsp_url,omitempty"`
+	ESubCertAiaMissing                                   *ResultStruct `json:"e_sub_cert_aia_missing,omitempty"`
+	ESubCertCertPolicyEmpty                              *ResultStruct `json:"e_sub_cert_cert_policy_empty,omitempty"`
+	WSubCertCertificatePoliciesMarkedCritical            *ResultStruct `json:"w_sub_cert_certificate_policies_marked_critical,omitempty"`
+	ESubCertCrlDistributionPointsDoesNotContainUrl       *ResultStruct `json:"e_sub_cert_crl_distribution_points_does_not_contain_url,omitempty"`
+	ESubCertCrlDistributionPointsMarkedCritical          *ResultStruct `json:"e_sub_cert_crl_distribution_points_marked_critical,omitempty"`
+	WSubCertEkuExtraValues                               *ResultStruct `json:"w_sub_cert_eku_extra_values,omitempty"`
+	ESubCertEkuMissing                                   *ResultStruct `json:"e_sub_cert_eku_missing,omitempty"`
+	ESubCertEkuServerAuthClientAuthMissing               *ResultStruct `json:"e_sub_cert_eku_server_auth_client_auth_missing,omitempty"`
+	ESubCertKeyUsageCertSignBitSet                       *ResultStruct `json:"e_sub_cert_key_usage_cert_sign_bit_set,omitempty"`
+	ESubCertOrSubCaUsingSha1                             *ResultStruct `json:"e_sub_cert_or_sub_ca_using_sha1,omitempty"`
+	WSubCertSha1ExpirationTooLong                        *ResultStruct `json:"w_sub_cert_sha1_expiration_too_long,omitempty"`
+	ESubjectCommonNameDisallowed                         *ResultStruct `json:"e_subject_common_name_disallowed,omitempty"`
+	ISubjectCommonNameIncluded                           *ResultStruct `json:"i_subject_common_name_included,omitempty"`
+	ESubjectCommonNameNotFromSan                         *ResultStruct `json:"e_subject_common_name_not_from_san,omitempty"`
+	ESubjectContainsNoninformationalValue                *ResultStruct `json:"e_subject_contains_noninformational_value,omitempty"`
+	ESubjectContainsReservedIp                           *ResultStruct `json:"e_subject_contains_reserved_ip,omitempty"`
+	ESubjectCountryNotIso                                *ResultStruct `json:"e_subject_country_not_iso,omitempty"`
+	ESubjectEmptyWithoutSan                              *ResultStruct `json:"e_subject_empty_without_san,omitempty"`
+	ESubjectInfoAccessMarkedCritical                     *ResultStruct `json:"e_subject_info_access_marked_critical,omitempty"`
+	ESubjectLocalityWithoutOrg                           *ResultStruct `json:"e_subject_locality_without_org,omitempty"`
+	ESubjectNotDn                                        *ResultStruct `json:"e_subject_not_dn,omitempty"`
+	ESubjectOrgWithoutCountry                            *ResultStruct `json:"e_subject_org_without_country,omitempty"`
+	ESubjectOrgWithoutLocalityOrProvince                 *ResultStruct `json:"e_subject_org_without_locality_or_province,omitempty"`
+	ESubjectPostalWithoutOrg                             *ResultStruct `json:"e_subject_postal_without_org,omitempty"`
+	ESubjectProvinceWithoutOrg                           *ResultStruct `json:"e_subject_province_without_org,omitempty"`
+	ESubjectStreetWithoutOrg                             *ResultStruct `json:"e_subject_street_without_org,omitempty"`
+	EUtcTimeDoesNotIncludeSeconds                        *ResultStruct `json:"e_utc_time_does_not_include_seconds,omitempty"`
+	EUtcTimeNotInZulu                                    *ResultStruct `json:"e_utc_time_not_in_zulu,omitempty"`
+	EValidityTimeNotPositive                             *ResultStruct `json:"e_validity_time_not_positive,omitempty"`
+	EWrongTimeFormatPre2050                              *ResultStruct `json:"e_wrong_time_format_pre2050,omitempty"`
+	ERsaNoPublicKey                                      *ResultStruct `json:"e_rsa_no_public_key,omitempty"`
+	ESubCertCertificatePoliciesMissing                   *ResultStruct `json:"e_sub_cert_certificate_policies_missing,omitempty"`
+	ESubCertKeyUsageCrlSignBitSet                        *ResultStruct `json:"e_sub_cert_key_usage_crl_sign_bit_set,omitempty"`
+}
+
 const ZLintVersion = 1
 
 type ZLintResult struct {
 	ZLintVersion int64
-	ZLints       map[string]string
 	Timestamp    int64
+	ZLints       *ZLints
 }
 
 type LintTest interface {
@@ -49,4 +238,381 @@ func RegisterLint(l *Lint) {
 	}
 	l.Test.Initialize()
 	Lints[l.Name] = l
+}
+
+func UpdateLintStruct(lintName string, result *ResultStruct, zlints *ZLints) {
+	switch lintName {
+	case "e_basic_constraints_not_critical":
+		zlints.EBasicConstraintsNotCritical = result
+	case "e_ian_bare_wildcard":
+		zlints.EIanBareWildcard = result
+	case "e_ian_wildcard_not_first":
+		zlints.EIanWildcardNotFirst = result
+	case "e_san_bare_wildcard":
+		zlints.ESanBareWildcard = result
+	case "e_san_wildcard_not_first":
+		zlints.ESanWildcardNotFirst = result
+	case "e_ca_country_name_invalid":
+		zlints.ECaCountryNameInvalid = result
+	case "e_ca_country_name_missing":
+		zlints.ECaCountryNameMissing = result
+	case "e_ca_crl_sign_not_set":
+		zlints.ECaCrlSignNotSet = result
+	case "i_ca_digital_signature_not_set":
+		zlints.ICaDigitalSignatureNotSet = result
+	case "e_ca_key_cert_sign_not_set":
+		zlints.ECaKeyCertSignNotSet = result
+	case "e_ca_key_usage_missing":
+		zlints.ECaKeyUsageMissing = result
+	case "e_ca_key_usage_not_critical":
+		zlints.ECaKeyUsageNotCritical = result
+	case "e_ca_organization_name_missing":
+		zlints.ECaOrganizationNameMissing = result
+	case "e_ca_subject_field_empty":
+		zlints.ECaSubjectFieldEmpty = result
+	case "e_cert_contains_unique_identifier":
+		zlints.ECertContainsUniqueIdentifier = result
+	case "e_cert_extensions_version_not_3":
+		zlints.ECertExtensionsVersionNot_3 = result
+	case "e_cab_dv_conflicts_with_locality":
+		zlints.ECabDvConflictsWithLocality = result
+	case "e_cab_dv_conflicts_with_org":
+		zlints.ECabDvConflictsWithOrg = result
+	case "e_cab_dv_conflicts_with_postal":
+		zlints.ECabDvConflictsWithPostal = result
+	case "e_cab_dv_conflicts_with_province":
+		zlints.ECabDvConflictsWithProvince = result
+	case "e_cab_dv_conflicts_with_street":
+		zlints.ECabDvConflictsWithStreet = result
+	case "e_cert_policy_iv_requires_country":
+		zlints.ECertPolicyIvRequiresCountry = result
+	case "e_cert_policy_iv_requires_province_or_locality":
+		zlints.ECertPolicyIvRequiresProvinceOrLocality = result
+	case "e_cert_policy_ov_requires_country":
+		zlints.ECertPolicyOvRequiresCountry = result
+	case "e_cert_policy_ov_requires_province_or_locality":
+		zlints.ECertPolicyOvRequiresProvinceOrLocality = result
+	case "e_cab_ov_requires_org":
+		zlints.ECabOvRequiresOrg = result
+	case "e_cab_iv_requires_personal_name":
+		zlints.ECabIvRequiresPersonalName = result
+	case "e_cert_unique_identifier_version_not_2_or_3":
+		zlints.ECertUniqueIdentifierVersionNot_2Or_3 = result
+	case "e_dh_params_missing":
+		zlints.EDhParamsMissing = result
+	case "e_distribution_point_incomplete":
+		zlints.EDistributionPointIncomplete = result
+	case "w_distribution_point_missing_ldap_or_uri":
+		zlints.WDistributionPointMissingLdapOrUri = result
+	case "e_dsa_improper_modulus_or_divisor_size":
+		zlints.EDsaImproperModulusOrDivisorSize = result
+	case "e_dsa_shorter_than_2048_bits":
+		zlints.EDsaShorterThan_2048Bits = result
+	case "e_ec_improper_curves":
+		zlints.EEcImproperCurves = result
+	case "w_eku_critical_improperly":
+		zlints.WEkuCriticalImproperly = result
+	case "e_ev_business_category_missing":
+		zlints.EEvBusinessCategoryMissing = result
+	case "e_ev_country_name_missing":
+		zlints.EEvCountryNameMissing = result
+	case "e_ev_locality_name_missing":
+		zlints.EEvLocalityNameMissing = result
+	case "e_ev_organization_name_missing":
+		zlints.EEvOrganizationNameMissing = result
+	case "e_ev_serial_number_missing":
+		zlints.EEvSerialNumberMissing = result
+	case "e_ev_valid_time_too_long":
+		zlints.EEvValidTimeTooLong = result
+	case "w_ext_aia_access_location_missing":
+		zlints.WExtAiaAccessLocationMissing = result
+	case "e_ext_aia_marked_critical":
+		zlints.EExtAiaMarkedCritical = result
+	case "e_ext_authority_key_identifier_critical":
+		zlints.EExtAuthorityKeyIdentifierCritical = result
+	case "e_ext_authority_key_identifier_missing":
+		zlints.EExtAuthorityKeyIdentifierMissing = result
+	case "e_ext_authority_key_identifier_no_key_identifier":
+		zlints.EExtAuthorityKeyIdentifierNoKeyIdentifier = result
+	case "w_ext_cert_policy_contains_noticeref":
+		zlints.WExtCertPolicyContainsNoticeref = result
+	case "e_ext_cert_policy_disallowed_any_policy_qualifier":
+		zlints.EExtCertPolicyDisallowedAnyPolicyQualifier = result
+	case "e_ext_cert_policy_duplicate":
+		zlints.EExtCertPolicyDuplicate = result
+	case "e_ext_cert_policy_explicit_text_ia5_string":
+		zlints.EExtCertPolicyExplicitTextIa5String = result
+	case "w_ext_cert_policy_explicit_text_includes_control":
+		zlints.WExtCertPolicyExplicitTextIncludesControl = result
+	case "w_ext_cert_policy_explicit_text_not_nfc":
+		zlints.WExtCertPolicyExplicitTextNotNfc = result
+	case "w_ext_cert_policy_explicit_text_not_utf8":
+		zlints.WExtCertPolicyExplicitTextNotUtf8 = result
+	case "e_ext_cert_policy_explicit_text_too_long":
+		zlints.EExtCertPolicyExplicitTextTooLong = result
+	case "w_ext_crl_distribution_marked_critical":
+		zlints.WExtCrlDistributionMarkedCritical = result
+	case "e_ext_duplicate_extension":
+		zlints.EExtDuplicateExtension = result
+	case "e_ext_freshest_crl_marked_critical":
+		zlints.EExtFreshestCrlMarkedCritical = result
+	case "w_ext_ian_critical":
+		zlints.WExtIanCritical = result
+	case "e_ext_ian_dns_not_ia5_string":
+		zlints.EExtIanDnsNotIa5String = result
+	case "e_ext_ian_empty_name":
+		zlints.EExtIanEmptyName = result
+	case "e_ext_ian_no_entries":
+		zlints.EExtIanNoEntries = result
+	case "e_ext_ian_rfc822_format_invalid":
+		zlints.EExtIanRfc822FormatInvalid = result
+	case "e_ext_ian_space_dns_name":
+		zlints.EExtIanSpaceDnsName = result
+	case "e_ext_ian_uri_format_invalid":
+		zlints.EExtIanUriFormatInvalid = result
+	case "e_ext_ian_uri_host_not_fqdn_or_ip":
+		zlints.EExtIanUriHostNotFqdnOrIp = result
+	case "e_ext_ian_uri_not_ia5":
+		zlints.EExtIanUriNotIa5 = result
+	case "e_ext_ian_uri_relative":
+		zlints.EExtIanUriRelative = result
+	case "e_ext_key_usage_cert_sign_without_ca":
+		zlints.EExtKeyUsageCertSignWithoutCa = result
+	case "w_ext_key_usage_not_critical":
+		zlints.WExtKeyUsageNotCritical = result
+	case "e_ext_key_usage_without_bits":
+		zlints.EExtKeyUsageWithoutBits = result
+	case "e_ext_name_constraints_not_critical":
+		zlints.EExtNameConstraintsNotCritical = result
+	case "e_ext_name_constraints_not_in_ca":
+		zlints.EExtNameConstraintsNotInCa = result
+	case "e_ext_policy_constraints_empty":
+		zlints.EExtPolicyConstraintsEmpty = result
+	case "e_ext_policy_constraints_not_critical":
+		zlints.EExtPolicyConstraintsNotCritical = result
+	case "e_ext_policy_map_any_policy":
+		zlints.EExtPolicyMapAnyPolicy = result
+	case "w_ext_policy_map_not_critical":
+		zlints.WExtPolicyMapNotCritical = result
+	case "w_ext_policy_map_not_in_cert_policy":
+		zlints.WExtPolicyMapNotInCertPolicy = result
+	case "e_ext_san_contains_reserved_ip":
+		zlints.EExtSanContainsReservedIp = result
+	case "w_ext_san_critical_with_subject_dn":
+		zlints.WExtSanCriticalWithSubjectDn = result
+	case "e_ext_san_directory_name_present":
+		zlints.EExtSanDirectoryNamePresent = result
+	case "e_ext_san_dns_not_ia5_string":
+		zlints.EExtSanDnsNotIa5String = result
+	case "e_ext_san_dns_syntax_incorrect":
+		zlints.EExtSanDnsSyntaxIncorrect = result
+	case "e_ext_san_dnsname_not_fqdn":
+		zlints.EExtSanDnsnameNotFqdn = result
+	case "e_ext_san_edi_party_name_present":
+		zlints.EExtSanEdiPartyNamePresent = result
+	case "e_ext_san_empty_name":
+		zlints.EExtSanEmptyName = result
+	case "e_ext_san_missing":
+		zlints.EExtSanMissing = result
+	case "e_ext_san_no_entries":
+		zlints.EExtSanNoEntries = result
+	case "e_ext_san_not_critical_without_subject":
+		zlints.EExtSanNotCriticalWithoutSubject = result
+	case "e_ext_san_other_name_present":
+		zlints.EExtSanOtherNamePresent = result
+	case "e_ext_san_registered_id_present":
+		zlints.EExtSanRegisteredIdPresent = result
+	case "e_ext_san_rfc822_format_invalid":
+		zlints.EExtSanRfc822FormatInvalid = result
+	case "e_ext_san_rfc822_name_present":
+		zlints.EExtSanRfc822NamePresent = result
+	case "e_ext_san_space_dns_name":
+		zlints.EExtSanSpaceDnsName = result
+	case "e_ext_san_uniform_resource_identifier_present":
+		zlints.EExtSanUniformResourceIdentifierPresent = result
+	case "e_ext_san_uri_format_invalid":
+		zlints.EExtSanUriFormatInvalid = result
+	case "e_ext_san_uri_host_not_fqdn_or_ip":
+		zlints.EExtSanUriHostNotFqdnOrIp = result
+	case "e_ext_san_uri_not_ia5":
+		zlints.EExtSanUriNotIa5 = result
+	case "e_ext_san_uri_relative":
+		zlints.EExtSanUriRelative = result
+	case "e_ext_subject_directory_attr_critical":
+		zlints.EExtSubjectDirectoryAttrCritical = result
+	case "e_ext_subject_key_identifier_critical":
+		zlints.EExtSubjectKeyIdentifierCritical = result
+	case "e_ext_subject_key_identifier_missing_ca":
+		zlints.EExtSubjectKeyIdentifierMissingCa = result
+	case "w_ext_subject_key_identifier_missing_sub_cert":
+		zlints.WExtSubjectKeyIdentifierMissingSubCert = result
+	case "e_generalized_time_does_not_include_seconds":
+		zlints.EGeneralizedTimeDoesNotIncludeSeconds = result
+	case "e_generalized_time_includes_fraction_seconds":
+		zlints.EGeneralizedTimeIncludesFractionSeconds = result
+	case "e_generalized_time_not_in_zulu":
+		zlints.EGeneralizedTimeNotInZulu = result
+	case "w_gtld_under_consideration":
+		zlints.WGtldUnderConsideration = result
+	case "e_ian_dns_name_includes_null_char":
+		zlints.EIanDnsNameIncludesNullChar = result
+	case "e_ian_dns_name_starts_with_period":
+		zlints.EIanDnsNameStartsWithPeriod = result
+	case "w_ian_iana_pub_suffix_empty":
+		zlints.WIanIanaPubSuffixEmpty = result
+	case "e_inhibit_any_policy_not_critical":
+		zlints.EInhibitAnyPolicyNotCritical = result
+	case "e_invalid_certificate_version":
+		zlints.EInvalidCertificateVersion = result
+	case "e_issuer_field_empty":
+		zlints.EIssuerFieldEmpty = result
+	case "e_name_constraint_empty":
+		zlints.ENameConstraintEmpty = result
+	case "e_name_constraint_maximum_not_absent":
+		zlints.ENameConstraintMaximumNotAbsent = result
+	case "e_name_constraint_minimum_non_zero":
+		zlints.ENameConstraintMinimumNonZero = result
+	case "w_name_constraint_on_edi_party_name":
+		zlints.WNameConstraintOnEdiPartyName = result
+	case "w_name_constraint_on_registered_id":
+		zlints.WNameConstraintOnRegisteredId = result
+	case "w_name_constraint_on_x400":
+		zlints.WNameConstraintOnX400 = result
+	case "e_old_root_ca_rsa_mod_less_than_2048_bits":
+		zlints.EOldRootCaRsaModLessThan_2048Bits = result
+	case "e_old_sub_ca_rsa_mod_less_than_1024_bits":
+		zlints.EOldSubCaRsaModLessThan_1024Bits = result
+	case "e_old_sub_cert_rsa_mod_less_than_1024_bits":
+		zlints.EOldSubCertRsaModLessThan_1024Bits = result
+	case "e_path_len_constraint_improperly_included":
+		zlints.EPathLenConstraintImproperlyIncluded = result
+	case "e_path_len_constraint_zero_or_less":
+		zlints.EPathLenConstraintZeroOrLess = result
+	case "e_public_key_type_not_allowed":
+		zlints.EPublicKeyTypeNotAllowed = result
+	case "w_root_ca_basic_constraints_path_len_constraint_field_present":
+		zlints.WRootCaBasicConstraintsPathLenConstraintFieldPresent = result
+	case "w_root_ca_contains_cert_policy":
+		zlints.WRootCaContainsCertPolicy = result
+	case "e_root_ca_extended_key_usage_present":
+		zlints.ERootCaExtendedKeyUsagePresent = result
+	case "e_rsa_exp_negative":
+		zlints.ERsaExpNegative = result
+	case "w_rsa_mod_factors_smaller_than_752":
+		zlints.WRsaModFactorsSmallerThan_752 = result
+	case "e_rsa_mod_less_than_2048_bits":
+		zlints.ERsaModLessThan_2048Bits = result
+	case "w_rsa_mod_not_odd":
+		zlints.WRsaModNotOdd = result
+	case "w_rsa_public_exponent_not_in_range":
+		zlints.WRsaPublicExponentNotInRange = result
+	case "e_rsa_public_exponent_not_odd":
+		zlints.ERsaPublicExponentNotOdd = result
+	case "e_rsa_public_exponent_too_small":
+		zlints.ERsaPublicExponentTooSmall = result
+	case "e_san_dns_name_includes_null_char":
+		zlints.ESanDnsNameIncludesNullChar = result
+	case "e_san_dns_name_starts_with_period":
+		zlints.ESanDnsNameStartsWithPeriod = result
+	case "w_san_iana_pub_suffix_empty":
+		zlints.WSanIanaPubSuffixEmpty = result
+	case "e_serial_number_longer_than_20_octets":
+		zlints.ESerialNumberLongerThan_20Octets = result
+	case "e_serial_number_not_positive":
+		zlints.ESerialNumberNotPositive = result
+	case "w_sub_ca_aia_does_not_contain_issuing_ca_url":
+		zlints.WSubCaAiaDoesNotContainIssuingCaUrl = result
+	case "e_sub_ca_aia_does_not_contain_ocsp_url":
+		zlints.ESubCaAiaDoesNotContainOcspUrl = result
+	case "e_sub_ca_aia_missing":
+		zlints.ESubCaAiaMissing = result
+	case "w_sub_ca_certificate_policies_marked_critical":
+		zlints.WSubCaCertificatePoliciesMarkedCritical = result
+	case "e_sub_ca_certificate_policies_missing":
+		zlints.ESubCaCertificatePoliciesMissing = result
+	case "e_sub_ca_crl_distribution_points_does_not_contain_url":
+		zlints.ESubCaCrlDistributionPointsDoesNotContainUrl = result
+	case "e_sub_ca_crl_distribution_points_marked_critical":
+		zlints.ESubCaCrlDistributionPointsMarkedCritical = result
+	case "e_sub_ca_crl_distribution_points_missing":
+		zlints.ESubCaCrlDistributionPointsMissing = result
+	case "w_sub_ca_eku_critical":
+		zlints.WSubCaEkuCritical = result
+	case "w_sub_ca_name_constraints_not_critical":
+		zlints.WSubCaNameConstraintsNotCritical = result
+	case "e_sub_ca_no_dns_name_constraints":
+		zlints.ESubCaNoDnsNameConstraints = result
+	case "e_sub_ca_no_ip_name_constraints":
+		zlints.ESubCaNoIpNameConstraints = result
+	case "e_sub_cert_aia_does_not_contain_issuing_ca_url":
+		zlints.ESubCertAiaDoesNotContainIssuingCaUrl = result
+	case "e_sub_cert_aia_does_not_contain_ocsp_url":
+		zlints.ESubCertAiaDoesNotContainOcspUrl = result
+	case "e_sub_cert_aia_missing":
+		zlints.ESubCertAiaMissing = result
+	case "e_sub_cert_cert_policy_empty":
+		zlints.ESubCertCertPolicyEmpty = result
+	case "w_sub_cert_certificate_policies_marked_critical":
+		zlints.WSubCertCertificatePoliciesMarkedCritical = result
+	case "e_sub_cert_crl_distribution_points_does_not_contain_url":
+		zlints.ESubCertCrlDistributionPointsDoesNotContainUrl = result
+	case "e_sub_cert_crl_distribution_points_marked_critical":
+		zlints.ESubCertCrlDistributionPointsMarkedCritical = result
+	case "w_sub_cert_eku_extra_values":
+		zlints.WSubCertEkuExtraValues = result
+	case "e_sub_cert_eku_missing":
+		zlints.ESubCertEkuMissing = result
+	case "e_sub_cert_eku_server_auth_client_auth_missing":
+		zlints.ESubCertEkuServerAuthClientAuthMissing = result
+	case "e_sub_cert_key_usage_cert_sign_bit_set":
+		zlints.ESubCertKeyUsageCertSignBitSet = result
+	case "e_sub_cert_or_sub_ca_using_sha1":
+		zlints.ESubCertOrSubCaUsingSha1 = result
+	case "w_sub_cert_sha1_expiration_too_long":
+		zlints.WSubCertSha1ExpirationTooLong = result
+	case "e_subject_common_name_disallowed":
+		zlints.ESubjectCommonNameDisallowed = result
+	case "i_subject_common_name_included":
+		zlints.ISubjectCommonNameIncluded = result
+	case "e_subject_common_name_not_from_san":
+		zlints.ESubjectCommonNameNotFromSan = result
+	case "e_subject_contains_noninformational_value":
+		zlints.ESubjectContainsNoninformationalValue = result
+	case "e_subject_contains_reserved_ip":
+		zlints.ESubjectContainsReservedIp = result
+	case "e_subject_country_not_iso":
+		zlints.ESubjectCountryNotIso = result
+	case "e_subject_empty_without_san":
+		zlints.ESubjectEmptyWithoutSan = result
+	case "e_subject_info_access_marked_critical":
+		zlints.ESubjectInfoAccessMarkedCritical = result
+	case "e_subject_locality_without_org":
+		zlints.ESubjectLocalityWithoutOrg = result
+	case "e_subject_not_dn":
+		zlints.ESubjectNotDn = result
+	case "e_subject_org_without_country":
+		zlints.ESubjectOrgWithoutCountry = result
+	case "e_subject_org_without_locality_or_province":
+		zlints.ESubjectOrgWithoutLocalityOrProvince = result
+	case "e_subject_postal_without_org":
+		zlints.ESubjectPostalWithoutOrg = result
+	case "e_subject_province_without_org":
+		zlints.ESubjectProvinceWithoutOrg = result
+	case "e_subject_street_without_org":
+		zlints.ESubjectStreetWithoutOrg = result
+	case "e_utc_time_does_not_include_seconds":
+		zlints.EUtcTimeDoesNotIncludeSeconds = result
+	case "e_utc_time_not_in_zulu":
+		zlints.EUtcTimeNotInZulu = result
+	case "e_validity_time_not_positive":
+		zlints.EValidityTimeNotPositive = result
+	case "e_wrong_time_format_pre2050":
+		zlints.EWrongTimeFormatPre2050 = result
+	case "e_rsa_no_public_key":
+		zlints.ERsaNoPublicKey = result
+	case "e_sub_cert_certificate_policies_missing":
+		zlints.ESubCertCertificatePoliciesMissing = result
+	case "e_sub_cert_key_usage_crl_sign_bit_set":
+		zlints.ESubCertKeyUsageCrlSignBitSet = result
+	}
 }

--- a/lints/lint_basic_constraints_not_critical.go
+++ b/lints/lint_basic_constraints_not_critical.go
@@ -51,5 +51,7 @@ func init() {
 		Description:   "Conforming CAs must mark Basic Constraints as critical when it is included in CA certs",
 		Providence:    "RFC 5280: 4.2.1.9",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &basicConstCrit{}})
+		Test:          &basicConstCrit{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EBasicConstraintsNotCritical = result },
+	})
 }

--- a/lints/lint_ca_country_name_invalid.go
+++ b/lints/lint_ca_country_name_invalid.go
@@ -45,5 +45,7 @@ func init() {
 		Description:   "Root & Subordinate CA certificates must have a two-letter country code that is in ISO 3166-1",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &caCountryNameInvalid{}})
+		Test:          &caCountryNameInvalid{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaCountryNameInvalid = result },
+	})
 }

--- a/lints/lint_ca_country_name_missing.go
+++ b/lints/lint_ca_country_name_missing.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "Root & Subordinate CA certificates must have a countryName present in subject information",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &caCountryNameMissing{}})
+		Test:          &caCountryNameMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaCountryNameMissing = result },
+	})
 }

--- a/lints/lint_ca_crl_sign_not_set.go
+++ b/lints/lint_ca_crl_sign_not_set.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "Root & Subordinate CA certificate keyUsage extension's crlSign bit must be set",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &caCRLSignNotSet{}})
+		Test:          &caCRLSignNotSet{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaCrlSignNotSet = result },
+	})
 }

--- a/lints/lint_ca_digital_signature_not_set.go
+++ b/lints/lint_ca_digital_signature_not_set.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "Root & Subordinate CA Certificates that wish to use their private key for signing OCSP responses will not be able to with out digital signature set",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &caDigSignNotSet{}})
+		Test:          &caDigSignNotSet{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ICaDigitalSignatureNotSet = result },
+	})
 }

--- a/lints/lint_ca_key_cert_sign_not_set.go
+++ b/lints/lint_ca_key_cert_sign_not_set.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "Root & Subordinate CA certificate keyUsage extension's keyCertSign bit must be set",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &caKeyCertSignNotSet{}})
+		Test:          &caKeyCertSignNotSet{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaKeyCertSignNotSet = result },
+	})
 }

--- a/lints/lint_ca_key_usage_missing.go
+++ b/lints/lint_ca_key_usage_missing.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "Root & Subordinate CA certificate keyUsage extension must be present",
 		Providence:    "CAB: 7.1.2.1, RFC 5280: 4.2.1.3",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &caKeyUsageMissing{}})
+		Test:          &caKeyUsageMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaKeyUsageMissing = result },
+	})
 }

--- a/lints/lint_ca_key_usage_not_critical.go
+++ b/lints/lint_ca_key_usage_not_critical.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "Root & Subordinate CA certificate keyUsage extension must be marked as critical",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &caKeyUsageNotCrit{}})
+		Test:          &caKeyUsageNotCrit{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaKeyUsageNotCritical = result },
+	})
 }

--- a/lints/lint_ca_organization_name_missing.go
+++ b/lints/lint_ca_organization_name_missing.go
@@ -38,5 +38,7 @@ func init() {
 		Description:   "Root & Subordinate CA certificates must have a organizationName present in subject information",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &caOrganizationNameMissing{}})
+		Test:          &caOrganizationNameMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaOrganizationNameMissing = result },
+	})
 }

--- a/lints/lint_ca_subject_field_empty.go
+++ b/lints/lint_ca_subject_field_empty.go
@@ -45,5 +45,7 @@ func init() {
 		Description:   "CA Certificates subject field must not be empty and must have a non-empty distingushed name",
 		Providence:    "RFC 5280: 4.1.2.6",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &caSubjectEmpty{}})
+		Test:          &caSubjectEmpty{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaSubjectFieldEmpty = result },
+	})
 }

--- a/lints/lint_cab_dv_conflicts_with_locality.go
+++ b/lints/lint_cab_dv_conflicts_with_locality.go
@@ -37,5 +37,7 @@ func init() {
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, locality name must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &certPolicyConflictsWithLocality{}})
+		Test:          &certPolicyConflictsWithLocality{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabDvConflictsWithLocality = result },
+	})
 }

--- a/lints/lint_cab_dv_conflicts_with_org.go
+++ b/lints/lint_cab_dv_conflicts_with_org.go
@@ -37,5 +37,7 @@ func init() {
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, organization name must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &certPolicyConflictsWithOrg{}})
+		Test:          &certPolicyConflictsWithOrg{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabDvConflictsWithOrg = result },
+	})
 }

--- a/lints/lint_cab_dv_conflicts_with_postal.go
+++ b/lints/lint_cab_dv_conflicts_with_postal.go
@@ -37,5 +37,7 @@ func init() {
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, postalCode must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &certPolicyConflictsWithPostal{}})
+		Test:          &certPolicyConflictsWithPostal{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabDvConflictsWithPostal = result },
+	})
 }

--- a/lints/lint_cab_dv_conflicts_with_province.go
+++ b/lints/lint_cab_dv_conflicts_with_province.go
@@ -37,5 +37,7 @@ func init() {
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, stateOrProvinceName must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &certPolicyConflictsWithProvince{}})
+		Test:          &certPolicyConflictsWithProvince{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabDvConflictsWithProvince = result },
+	})
 }

--- a/lints/lint_cab_dv_conflicts_with_street.go
+++ b/lints/lint_cab_dv_conflicts_with_street.go
@@ -37,5 +37,7 @@ func init() {
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, streetAddress must not be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &certPolicyConflictsWithStreet{}})
+		Test:          &certPolicyConflictsWithStreet{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabDvConflictsWithStreet = result },
+	})
 }

--- a/lints/lint_cab_iv_requires_personal_name.go
+++ b/lints/lint_cab_iv_requires_personal_name.go
@@ -36,5 +36,7 @@ func init() {
 		Description:   "If certificate policy 2.23.140.1.2.3 is included, either organizationName or givenName and surname must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,
-		Test:          &CertPolicyRequiresPersonalName{}})
+		Test:          &CertPolicyRequiresPersonalName{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabIvRequiresPersonalName = result },
+	})
 }

--- a/lints/lint_cab_ov_requires_org.go
+++ b/lints/lint_cab_ov_requires_org.go
@@ -36,5 +36,7 @@ func init() {
 		Description:   "If certificate policy 2.23.140.1.2.2 is included, organizationName must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &CertPolicyRequiresOrg{}})
+		Test:          &CertPolicyRequiresOrg{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabOvRequiresOrg = result },
+	})
 }

--- a/lints/lint_cert_contains_unique_identifier.go
+++ b/lints/lint_cert_contains_unique_identifier.go
@@ -44,5 +44,7 @@ func init() {
 		Description:   "CAs must not generate certificate with unique identifiers.",
 		Providence:    "RFC 5280: 4.1.2.8",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &CertContainsUniqueIdentifier{}})
+		Test:          &CertContainsUniqueIdentifier{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECertContainsUniqueIdentifier = result },
+	})
 }

--- a/lints/lint_cert_extensions_version_not_3.go
+++ b/lints/lint_cert_extensions_version_not_3.go
@@ -50,5 +50,7 @@ func init() {
 		Description:   "The extensions field must only appear in version 3 certificates.",
 		Providence:    "RFC 5280: 4.1.2.9",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &CertExtensionsVersonNot3{}})
+		Test:          &CertExtensionsVersonNot3{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECertExtensionsVersionNot_3 = result },
+	})
 }

--- a/lints/lint_cert_policy_iv_requires_country.go
+++ b/lints/lint_cert_policy_iv_requires_country.go
@@ -36,5 +36,7 @@ func init() {
 		Description:   "If certificate policy 2.23.140.1.2.3 is included, countryName must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,
-		Test:          &CertPolicyIVRequiresCountry{}})
+		Test:          &CertPolicyIVRequiresCountry{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECertPolicyIvRequiresCountry = result },
+	})
 }

--- a/lints/lint_cert_policy_iv_requires_province_or_locality.go
+++ b/lints/lint_cert_policy_iv_requires_province_or_locality.go
@@ -36,5 +36,9 @@ func init() {
 		Description:   "If certificate policy 2.23.140.1.2.3 is included, localityName or stateOrProvinceName must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,
-		Test:          &CertPolicyIVRequiresProvinceOrLocal{}})
+		Test:          &CertPolicyIVRequiresProvinceOrLocal{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.ECertPolicyIvRequiresProvinceOrLocality = result
+		},
+	})
 }

--- a/lints/lint_cert_policy_ov_requires_country.go
+++ b/lints/lint_cert_policy_ov_requires_country.go
@@ -36,5 +36,7 @@ func init() {
 		Description:   "If certificate policy 2.23.140.1.2.2 is included, countryName must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &CertPolicyOVRequiresCountry{}})
+		Test:          &CertPolicyOVRequiresCountry{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECertPolicyOvRequiresCountry = result },
+	})
 }

--- a/lints/lint_cert_policy_ov_requires_province_or_locality.go
+++ b/lints/lint_cert_policy_ov_requires_province_or_locality.go
@@ -36,5 +36,9 @@ func init() {
 		Description:   "If certificate policy 2.23.140.1.2.2 is included, localityName or stateOrProvinceName must be included in subject.",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &CertPolicyOVRequiresProvinceOrLocal{}})
+		Test:          &CertPolicyOVRequiresProvinceOrLocal{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.ECertPolicyOvRequiresProvinceOrLocality = result
+		},
+	})
 }

--- a/lints/lint_cert_unique_identifier_version_not_2_or_3.go
+++ b/lints/lint_cert_unique_identifier_version_not_2_or_3.go
@@ -46,5 +46,7 @@ func init() {
 		Description:   "Unique identifiers must only appear if the version is 2 or 3.",
 		Providence:    "RFC 5280: 4.1.2.8",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &certUniqueIdVersion{}})
+		Test:          &certUniqueIdVersion{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ECertUniqueIdentifierVersionNot_2Or_3 = result },
+	})
 }

--- a/lints/lint_dh_params_missing.go
+++ b/lints/lint_dh_params_missing.go
@@ -35,5 +35,7 @@ func init() {
 		Description:   "DH keys must have parameters",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &dsaParamsMissing{}})
+		Test:          &dsaParamsMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EDhParamsMissing = result },
+	})
 }

--- a/lints/lint_distribution_point_incomplete.go
+++ b/lints/lint_distribution_point_incomplete.go
@@ -63,5 +63,7 @@ func init() {
 		Description:   "A DistributionPoint from the CRLDistributionPoints extension MUST NOT consist of only the reasons field; either distributionPoint or CRLIssuer must be present",
 		Providence:    "RFC 5280: 4.2.1.13",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &dpIncomplete{}})
+		Test:          &dpIncomplete{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EDistributionPointIncomplete = result },
+	})
 }

--- a/lints/lint_distribution_point_missing_ldap_or_uri.go
+++ b/lints/lint_distribution_point_missing_ldap_or_uri.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "When present in the CRLDistributionPoints extension, DistributionPointName SHOULD include at least one LDAP or HTTP URI.",
 		Providence:    "RFC 5280: 4.2.1.13",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &distribNoLDAPorURI{}})
+		Test:          &distribNoLDAPorURI{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WDistributionPointMissingLdapOrUri = result },
+	})
 }

--- a/lints/lint_dsa_improper_modulus_or_divisor_size.go
+++ b/lints/lint_dsa_improper_modulus_or_divisor_size.go
@@ -47,5 +47,7 @@ func init() {
 		Providence:  "CAB: 6.1.5",
 		// Refer to CAB: 6.1.5, taking the statement "Before 31 Dec 2010" literally
 		EffectiveDate: util.ZeroDate,
-		Test:          &dsaImproperSize{}})
+		Test:          &dsaImproperSize{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EDsaImproperModulusOrDivisorSize = result },
+	})
 }

--- a/lints/lint_dsa_shorter_than_2048_bits.go
+++ b/lints/lint_dsa_shorter_than_2048_bits.go
@@ -41,5 +41,7 @@ func init() {
 		Providence:  "CAB: 6.1.5",
 		// Refer to CAB: 6.1.5, taking the statement "Before 31 Dec 2010" literally
 		EffectiveDate: util.ZeroDate,
-		Test:          &dsaTooShort{}})
+		Test:          &dsaTooShort{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EDsaShorterThan_2048Bits = result },
+	})
 }

--- a/lints/lint_ec_improper_curves.go
+++ b/lints/lint_ec_improper_curves.go
@@ -54,5 +54,7 @@ func init() {
 		Providence:  "CAB: 6.1.5",
 		// Refer to CAB: 6.1.5, taking the statement "Before 31 Dec 2010" literally
 		EffectiveDate: util.ZeroDate,
-		Test:          &ecImproperCurves{}})
+		Test:          &ecImproperCurves{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EEcImproperCurves = result },
+	})
 }

--- a/lints/lint_eku_critical_improperly.go
+++ b/lints/lint_eku_critical_improperly.go
@@ -50,5 +50,7 @@ func init() {
 		Description:   "Conforming CAs SHOULD NOT mark extended key usage extension as critical if the anyExtendedKeyUsage KeyPurposedID is present",
 		Providence:    "RFC 5280: 4.2.1.12",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &ekuBadCritical{}})
+		Test:          &ekuBadCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WEkuCriticalImproperly = result },
+	})
 }

--- a/lints/lint_ev_business_category_missing.go
+++ b/lints/lint_ev_business_category_missing.go
@@ -33,5 +33,7 @@ func init() {
 		Description:   "EV certificates must include businessCategory in subject",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &evNoBiz{}})
+		Test:          &evNoBiz{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EEvBusinessCategoryMissing = result },
+	})
 }

--- a/lints/lint_ev_country_name_missing.go
+++ b/lints/lint_ev_country_name_missing.go
@@ -33,5 +33,7 @@ func init() {
 		Description:   "EV certificates must include countryName in subject",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &evCountryMissing{}})
+		Test:          &evCountryMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EEvCountryNameMissing = result },
+	})
 }

--- a/lints/lint_ev_locality_name_missing.go
+++ b/lints/lint_ev_locality_name_missing.go
@@ -33,5 +33,7 @@ func init() {
 		Description:   "EV certificates must include localityName in subject",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &evLocalityMissing{}})
+		Test:          &evLocalityMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EEvLocalityNameMissing = result },
+	})
 }

--- a/lints/lint_ev_organization_name_missing.go
+++ b/lints/lint_ev_organization_name_missing.go
@@ -33,5 +33,7 @@ func init() {
 		Description:   "EV certificates must include organizationName in subject",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &evOrgMissing{}})
+		Test:          &evOrgMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EEvOrganizationNameMissing = result },
+	})
 }

--- a/lints/lint_ev_serial_number_missing.go
+++ b/lints/lint_ev_serial_number_missing.go
@@ -32,5 +32,7 @@ func init() {
 		Description:   "EV certificates must include serialNumber in subject",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &evSNMissing{}})
+		Test:          &evSNMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EEvSerialNumberMissing = result },
+	})
 }

--- a/lints/lint_ev_valid_time_too_long.go
+++ b/lints/lint_ev_valid_time_too_long.go
@@ -32,5 +32,7 @@ func init() {
 		Description:   "EV certificates must be 27 months in validity or less",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &evValidTooLong{}})
+		Test:          &evValidTooLong{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EEvValidTimeTooLong = result },
+	})
 }

--- a/lints/lint_ext_aia_access_location_missing.go
+++ b/lints/lint_ext_aia_access_location_missing.go
@@ -46,5 +46,7 @@ func init() {
 		Description:   "When the id-ad-caIssuers accessMethod is used, at least one instance SHOULD specify an accessLocation that is an HTTP or LDAP URI.",
 		Providence:    "RFC 5280: 4.2.2.1",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &aiaNoHTTPorLDAP{}})
+		Test:          &aiaNoHTTPorLDAP{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WExtAiaAccessLocationMissing = result },
+	})
 }

--- a/lints/lint_ext_aia_marked_critical.go
+++ b/lints/lint_ext_aia_marked_critical.go
@@ -38,5 +38,7 @@ func init() {
 		Description:   "Conforming CAs must mark the Authority Information Access extension as non-critical",
 		Providence:    "RFC 5280: 4.2.2.1",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &ExtAiaMarkedCritical{}})
+		Test:          &ExtAiaMarkedCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtAiaMarkedCritical = result },
+	})
 }

--- a/lints/lint_ext_authority_key_identifier_critical.go
+++ b/lints/lint_ext_authority_key_identifier_critical.go
@@ -38,5 +38,7 @@ func init() {
 		Description:   "The authority key identifier extension must be non-critical.",
 		Providence:    "RFC 5280: 4.2.1.1",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &authorityKeyIdCritical{}})
+		Test:          &authorityKeyIdCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtAuthorityKeyIdentifierCritical = result },
+	})
 }

--- a/lints/lint_ext_authority_key_identifier_missing.go
+++ b/lints/lint_ext_authority_key_identifier_missing.go
@@ -47,5 +47,7 @@ func init() {
 		Description:   "CAs must support key identifiers and include them in all certs",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.1",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &authorityKeyIdMissing{}})
+		Test:          &authorityKeyIdMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtAuthorityKeyIdentifierMissing = result },
+	})
 }

--- a/lints/lint_ext_authority_key_identifier_no_key_identifier.go
+++ b/lints/lint_ext_authority_key_identifier_no_key_identifier.go
@@ -47,5 +47,9 @@ func init() {
 		Description:   "CAs must include keyIdentifer field of aki in all non-self-issued certs",
 		Providence:    "RFC 5280: 4.2.1.1",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &authorityKeyIdNoKeyIdField{}})
+		Test:          &authorityKeyIdNoKeyIdField{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.EExtAuthorityKeyIdentifierNoKeyIdentifier = result
+		},
+	})
 }

--- a/lints/lint_ext_cert_policy_contains_noticeref.go
+++ b/lints/lint_ext_cert_policy_contains_noticeref.go
@@ -49,5 +49,7 @@ func init() {
 		Description:   "Compliant certificates should not use the noticeRef option",
 		Providence:    "RFC 5280: 4.2.1.4",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &noticeRefPres{}})
+		Test:          &noticeRefPres{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WExtCertPolicyContainsNoticeref = result },
+	})
 }

--- a/lints/lint_ext_cert_policy_disallowed_any_policy_qualifier.go
+++ b/lints/lint_ext_cert_policy_disallowed_any_policy_qualifier.go
@@ -46,5 +46,9 @@ func init() {
 		Description:   "when qualifiers are used with the special policy anyPolicy, the must be limited to qualifiers identified in this section (4.2.1.4)",
 		Providence:    "RFC 5280: 4.2.1.4",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &unrecommendedQualifier{}})
+		Test:          &unrecommendedQualifier{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.EExtCertPolicyDisallowedAnyPolicyQualifier = result
+		},
+	})
 }

--- a/lints/lint_ext_cert_policy_duplicate.go
+++ b/lints/lint_ext_cert_policy_duplicate.go
@@ -47,5 +47,7 @@ func init() {
 		Description:   "a cert policy OID must not appear more than once in the extension",
 		Providence:    "RFC 5280: 4.2.1.4",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &ExtCertPolicyDuplicate{}})
+		Test:          &ExtCertPolicyDuplicate{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtCertPolicyDuplicate = result },
+	})
 }

--- a/lints/lint_ext_cert_policy_explicit_text_ia5_string.go
+++ b/lints/lint_ext_cert_policy_explicit_text_ia5_string.go
@@ -54,5 +54,7 @@ func init() {
 		Description:   "Compliant certificates must not encode explicitTest as IA5String",
 		Providence:    "RFC 6818: 3",
 		EffectiveDate: util.RFC6818Date,
-		Test:          &explicitTextIA5String{}})
+		Test:          &explicitTextIA5String{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtCertPolicyExplicitTextIa5String = result },
+	})
 }

--- a/lints/lint_ext_cert_policy_explicit_text_includes_control.go
+++ b/lints/lint_ext_cert_policy_explicit_text_includes_control.go
@@ -72,5 +72,9 @@ func init() {
 		Description:   "Explicit text should not include any control charaters",
 		Providence:    "RFC 6818: 3",
 		EffectiveDate: util.RFC6818Date,
-		Test:          &controlChar{}})
+		Test:          &controlChar{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.WExtCertPolicyExplicitTextIncludesControl = result
+		},
+	})
 }

--- a/lints/lint_ext_cert_policy_explicit_text_not_nfc.go
+++ b/lints/lint_ext_cert_policy_explicit_text_not_nfc.go
@@ -48,5 +48,7 @@ func init() {
 		Description:   "When utf8string or bmpstring encoding is used for explicitText field in cert policy, it SHOULD BE normalized by NFC format",
 		Providence:    "Fill this in...",
 		EffectiveDate: util.RFC6818Date,
-		Test:          &ExtCertPolicyExplicitTextNotNFC{}})
+		Test:          &ExtCertPolicyExplicitTextNotNFC{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WExtCertPolicyExplicitTextNotNfc = result },
+	})
 }

--- a/lints/lint_ext_cert_policy_explicit_text_not_utf8.go
+++ b/lints/lint_ext_cert_policy_explicit_text_not_utf8.go
@@ -53,5 +53,7 @@ func init() {
 		Description:   "Compliant certificates should use the utf8string encoding for explicitText",
 		Providence:    "RFC 6818: 3",
 		EffectiveDate: util.RFC6818Date,
-		Test:          &explicitTextUtf8{}})
+		Test:          &explicitTextUtf8{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WExtCertPolicyExplicitTextNotUtf8 = result },
+	})
 }

--- a/lints/lint_ext_cert_policy_explicit_text_too_long.go
+++ b/lints/lint_ext_cert_policy_explicit_text_too_long.go
@@ -53,5 +53,7 @@ func init() {
 		Description:   "explicit text has a maximum size of 200 characters",
 		Providence:    "RFC 6818: 3",
 		EffectiveDate: util.RFC6818Date,
-		Test:          &explicitTextTooLong{}})
+		Test:          &explicitTextTooLong{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtCertPolicyExplicitTextTooLong = result },
+	})
 }

--- a/lints/lint_ext_crl_distribution_marked_critical.go
+++ b/lints/lint_ext_crl_distribution_marked_critical.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "If included, the CRL Distribution Points extension SHOULD NOT be marked critical.",
 		Providence:    "RFC 5280: 4.2.1.13",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &ExtCrlDistributionMarkedCritical{}})
+		Test:          &ExtCrlDistributionMarkedCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WExtCrlDistributionMarkedCritical = result },
+	})
 }

--- a/lints/lint_ext_duplicate_extension.go
+++ b/lints/lint_ext_duplicate_extension.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "A certificate MUST NOT include more than one instance of a particular extension.",
 		Providence:    "RFC 5280: 4.2",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &ExtDuplicateExtension{}})
+		Test:          &ExtDuplicateExtension{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtDuplicateExtension = result },
+	})
 }

--- a/lints/lint_ext_freshest_crl_marked_critical.go
+++ b/lints/lint_ext_freshest_crl_marked_critical.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "Freshest CRL MUST be marked as non-critical by conforming CAs.",
 		Providence:    "RFC 5280: 4.2.1.15",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &ExtFreshestCrlMarkedCritical{}})
+		Test:          &ExtFreshestCrlMarkedCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtFreshestCrlMarkedCritical = result },
+	})
 }

--- a/lints/lint_ext_ian_critical.go
+++ b/lints/lint_ext_ian_critical.go
@@ -38,5 +38,7 @@ func init() {
 		Description:   "issuer alternate name should be marked as non-critical",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &ExtIANCritical{}})
+		Test:          &ExtIANCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WExtIanCritical = result },
+	})
 }

--- a/lints/lint_ext_ian_dns_not_ia5_string.go
+++ b/lints/lint_ext_ian_dns_not_ia5_string.go
@@ -72,5 +72,7 @@ func init() {
 		Description:   "dNSNames are IA5 strings",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &IANDNSNotIA5String{}})
+		Test:          &IANDNSNotIA5String{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtIanDnsNotIa5String = result },
+	})
 }

--- a/lints/lint_ext_ian_empty_name.go
+++ b/lints/lint_ext_ian_empty_name.go
@@ -65,5 +65,7 @@ func init() {
 		Description:   "general name fields must not be empty in IAN",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &IANEmptyName{}})
+		Test:          &IANEmptyName{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtIanEmptyName = result },
+	})
 }

--- a/lints/lint_ext_ian_no_entries.go
+++ b/lints/lint_ext_ian_no_entries.go
@@ -45,5 +45,7 @@ func init() {
 		Description:   "if present, the IAN extension must contain at least one entry",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &IANNoEntry{}})
+		Test:          &IANNoEntry{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtIanNoEntries = result },
+	})
 }

--- a/lints/lint_ext_ian_rfc822_format_invalid.go
+++ b/lints/lint_ext_ian_rfc822_format_invalid.go
@@ -51,5 +51,7 @@ func init() {
 		Description:   "email must not be surrounded with `<>`, and there must be no trailing comments in `()`",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &IANEmail{}})
+		Test:          &IANEmail{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtIanRfc822FormatInvalid = result },
+	})
 }

--- a/lints/lint_ext_ian_space_dns_name.go
+++ b/lints/lint_ext_ian_space_dns_name.go
@@ -49,5 +49,7 @@ func init() {
 		Description:   "the dNSName ` ` must not be used",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &IANSpace{}})
+		Test:          &IANSpace{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtIanSpaceDnsName = result },
+	})
 }

--- a/lints/lint_ext_ian_uri_format_invalid.go
+++ b/lints/lint_ext_ian_uri_format_invalid.go
@@ -51,5 +51,7 @@ func init() {
 		Description:   "URIs in SAN extension must have a scheme and scheme specific part",
 		Providence:    "RFC5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &IANURIFormat{}})
+		Test:          &IANURIFormat{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtIanUriFormatInvalid = result },
+	})
 }

--- a/lints/lint_ext_ian_uri_host_not_fqdn_or_ip.go
+++ b/lints/lint_ext_ian_uri_host_not_fqdn_or_ip.go
@@ -50,5 +50,7 @@ func init() {
 		Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host.",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &IANURIFQDNOrIP{}})
+		Test:          &IANURIFQDNOrIP{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtIanUriHostNotFqdnOrIp = result },
+	})
 }

--- a/lints/lint_ext_ian_uri_not_ia5.go
+++ b/lints/lint_ext_ian_uri_not_ia5.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "When SAN contains a URI, the name must be an IA5 string",
 		Providence:    "RFC5280: 4.2.1.7",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &IANURIIA5String{}})
+		Test:          &IANURIIA5String{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtIanUriNotIa5 = result },
+	})
 }

--- a/lints/lint_ext_ian_uri_relative.go
+++ b/lints/lint_ext_ian_uri_relative.go
@@ -52,5 +52,7 @@ func init() {
 		Description:   "When IAN extension is present and URI is used, the name must not be a relative URI ",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &uriRelative{}})
+		Test:          &uriRelative{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtIanUriRelative = result },
+	})
 }

--- a/lints/lint_ext_key_usage_cert_sign_without_ca.go
+++ b/lints/lint_ext_key_usage_cert_sign_without_ca.go
@@ -47,5 +47,7 @@ func init() {
 		Description:   "if the keyCertSign bit is asserted, then the cA bit MUST also be asserted",
 		Providence:    "RFC 5280: 4.2.1.3 & 4.2.1.9",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &keyUsageCertSignNoCa{}})
+		Test:          &keyUsageCertSignNoCa{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtKeyUsageCertSignWithoutCa = result },
+	})
 }

--- a/lints/lint_ext_key_usage_not_critical.go
+++ b/lints/lint_ext_key_usage_not_critical.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "The keyUsage extension SHOULD be critical.",
 		Providence:    "RFC 5280: 4.2.1.3",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &checkKeyUsageCritical{}})
+		Test:          &checkKeyUsageCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WExtKeyUsageNotCritical = result },
+	})
 }

--- a/lints/lint_ext_key_usage_without_bits.go
+++ b/lints/lint_ext_key_usage_without_bits.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "when included, at least one bit must be set to 1",
 		Providence:    "RFC 5280: 4.2.1.3",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &keyUsageBitsSet{}})
+		Test:          &keyUsageBitsSet{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtKeyUsageWithoutBits = result },
+	})
 }

--- a/lints/lint_ext_name_constraints_not_critical.go
+++ b/lints/lint_ext_name_constraints_not_critical.go
@@ -45,5 +45,7 @@ func init() {
 		Description:   "If it is included, conforming CAs must mark the name constrains extension as critical.",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &nameConstraintCrit{}})
+		Test:          &nameConstraintCrit{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtNameConstraintsNotCritical = result },
+	})
 }

--- a/lints/lint_ext_name_constraints_not_in_ca.go
+++ b/lints/lint_ext_name_constraints_not_in_ca.go
@@ -43,5 +43,7 @@ func init() {
 		Description:   "The name constraints extension must only be used in CA certificates",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &nameConstraintNotCa{}})
+		Test:          &nameConstraintNotCa{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtNameConstraintsNotInCa = result },
+	})
 }

--- a/lints/lint_ext_policy_constraints_empty.go
+++ b/lints/lint_ext_policy_constraints_empty.go
@@ -54,5 +54,7 @@ func init() {
 		Description:   "Conforming CAs MUST NOT issue certificates where policy constraints is an empty sequence. That is, either the inhibitPolicyMapping field or the requireExplicityPolicy field MUST be present",
 		Providence:    "RFC 5280: 4.2.1.11",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &policyConstraintsContents{}})
+		Test:          &policyConstraintsContents{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtPolicyConstraintsEmpty = result },
+	})
 }

--- a/lints/lint_ext_policy_constraints_not_critical.go
+++ b/lints/lint_ext_policy_constraints_not_critical.go
@@ -38,5 +38,7 @@ func init() {
 		Description:   "Conforming CAs must mark the policy constraints extension as critical.",
 		Providence:    "RFC 5280: 4.2.1.11",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &policyConstraintsCritical{}})
+		Test:          &policyConstraintsCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtPolicyConstraintsNotCritical = result },
+	})
 }

--- a/lints/lint_ext_policy_map_any_policy.go
+++ b/lints/lint_ext_policy_map_any_policy.go
@@ -47,5 +47,7 @@ func init() {
 		Description:   "policies must not be mapped to or from the anyPolicy value",
 		Providence:    "RFC 5280: 4.2.1.5",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &policyMapAnyPolicy{}})
+		Test:          &policyMapAnyPolicy{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtPolicyMapAnyPolicy = result },
+	})
 }

--- a/lints/lint_ext_policy_map_not_critical.go
+++ b/lints/lint_ext_policy_map_not_critical.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "Policy mappings should be marked as critical",
 		Providence:    "RFC 5280: 4.2.1.5",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &policyMapCritical{}})
+		Test:          &policyMapCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WExtPolicyMapNotCritical = result },
+	})
 }

--- a/lints/lint_ext_policy_map_not_in_cert_policy.go
+++ b/lints/lint_ext_policy_map_not_in_cert_policy.go
@@ -47,5 +47,7 @@ func init() {
 		Description:   "each issuerDomainPolicy named in policy mappings extension should also be asserted in a certificate policies extension",
 		Providence:    "RFC 5280: 4.2.1.5",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &policyMapMatchesCertPolicy{}})
+		Test:          &policyMapMatchesCertPolicy{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WExtPolicyMapNotInCertPolicy = result },
+	})
 }

--- a/lints/lint_ext_san_contains_reserved_ip.go
+++ b/lints/lint_ext_san_contains_reserved_ip.go
@@ -43,5 +43,7 @@ func init() {
 		Description:   "Certs and expiring after 2015-11-01 must not contain a reserved ip address in the subjectAlternativeName extension.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &SANReservedIP{}})
+		Test:          &SANReservedIP{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanContainsReservedIp = result },
+	})
 }

--- a/lints/lint_ext_san_critical_with_subject_dn.go
+++ b/lints/lint_ext_san_critical_with_subject_dn.go
@@ -43,5 +43,7 @@ func init() {
 		Description:   "If the subject contains a distinguished name SAN should be non-critical.",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &ExtSANCriticalWithSubjectDN{}})
+		Test:          &ExtSANCriticalWithSubjectDN{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WExtSanCriticalWithSubjectDn = result },
+	})
 }

--- a/lints/lint_ext_san_directory_name_present.go
+++ b/lints/lint_ext_san_directory_name_present.go
@@ -42,5 +42,7 @@ func init() {
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &SANDirName{}})
+		Test:          &SANDirName{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanDirectoryNamePresent = result },
+	})
 }

--- a/lints/lint_ext_san_dns_not_ia5_string.go
+++ b/lints/lint_ext_san_dns_not_ia5_string.go
@@ -72,5 +72,7 @@ func init() {
 		Description:   "dNSNames are IA5 strings",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &SANDNSNotIA5String{}})
+		Test:          &SANDNSNotIA5String{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanDnsNotIa5String = result },
+	})
 }

--- a/lints/lint_ext_san_dnsname_not_fqdn.go
+++ b/lints/lint_ext_san_dnsname_not_fqdn.go
@@ -44,5 +44,7 @@ func init() {
 		Description:   "SAN dnsnames must be a fully qualified domain name.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &DNSFQDN{}})
+		Test:          &DNSFQDN{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanDnsnameNotFqdn = result },
+	})
 }

--- a/lints/lint_ext_san_edi_party_name_present.go
+++ b/lints/lint_ext_san_edi_party_name_present.go
@@ -42,5 +42,7 @@ func init() {
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &SANEDI{}})
+		Test:          &SANEDI{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanEdiPartyNamePresent = result },
+	})
 }

--- a/lints/lint_ext_san_empty_name.go
+++ b/lints/lint_ext_san_empty_name.go
@@ -65,5 +65,7 @@ func init() {
 		Description:   "general name fields must not be empty in SAN",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &SANEmptyName{}})
+		Test:          &SANEmptyName{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanEmptyName = result },
+	})
 }

--- a/lints/lint_ext_san_missing.go
+++ b/lints/lint_ext_san_missing.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "Certificates must contain the Subject Alternate Name extension.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &SANMissing{}})
+		Test:          &SANMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanMissing = result },
+	})
 }

--- a/lints/lint_ext_san_no_entries.go
+++ b/lints/lint_ext_san_no_entries.go
@@ -45,5 +45,7 @@ func init() {
 		Description:   "if present, the SAN extension must contain at least one entry",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &SANNoEntry{}})
+		Test:          &SANNoEntry{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanNoEntries = result },
+	})
 }

--- a/lints/lint_ext_san_not_critical_without_subject.go
+++ b/lints/lint_ext_san_not_critical_without_subject.go
@@ -45,5 +45,7 @@ func init() {
 		Description:   "If there is an empty subject field, then the SAN extension must be critical",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &extSANNotCritNoSubject{}})
+		Test:          &extSANNotCritNoSubject{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanNotCriticalWithoutSubject = result },
+	})
 }

--- a/lints/lint_ext_san_other_name_present.go
+++ b/lints/lint_ext_san_other_name_present.go
@@ -42,5 +42,7 @@ func init() {
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &SANOtherName{}})
+		Test:          &SANOtherName{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanOtherNamePresent = result },
+	})
 }

--- a/lints/lint_ext_san_registered_id_present.go
+++ b/lints/lint_ext_san_registered_id_present.go
@@ -42,5 +42,7 @@ func init() {
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &SANRegId{}})
+		Test:          &SANRegId{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanRegisteredIdPresent = result },
+	})
 }

--- a/lints/lint_ext_san_rfc822_format_invalid.go
+++ b/lints/lint_ext_san_rfc822_format_invalid.go
@@ -51,5 +51,7 @@ func init() {
 		Description:   "email must not be surrounded with `<>`, and there must be no trailing comments in `()`",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &invalidEmail{}})
+		Test:          &invalidEmail{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanRfc822FormatInvalid = result },
+	})
 }

--- a/lints/lint_ext_san_rfc822_name_present.go
+++ b/lints/lint_ext_san_rfc822_name_present.go
@@ -42,5 +42,7 @@ func init() {
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &SANRfc822{}})
+		Test:          &SANRfc822{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanRfc822NamePresent = result },
+	})
 }

--- a/lints/lint_ext_san_space_dns_name.go
+++ b/lints/lint_ext_san_space_dns_name.go
@@ -49,5 +49,7 @@ func init() {
 		Description:   "the dNSName ` ` must not be used",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &SANIsSpaceDNS{}})
+		Test:          &SANIsSpaceDNS{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanSpaceDnsName = result },
+	})
 }

--- a/lints/lint_ext_san_uniform_resource_identifier_present.go
+++ b/lints/lint_ext_san_uniform_resource_identifier_present.go
@@ -42,5 +42,9 @@ func init() {
 		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &SANURI{}})
+		Test:          &SANURI{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.EExtSanUniformResourceIdentifierPresent = result
+		},
+	})
 }

--- a/lints/lint_ext_san_uri_format_invalid.go
+++ b/lints/lint_ext_san_uri_format_invalid.go
@@ -51,5 +51,7 @@ func init() {
 		Description:   "URIs in SAN extension must have a scheme and scheme specific part",
 		Providence:    "RFC5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &extSANURIFormatInvalid{}})
+		Test:          &extSANURIFormatInvalid{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanUriFormatInvalid = result },
+	})
 }

--- a/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
+++ b/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
@@ -48,5 +48,7 @@ func init() {
 		Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host.",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &SANURIHost{}})
+		Test:          &SANURIHost{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanUriHostNotFqdnOrIp = result },
+	})
 }

--- a/lints/lint_ext_san_uri_not_ia5.go
+++ b/lints/lint_ext_san_uri_not_ia5.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "When SAN contains a URI, the name must be an IA5 string",
 		Providence:    "RFC5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &extSANURINotIA5{}})
+		Test:          &extSANURINotIA5{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanUriNotIa5 = result },
+	})
 }

--- a/lints/lint_ext_san_uri_relative.go
+++ b/lints/lint_ext_san_uri_relative.go
@@ -52,5 +52,7 @@ func init() {
 		Description:   "When SAN extension is present and URI is used, the name must not be a relative URI ",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &extSANURIRelative{}})
+		Test:          &extSANURIRelative{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanUriRelative = result },
+	})
 }

--- a/lints/lint_ext_subject_directory_attr_critical.go
+++ b/lints/lint_ext_subject_directory_attr_critical.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "Conforming CAs must mark the Subject Directory Attributes extension as not critical",
 		Providence:    "RFC 5280: 4.2.1.8",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &subDirAttrCrit{}})
+		Test:          &subDirAttrCrit{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSubjectDirectoryAttrCritical = result },
+	})
 }

--- a/lints/lint_ext_subject_key_identifier_critical.go
+++ b/lints/lint_ext_subject_key_identifier_critical.go
@@ -38,5 +38,7 @@ func init() {
 		Description:   "The subject key identifier extension must be non-critical.",
 		Providence:    "RFC 5280: 4.2.1.2",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &subjectKeyIdCritical{}})
+		Test:          &subjectKeyIdCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSubjectKeyIdentifierCritical = result },
+	})
 }

--- a/lints/lint_ext_subject_key_identifier_missing_ca.go
+++ b/lints/lint_ext_subject_key_identifier_missing_ca.go
@@ -52,5 +52,7 @@ func init() {
 		Description:   "CAs must include ski in all CA certificates.",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.2",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &subjectKeyIdMissingCA{}})
+		Test:          &subjectKeyIdMissingCA{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSubjectKeyIdentifierMissingCa = result },
+	})
 }

--- a/lints/lint_ext_subject_key_identifier_missing_sub_cert.go
+++ b/lints/lint_ext_subject_key_identifier_missing_sub_cert.go
@@ -52,5 +52,7 @@ func init() {
 		Description:   "Sub certs should include ski in end entity certs",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.2",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &subjectKeyIdMissingSubscriber{}})
+		Test:          &subjectKeyIdMissingSubscriber{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WExtSubjectKeyIdentifierMissingSubCert = result },
+	})
 }

--- a/lints/lint_generalized_time_does_not_include_seconds.go
+++ b/lints/lint_generalized_time_does_not_include_seconds.go
@@ -75,5 +75,7 @@ func init() {
 		Description:   "Generalized time values must include seconds",
 		Providence:    "RFC 5280: 4.1.2.5.2",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &generalizedNoSeconds{}})
+		Test:          &generalizedNoSeconds{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EGeneralizedTimeDoesNotIncludeSeconds = result },
+	})
 }

--- a/lints/lint_generalized_time_includes_fraction_seconds.go
+++ b/lints/lint_generalized_time_includes_fraction_seconds.go
@@ -75,5 +75,9 @@ func init() {
 		Description:   "Generalized time values must not include fraction seconds",
 		Providence:    "RFC 5280: 4.1.2.5.2",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &generalizedTimeFraction{}})
+		Test:          &generalizedTimeFraction{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.EGeneralizedTimeIncludesFractionSeconds = result
+		},
+	})
 }

--- a/lints/lint_generalized_time_not_in_zulu.go
+++ b/lints/lint_generalized_time_not_in_zulu.go
@@ -57,5 +57,7 @@ func init() {
 		Description:   "Generalized time values must be expressed in Greenwich Mean Time (Zulu)",
 		Providence:    "RFC 5280: 4.1.2.5.2",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &generalizedNotZulu{}})
+		Test:          &generalizedNotZulu{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EGeneralizedTimeNotInZulu = result },
+	})
 }

--- a/lints/lint_gtld_under_consideration.go
+++ b/lints/lint_gtld_under_consideration.go
@@ -50,5 +50,7 @@ func init() {
 		Description:   "CAs SHOULD NOT issue Certificates containing a new gTLD under consideration by ICANN.",
 		Providence:    "CAB: 4.2.2",
 		EffectiveDate: util.CABV113Date,
-		Test:          &gtldUnderConsideration{}})
+		Test:          &gtldUnderConsideration{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WGtldUnderConsideration = result },
+	})
 }

--- a/lints/lint_ian_bare_wildcard.go
+++ b/lints/lint_ian_bare_wildcard.go
@@ -35,5 +35,7 @@ func init() {
 		Description:   "Wildcard MUST be accompanied by other data to it's right (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &brIANBareWildcard{}})
+		Test:          &brIANBareWildcard{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EIanBareWildcard = result },
+	})
 }

--- a/lints/lint_ian_dns_name_includes_null_char.go
+++ b/lints/lint_ian_dns_name_includes_null_char.go
@@ -36,5 +36,7 @@ func init() {
 		Description:   "DNSNames MUST NOT include a null character ",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &IANDNSNull{}})
+		Test:          &IANDNSNull{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EIanDnsNameIncludesNullChar = result },
+	})
 }

--- a/lints/lint_ian_dns_name_starts_with_period.go
+++ b/lints/lint_ian_dns_name_starts_with_period.go
@@ -35,5 +35,7 @@ func init() {
 		Description:   "DNSName MUST NOT start with a period",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &IANDNSPeriod{}})
+		Test:          &IANDNSPeriod{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EIanDnsNameStartsWithPeriod = result },
+	})
 }

--- a/lints/lint_ian_iana_pub_suffix_empty.go
+++ b/lints/lint_ian_iana_pub_suffix_empty.go
@@ -35,5 +35,7 @@ func init() {
 		Description:   "Domain SHOULD NOT have bare public suffix",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &IANPubSuffix{}})
+		Test:          &IANPubSuffix{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WIanIanaPubSuffixEmpty = result },
+	})
 }

--- a/lints/lint_ian_wildcard_not_first.go
+++ b/lints/lint_ian_wildcard_not_first.go
@@ -36,5 +36,7 @@ func init() {
 		Description:   "Wildcard MUST be in the first label of FQDN, ie not: www.*.com (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &brIANWildcardFirst{}})
+		Test:          &brIANWildcardFirst{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EIanWildcardNotFirst = result },
+	})
 }

--- a/lints/lint_inhibit_any_policy_not_critical.go
+++ b/lints/lint_inhibit_any_policy_not_critical.go
@@ -46,5 +46,7 @@ func init() {
 		Description:   "CAs must mark the inhibitAnyPolicy extension as critical",
 		Providence:    "RFC 5280: 4.2.1.14",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &InhibitAnyPolicyNotCritical{}})
+		Test:          &InhibitAnyPolicyNotCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EInhibitAnyPolicyNotCritical = result },
+	})
 }

--- a/lints/lint_invalid_certificate_version.go
+++ b/lints/lint_invalid_certificate_version.go
@@ -36,5 +36,7 @@ func init() {
 		Description:   "Certificate must be version 3 (encoded as 2)",
 		Providence:    "CAB: 7.1.1",
 		EffectiveDate: util.CABV130Date,
-		Test:          &InvalidCertificateVersion{}})
+		Test:          &InvalidCertificateVersion{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EInvalidCertificateVersion = result },
+	})
 }

--- a/lints/lint_issuer_field_empty.go
+++ b/lints/lint_issuer_field_empty.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "Certificates issuer field must not be empty and must have a non-empty distingushed name",
 		Providence:    "RFC 5280: 4.1.2.4",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &issuerFieldEmpty{}})
+		Test:          &issuerFieldEmpty{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EIssuerFieldEmpty = result },
+	})
 }

--- a/lints/lint_name_constraint_empty.go
+++ b/lints/lint_name_constraint_empty.go
@@ -57,5 +57,7 @@ func init() {
 		Description:   "Conforming CAs must not issue certificates where name constraints is an empty sequence. That is, either the permittedSubtree or excludedSubtree fields must be present",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &nameConstraintEmpty{}})
+		Test:          &nameConstraintEmpty{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ENameConstraintEmpty = result },
+	})
 }

--- a/lints/lint_name_constraint_maximum_not_absent.go
+++ b/lints/lint_name_constraint_maximum_not_absent.go
@@ -109,5 +109,7 @@ func init() {
 		Description:   "In the name constraints name forms the maximum is not used and therefore MUST be absent",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &nameConstraintMax{}})
+		Test:          &nameConstraintMax{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ENameConstraintMaximumNotAbsent = result },
+	})
 }

--- a/lints/lint_name_constraint_minimum_non_zero.go
+++ b/lints/lint_name_constraint_minimum_non_zero.go
@@ -109,5 +109,7 @@ func init() {
 		Description:   "In the name constraints name forms the minimum is not used and therefore MUST be zero",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &nameConstMin{}})
+		Test:          &nameConstMin{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ENameConstraintMinimumNonZero = result },
+	})
 }

--- a/lints/lint_name_constraint_on_edi_party_name.go
+++ b/lints/lint_name_constraint_on_edi_party_name.go
@@ -44,5 +44,7 @@ func init() {
 		Description:   "The name constraints extension SHOULD NOT impose constraints on the ediPartyName name form",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &nameConstraintOnEDI{}})
+		Test:          &nameConstraintOnEDI{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WNameConstraintOnEdiPartyName = result },
+	})
 }

--- a/lints/lint_name_constraint_on_registered_id.go
+++ b/lints/lint_name_constraint_on_registered_id.go
@@ -44,5 +44,7 @@ func init() {
 		Description:   "The name constraints extension SHOULD NOT impose constraints on the registeredID name form",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &nameConstraintOnRegisteredId{}})
+		Test:          &nameConstraintOnRegisteredId{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WNameConstraintOnRegisteredId = result },
+	})
 }

--- a/lints/lint_name_constraint_on_x400.go
+++ b/lints/lint_name_constraint_on_x400.go
@@ -44,5 +44,7 @@ func init() {
 		Description:   "The name constraints extension SHOULD NOT impose constraints on the x400Address name form",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC5280Date,
-		Test:          &nameConstraintOnX400{}})
+		Test:          &nameConstraintOnX400{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WNameConstraintOnX400 = result },
+	})
 }

--- a/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
+++ b/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "In a validity period beginning on or before 31 dec 2010, root CA certificates using RSA public key algorithm must have 2048 bits of modulus",
 		Providence:    "CAB: 6.1.5",
 		EffectiveDate: util.ZeroDate,
-		Test:          &rootCaModSize{}})
+		Test:          &rootCaModSize{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EOldRootCaRsaModLessThan_2048Bits = result },
+	})
 }

--- a/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
+++ b/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
@@ -40,5 +40,7 @@ func init() {
 		Providence:  "CAB: 6.1.5",
 		// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test
 		EffectiveDate: util.ZeroDate,
-		Test:          &subCaModSize{}})
+		Test:          &subCaModSize{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EOldSubCaRsaModLessThan_1024Bits = result },
+	})
 }

--- a/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
+++ b/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
@@ -39,5 +39,7 @@ func init() {
 		Providence:  "CAB: 6.1.5",
 		// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test
 		EffectiveDate: util.ZeroDate,
-		Test:          &subModSize{}})
+		Test:          &subModSize{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EOldSubCertRsaModLessThan_1024Bits = result },
+	})
 }

--- a/lints/lint_path_len_constraint_improperly_included.go
+++ b/lints/lint_path_len_constraint_improperly_included.go
@@ -51,5 +51,7 @@ func init() {
 		Description:   "CAs MUST NOT include the pathLenConstraint field unless the CA boolean is asserted and the keyCertSign bit is set.",
 		Providence:    "RFC 5280: 4.2.1.9",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &pathLenIncluded{}})
+		Test:          &pathLenIncluded{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EPathLenConstraintImproperlyIncluded = result },
+	})
 }

--- a/lints/lint_path_len_constraint_zero_or_less.go
+++ b/lints/lint_path_len_constraint_zero_or_less.go
@@ -58,5 +58,7 @@ func init() {
 		Description:   "Where it appears, the pathLenConstraint field must be greater than or equal to zero",
 		Providence:    "RFC 5280: 4.2.1.9",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &pathLenNonPositive{}})
+		Test:          &pathLenNonPositive{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EPathLenConstraintZeroOrLess = result },
+	})
 }

--- a/lints/lint_public_key_type_not_allowed.go
+++ b/lints/lint_public_key_type_not_allowed.go
@@ -34,5 +34,7 @@ func init() {
 		Description:   "Certificates must have RSA, DSA, or ECDSA public key type.",
 		Providence:    "CAB: 6.1.5",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &publicKeyAllowed{}})
+		Test:          &publicKeyAllowed{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EPublicKeyTypeNotAllowed = result },
+	})
 }

--- a/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
+++ b/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
@@ -46,5 +46,9 @@ func init() {
 		Description:   "Root CA certificate basicConstraint extension pathLenConstraint field should not be present",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &rootCaPathLenPresent{}})
+		Test:          &rootCaPathLenPresent{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.WRootCaBasicConstraintsPathLenConstraintFieldPresent = result
+		},
+	})
 }

--- a/lints/lint_root_ca_contains_cert_policy.go
+++ b/lints/lint_root_ca_contains_cert_policy.go
@@ -38,5 +38,7 @@ func init() {
 		Description:   "Root CA certs SHOULD NOT contain the certificat policies extension.",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &rootCAContainsCertPolicy{}})
+		Test:          &rootCAContainsCertPolicy{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WRootCaContainsCertPolicy = result },
+	})
 }

--- a/lints/lint_root_ca_extended_key_usage_present.go
+++ b/lints/lint_root_ca_extended_key_usage_present.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "Root CA certificates must not have the extendedKeyUsage extension present",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &rootCAContainsEKU{}})
+		Test:          &rootCAContainsEKU{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ERootCaExtendedKeyUsagePresent = result },
+	})
 }

--- a/lints/lint_rsa_exp_negative.go
+++ b/lints/lint_rsa_exp_negative.go
@@ -35,5 +35,7 @@ func init() {
 		Description:   "RSA public key exponent must be positive",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &rsaExpNegative{}})
+		Test:          &rsaExpNegative{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ERsaExpNegative = result },
+	})
 }

--- a/lints/lint_rsa_mod_factors_smaller_than_752_bits.go
+++ b/lints/lint_rsa_mod_factors_smaller_than_752_bits.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "The modulus of a RSA public key should have no factors smaller than 752",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,
-		Test:          &rsaModSmallFactor{}})
+		Test:          &rsaModSmallFactor{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WRsaModFactorsSmallerThan_752 = result },
+	})
 }

--- a/lints/lint_rsa_mod_less_than_2048_bits.go
+++ b/lints/lint_rsa_mod_less_than_2048_bits.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "in validity period beginning after 31 Dec 2010, all certificates using RSA public key algorithm must have 2048 bits of modulus",
 		Providence:    "CAB: 6.1.5",
 		EffectiveDate: util.RsaDate, // CA/B BR is retroactive here
-		Test:          &rsaParsedTestsKeySize{}})
+		Test:          &rsaParsedTestsKeySize{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ERsaModLessThan_2048Bits = result },
+	})
 }

--- a/lints/lint_rsa_mod_not_odd.go
+++ b/lints/lint_rsa_mod_not_odd.go
@@ -42,5 +42,7 @@ func init() {
 		Description:   "The modulus of a RSA public key should be an odd number",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,
-		Test:          &rsaParsedTestsKeyModOdd{}})
+		Test:          &rsaParsedTestsKeyModOdd{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WRsaModNotOdd = result },
+	})
 }

--- a/lints/lint_rsa_no_public_key.go
+++ b/lints/lint_rsa_no_public_key.go
@@ -34,5 +34,7 @@ func init() {
 		Description:   "The RSA public key should be present",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &rsaParsedPubKeyExist{}})
+		Test:          &rsaParsedPubKeyExist{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ERsaNoPublicKey = result },
+	})
 }

--- a/lints/lint_rsa_public_exponent_not_in_range.go
+++ b/lints/lint_rsa_public_exponent_not_in_range.go
@@ -48,5 +48,7 @@ func init() {
 		Description:   "The RSA public exponent SHOULD be in the range between 2^16 + 1 and 2^256 - 1",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,
-		Test:          &rsaParsedTestsExpInRange{}})
+		Test:          &rsaParsedTestsExpInRange{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WRsaPublicExponentNotInRange = result },
+	})
 }

--- a/lints/lint_rsa_public_exponent_not_odd.go
+++ b/lints/lint_rsa_public_exponent_not_odd.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "RSA public key has to be an odd number",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,
-		Test:          &rsaParsedTestsKeyExpOdd{}})
+		Test:          &rsaParsedTestsKeyExpOdd{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ERsaPublicExponentNotOdd = result },
+	})
 }

--- a/lints/lint_rsa_public_exponent_too_small.go
+++ b/lints/lint_rsa_public_exponent_too_small.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "RSA public key has to be greater or equal to 3",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,
-		Test:          &rsaParsedTestsExpBounds{}})
+		Test:          &rsaParsedTestsExpBounds{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ERsaPublicExponentTooSmall = result },
+	})
 }

--- a/lints/lint_san_bare_wildcard.go
+++ b/lints/lint_san_bare_wildcard.go
@@ -35,5 +35,7 @@ func init() {
 		Description:   "Wildcard MUST be accompanied by other data to it's right (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &brSANBareWildcard{}})
+		Test:          &brSANBareWildcard{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESanBareWildcard = result },
+	})
 }

--- a/lints/lint_san_dns_name_includes_null_char.go
+++ b/lints/lint_san_dns_name_includes_null_char.go
@@ -36,5 +36,7 @@ func init() {
 		Description:   "DNSNames MUST NOT include a null character ",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &SANDNSNull{}})
+		Test:          &SANDNSNull{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESanDnsNameIncludesNullChar = result },
+	})
 }

--- a/lints/lint_san_dns_name_starts_with_period.go
+++ b/lints/lint_san_dns_name_starts_with_period.go
@@ -35,5 +35,7 @@ func init() {
 		Description:   "DNSName MUST NOT start with a period",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &SANDNSPeriod{}})
+		Test:          &SANDNSPeriod{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESanDnsNameStartsWithPeriod = result },
+	})
 }

--- a/lints/lint_san_iana_pub_suffix_empty.go
+++ b/lints/lint_san_iana_pub_suffix_empty.go
@@ -35,5 +35,7 @@ func init() {
 		Description:   "Domain SHOULD NOT have bare public suffix",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &pubSuffix{}})
+		Test:          &pubSuffix{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WSanIanaPubSuffixEmpty = result },
+	})
 }

--- a/lints/lint_san_wildcard_not_first.go
+++ b/lints/lint_san_wildcard_not_first.go
@@ -36,5 +36,7 @@ func init() {
 		Description:   "Wildcard MUST be in the first label of FQDN, ie not: www.*.com (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &SANWildCardFirst{}})
+		Test:          &SANWildCardFirst{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESanWildcardNotFirst = result },
+	})
 }

--- a/lints/lint_serial_number_longer_than_20_octets.go
+++ b/lints/lint_serial_number_longer_than_20_octets.go
@@ -50,5 +50,7 @@ func init() {
 		Description:   "Certificates must not have a serial number longer than 20 octets",
 		Providence:    "RFC 5280: 4.1.2.2",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &serialNumberTooLong{}})
+		Test:          &serialNumberTooLong{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESerialNumberLongerThan_20Octets = result },
+	})
 }

--- a/lints/lint_serial_number_not_positive.go
+++ b/lints/lint_serial_number_not_positive.go
@@ -49,5 +49,7 @@ func init() {
 		Description:   "Certificates must have a positive serial number",
 		Providence:    "RFC 5280: 4.1.2.2",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &SerialNumberNotPositive{}})
+		Test:          &SerialNumberNotPositive{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESerialNumberNotPositive = result },
+	})
 }

--- a/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "Subordinate CA certificates authorityInformationAccess extension should contain the HTTP URL of the Issuing CA’s certificate",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCaIssuerUrl{}})
+		Test:          &subCaIssuerUrl{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WSubCaAiaDoesNotContainIssuingCaUrl = result },
+	})
 }

--- a/lints/lint_sub_ca_aia_does_not_contain_ocsp_url.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_ocsp_url.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "Subordinate CA certificates authorityInformationAccess extension must contain the HTTP URL of the Issuing CA’s OCSP responder",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCaOcspUrl{}})
+		Test:          &subCaOcspUrl{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaAiaDoesNotContainOcspUrl = result },
+	})
 }

--- a/lints/lint_sub_ca_aia_missing.go
+++ b/lints/lint_sub_ca_aia_missing.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "Subordinate CA certificates must have a authorityInformationAccess extension.",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &caAiaMissing{}})
+		Test:          &caAiaMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaAiaMissing = result },
+	})
 }

--- a/lints/lint_sub_ca_certificate_policies_marked_critical.go
+++ b/lints/lint_sub_ca_certificate_policies_marked_critical.go
@@ -39,5 +39,9 @@ func init() {
 		Description:   "Subordinate CA certificates certificatePolicies extension should not be marked as critical",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCACertPolicyCrit{}})
+		Test:          &subCACertPolicyCrit{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.WSubCaCertificatePoliciesMarkedCritical = result
+		},
+	})
 }

--- a/lints/lint_sub_ca_certificate_policies_missing.go
+++ b/lints/lint_sub_ca_certificate_policies_missing.go
@@ -38,5 +38,7 @@ func init() {
 		Description:   "Subordinate CA certificates must have a certificatePolicies extension",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCACertPolicyMissing{}})
+		Test:          &subCACertPolicyMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaCertificatePoliciesMissing = result },
+	})
 }

--- a/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
@@ -40,5 +40,9 @@ func init() {
 		Description:   "Subordinate CA certificates cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service.",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCACRLDistNoUrl{}})
+		Test:          &subCACRLDistNoUrl{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.ESubCaCrlDistributionPointsDoesNotContainUrl = result
+		},
+	})
 }

--- a/lints/lint_sub_ca_crl_distribution_points_marked_critical.go
+++ b/lints/lint_sub_ca_crl_distribution_points_marked_critical.go
@@ -39,5 +39,9 @@ func init() {
 		Description:   "Subordinate CA certificates must not mark the cRLDistributionPoints extension as critical",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCACRLDistCrit{}})
+		Test:          &subCACRLDistCrit{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.ESubCaCrlDistributionPointsMarkedCritical = result
+		},
+	})
 }

--- a/lints/lint_sub_ca_crl_distribution_points_missing.go
+++ b/lints/lint_sub_ca_crl_distribution_points_missing.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "Subordinate CA certificates must have a cRLDistributionPoints extension",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCACRLDistMissing{}})
+		Test:          &subCACRLDistMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaCrlDistributionPointsMissing = result },
+	})
 }

--- a/lints/lint_sub_ca_eku_critical.go
+++ b/lints/lint_sub_ca_eku_critical.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "Subordinate CA certificate extkeyUsage extension should be marked non-critical if present.",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABV116Date,
-		Test:          &subCAEKUCrit{}})
+		Test:          &subCAEKUCrit{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WSubCaEkuCritical = result },
+	})
 }

--- a/lints/lint_sub_ca_name_constraints_not_critical.go
+++ b/lints/lint_sub_ca_name_constraints_not_critical.go
@@ -36,5 +36,7 @@ func init() {
 		Description:   "Subordinate CA certificate nameConstraints extension should be marked critical if present",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABV102Date,
-		Test:          &SubCANameConstraintsNotCritical{}})
+		Test:          &SubCANameConstraintsNotCritical{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WSubCaNameConstraintsNotCritical = result },
+	})
 }

--- a/lints/lint_sub_ca_no_dns_name_contstraints.go
+++ b/lints/lint_sub_ca_no_dns_name_contstraints.go
@@ -43,5 +43,7 @@ func init() {
 		Description:   "Subordanate CA certs must include in the name contraints extension either premitted dns names or prohibit the empty DNS name.",
 		Providence:    "CAB: 7.1.5",
 		EffectiveDate: util.CABV116Date,
-		Test:          &subCaBadDNSConstraint{}})
+		Test:          &subCaBadDNSConstraint{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaNoDnsNameConstraints = result },
+	})
 }

--- a/lints/lint_sub_ca_no_ip_name_contstraints.go
+++ b/lints/lint_sub_ca_no_ip_name_contstraints.go
@@ -59,5 +59,7 @@ func init() {
 		Description:   "Subordanate CA certs must include in the name contraints extension either premitted ip ranges or prohibit all ip addresses.",
 		Providence:    "CAB: 7.1.5",
 		EffectiveDate: util.CABV116Date,
-		Test:          &subCaBadIPConstraint{}})
+		Test:          &subCaBadIPConstraint{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaNoIpNameConstraints = result },
+	})
 }

--- a/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the Issuing CA’s certificate",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCertIssuerUrl{}})
+		Test:          &subCertIssuerUrl{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertAiaDoesNotContainIssuingCaUrl = result },
+	})
 }

--- a/lints/lint_sub_cert_aia_does_not_contain_ocsp_url.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_ocsp_url.go
@@ -42,5 +42,7 @@ func init() {
 		Description:   "Subscriber certificates authorityInformationAccess extension must contain the HTTP URL of the Issuing CA’s OCSP responder",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCertOcspUrl{}})
+		Test:          &subCertOcspUrl{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertAiaDoesNotContainOcspUrl = result },
+	})
 }

--- a/lints/lint_sub_cert_aia_missing.go
+++ b/lints/lint_sub_cert_aia_missing.go
@@ -42,5 +42,7 @@ func init() {
 		Description:   "Subscriber certificates must have a authorityInformationAccess extension.",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCertAiaMissing{}})
+		Test:          &subCertAiaMissing{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertAiaMissing = result },
+	})
 }

--- a/lints/lint_sub_cert_cert_policy_empty.go
+++ b/lints/lint_sub_cert_cert_policy_empty.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "Subscriber certificates must contain at least one policy identifier that indicates adherance to CAB standards",
 		Providence:    "CAB: 7.1.6.4",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCertPolicyEmpty{}})
+		Test:          &subCertPolicyEmpty{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertCertPolicyEmpty = result },
+	})
 }

--- a/lints/lint_sub_cert_certificate_policies_marked_critical.go
+++ b/lints/lint_sub_cert_certificate_policies_marked_critical.go
@@ -38,5 +38,9 @@ func init() {
 		Description:   "Subscriber certificate should have policies extension marked non-critical",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCertPolicyCrit{}})
+		Test:          &subCertPolicyCrit{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.WSubCertCertificatePoliciesMarkedCritical = result
+		},
+	})
 }

--- a/lints/lint_sub_cert_certificate_policies_missing.go
+++ b/lints/lint_sub_cert_certificate_policies_missing.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "Subscriber certificates should have certificates policies extension present",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCertPolicy{}})
+		Test:          &subCertPolicy{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertCertificatePoliciesMissing = result },
+	})
 }

--- a/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
@@ -43,5 +43,9 @@ func init() {
 		Description:   "Subscriber certificate cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service.",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCRLDistNoURL{}})
+		Test:          &subCRLDistNoURL{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.ESubCertCrlDistributionPointsDoesNotContainUrl = result
+		},
+	})
 }

--- a/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
+++ b/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
@@ -42,5 +42,9 @@ func init() {
 		Description:   "Subscriber certificate cRLDistributionPoints extension must not be marked critical if present",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCrlDistCrit{}})
+		Test:          &subCrlDistCrit{},
+		updateReport: func(report *LintReport, result ResultStruct) {
+			report.ESubCertCrlDistributionPointsMarkedCritical = result
+		},
+	})
 }

--- a/lints/lint_sub_cert_eku_extra_values.go
+++ b/lints/lint_sub_cert_eku_extra_values.go
@@ -48,5 +48,7 @@ func init() {
 		Description:   "Subscriber certificates should have only id-kp-serverAuth, id-kp-clientAuth, or id-kp-emailProtection in extKeyUsage. Anything should not be included.",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subExtKeyUsageLegalUsage{}})
+		Test:          &subExtKeyUsageLegalUsage{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WSubCertEkuExtraValues = result },
+	})
 }

--- a/lints/lint_sub_cert_eku_missing.go
+++ b/lints/lint_sub_cert_eku_missing.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "Subscriber certificates must have the extended key usage extension present",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subExtKeyUsage{}})
+		Test:          &subExtKeyUsage{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertEkuMissing = result },
+	})
 }

--- a/lints/lint_sub_cert_eku_server_auth_client_auth_missing.go
+++ b/lints/lint_sub_cert_eku_server_auth_client_auth_missing.go
@@ -43,5 +43,7 @@ func init() {
 		Description:   "Subscriber certificates must have have either id-kp-serverAuth or id-kp-clientAuth or both present in extKeyUsage",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subExtKeyUsageClientOrServer{}})
+		Test:          &subExtKeyUsageClientOrServer{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertEkuServerAuthClientAuthMissing = result },
+	})
 }

--- a/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
@@ -39,5 +39,7 @@ func init() {
 		Description:   "Subscriber certificates keyUsage extension keyCertSign bit must not be set",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCertKeyUsageBitSet{}})
+		Test:          &subCertKeyUsageBitSet{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertKeyUsageCertSignBitSet = result },
+	})
 }

--- a/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "Subscriber certificates keyUsage extension cRLSign bit must not be set",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subCrlSignAllowed{}})
+		Test:          &subCrlSignAllowed{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertKeyUsageCrlSignBitSet = result },
+	})
 }

--- a/lints/lint_sub_cert_or_sub_ca_using_sha1.go
+++ b/lints/lint_sub_cert_or_sub_ca_using_sha1.go
@@ -43,5 +43,7 @@ func init() {
 		Description:   "Subscriber certificates and subordinate CA certificates must not use the SHA-1 hash algorithm on a certificate with a NotBefore date after 1 Jan 2016",
 		Providence:    "CAB: 7.1.3",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &sigAlgTestsSHA1{}})
+		Test:          &sigAlgTestsSHA1{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertOrSubCaUsingSha1 = result },
+	})
 }

--- a/lints/lint_sub_cert_sha1_expiration_too_long.go
+++ b/lints/lint_sub_cert_sha1_expiration_too_long.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "Subscriber certificates using the SHA1 algorithm should not have an expiration date greater than 1 Jan 2017",
 		Providence:    "CAB: 7.1.3",
 		EffectiveDate: time.Date(2015, time.January, 16, 0, 0, 0, 0, time.UTC),
-		Test:          &sha1ExpireLong{}})
+		Test:          &sha1ExpireLong{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.WSubCertSha1ExpirationTooLong = result },
+	})
 }

--- a/lints/lint_subject_common_name_disallowed.go
+++ b/lints/lint_subject_common_name_disallowed.go
@@ -47,5 +47,7 @@ func init() {
 		Description:   "If present Common name MUST contain a single IP address or Fully‐Qualified Domain Name that is one of the values contained in the Certificate’s subjectAltName extension",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &BadCommonName{}})
+		Test:          &BadCommonName{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectCommonNameDisallowed = result },
+	})
 }

--- a/lints/lint_subject_common_name_included.go
+++ b/lints/lint_subject_common_name_included.go
@@ -37,5 +37,7 @@ func init() {
 		Description:   "Use of the common name field is discouraged.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &commonNames{}})
+		Test:          &commonNames{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ISubjectCommonNameIncluded = result },
+	})
 }

--- a/lints/lint_subject_common_name_not_from_san.go
+++ b/lints/lint_subject_common_name_not_from_san.go
@@ -49,5 +49,7 @@ func init() {
 		Description:   "The common name field must include only names from the SAN extension.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subjectCommonNameNotFromSAN{}})
+		Test:          &subjectCommonNameNotFromSAN{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectCommonNameNotFromSan = result },
+	})
 }

--- a/lints/lint_subject_contains_noninformational_value.go
+++ b/lints/lint_subject_contains_noninformational_value.go
@@ -60,5 +60,7 @@ func init() {
 		Description:   "Subject name fields must not contain '.','-',' ' or any other indication that the field has been ommited.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &illegalChar{}})
+		Test:          &illegalChar{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectContainsNoninformationalValue = result },
+	})
 }

--- a/lints/lint_subject_contains_reserved_ip.go
+++ b/lints/lint_subject_contains_reserved_ip.go
@@ -46,5 +46,7 @@ func init() {
 		Description:   "Certs and expiring after 2015-11-01 must not contain a reserved ip address in the common name field.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &subjectReservedIP{}})
+		Test:          &subjectReservedIP{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectContainsReservedIp = result },
+	})
 }

--- a/lints/lint_subject_country_not_iso.go
+++ b/lints/lint_subject_country_not_iso.go
@@ -42,5 +42,7 @@ func init() {
 		Description:   "The country name field must contain the two-letter ISO code for the country or XX.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &countryNotIso{}})
+		Test:          &countryNotIso{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectCountryNotIso = result },
+	})
 }

--- a/lints/lint_subject_empty_without_san.go
+++ b/lints/lint_subject_empty_without_san.go
@@ -51,5 +51,7 @@ func init() {
 		Description:   "CAs must support subject alternative name if the subject field is an empty sequence.",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &emptyWithoutSAN{}})
+		Test:          &emptyWithoutSAN{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectEmptyWithoutSan = result },
+	})
 }

--- a/lints/lint_subject_info_access_marked_critical.go
+++ b/lints/lint_subject_info_access_marked_critical.go
@@ -35,5 +35,7 @@ func init() {
 		Description:   "Conforming CAs must mark the Subject Info Access extension as non-critical.",
 		Providence:    "RFC 5280: 4.2.2.2",
 		EffectiveDate: util.RFC3280Date,
-		Test:          &siaCrit{}})
+		Test:          &siaCrit{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectInfoAccessMarkedCritical = result },
+	})
 }

--- a/lints/lint_subject_locality_without_org.go
+++ b/lints/lint_subject_locality_without_org.go
@@ -41,5 +41,7 @@ func init() {
 		Description:   "The locality field must not be included without an organization name.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &localNoOrg{}})
+		Test:          &localNoOrg{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectLocalityWithoutOrg = result },
+	})
 }

--- a/lints/lint_subject_not_dn.go
+++ b/lints/lint_subject_not_dn.go
@@ -42,5 +42,7 @@ func init() {
 		Description:   "When not empty, the subject field must be a distinguished name",
 		Providence:    "RFC 5280: 4.1.2.6",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &subjectDN{}})
+		Test:          &subjectDN{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectNotDn = result },
+	})
 }

--- a/lints/lint_subject_org_without_country.go
+++ b/lints/lint_subject_org_without_country.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "The organization name field must not be included without a country name.",
 		Providence:    "CAB: 7.1.4.2.2 (d&e)",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &orgNoCountry{}})
+		Test:          &orgNoCountry{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectOrgWithoutCountry = result },
+	})
 }

--- a/lints/lint_subject_org_without_locality_or_province.go
+++ b/lints/lint_subject_org_without_locality_or_province.go
@@ -36,5 +36,7 @@ func init() {
 		Description:   "If organiation is included, either stateOrProvince or locality must be included.",
 		Providence:    "CAB: 7.1.4.2.2 (d&e)",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &orgNoLocalOrProvince{}})
+		Test:          &orgNoLocalOrProvince{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectOrgWithoutLocalityOrProvince = result },
+	})
 }

--- a/lints/lint_subject_postal_without_org.go
+++ b/lints/lint_subject_postal_without_org.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "The postal code must not be included without an organization name.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &postalNoOrg{}})
+		Test:          &postalNoOrg{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectPostalWithoutOrg = result },
+	})
 }

--- a/lints/lint_subject_province_without_org.go
+++ b/lints/lint_subject_province_without_org.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "The stateOrProvince name must not be included without an organization name.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &provinceNoOrg{}})
+		Test:          &provinceNoOrg{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectProvinceWithoutOrg = result },
+	})
 }

--- a/lints/lint_subject_street_without_org.go
+++ b/lints/lint_subject_street_without_org.go
@@ -40,5 +40,7 @@ func init() {
 		Description:   "The street address field must not be included without an organization name.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
-		Test:          &streetNoOrg{}})
+		Test:          &streetNoOrg{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectStreetWithoutOrg = result },
+	})
 }

--- a/lints/lint_utc_time_does_not_include_seconds.go
+++ b/lints/lint_utc_time_does_not_include_seconds.go
@@ -62,5 +62,7 @@ func init() {
 		Description:   "UTCTime values must include seconds",
 		Providence:    "RFC 5280: 4.1.2.5.1",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &utcNoSecond{}})
+		Test:          &utcNoSecond{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EUtcTimeDoesNotIncludeSeconds = result },
+	})
 }

--- a/lints/lint_utc_time_not_in_zulu.go
+++ b/lints/lint_utc_time_not_in_zulu.go
@@ -74,5 +74,7 @@ func init() {
 		Description:   "UTCTime values MUST be expressed in Greenwich Mean Time (Zulu)",
 		Providence:    "RFC 5280: 4.1.2.5.1",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &utcTimeGMT{}})
+		Test:          &utcTimeGMT{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EUtcTimeNotInZulu = result },
+	})
 }

--- a/lints/lint_validity_time_not_positive.go
+++ b/lints/lint_validity_time_not_positive.go
@@ -35,5 +35,7 @@ func init() {
 		Description:   "Certificates MUST have a positive time for which they are valid",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
-		Test:          &validityNegative{}})
+		Test:          &validityNegative{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EValidityTimeNotPositive = result },
+	})
 }

--- a/lints/lint_wrong_time_format_pre2050.go
+++ b/lints/lint_wrong_time_format_pre2050.go
@@ -55,5 +55,7 @@ func init() {
 		Description:   "Certificates with validity through the year 2049 must be encoded in UTC time",
 		Providence:    "RFC 5280: 4.1.2.5",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &generalizedPre2050{}})
+		Test:          &generalizedPre2050{},
+		updateReport:  func(report *LintReport, result ResultStruct) { report.EWrongTimeFormatPre2050 = result },
+	})
 }

--- a/util/fqdn_test.go
+++ b/util/fqdn_test.go
@@ -31,7 +31,7 @@ func TestIsFQDNQuestionMarkFQDN(t *testing.T) {
 }
 
 func TestIsFQDNQuestionMarkIncorrectPlaceFQDN(t *testing.T) {
-	domain := "?.?.abc.?com"
+	domain := "?.?.abc?.com"
 	expected := false
 	actual := IsFQDN(domain)
 	if expected != actual {

--- a/zlint/zlint.go
+++ b/zlint/zlint.go
@@ -13,7 +13,7 @@ import (
 )
 
 //Calls all other checks on parsed certs producing version
-func ZLintResultTestHandler(cert *x509.Certificate) (*lints.ZLintResult, error) {
+func ZLintResultTestHandler(cert *x509.Certificate) (*lints.ZLintResult) {
 	if cert == nil {
 		return nil, errors.New("zlint: nil pointer passed in, no data returned")
 	}
@@ -24,7 +24,7 @@ func ZLintResultTestHandler(cert *x509.Certificate) (*lints.ZLintResult, error) 
 	ZLintResult.ZLintVersion = lints.ZLintVersion
 	ZLintResult.Timestamp = time.Now().Unix()
 	ZLintResult.ZLints = &ZLintReport
-	return &ZLintResult, nil
+	return &ZLintResult
 }
 
 //Calls all other checks on parsed certs

--- a/zlint/zlint.go
+++ b/zlint/zlint.go
@@ -15,7 +15,7 @@ import (
 //Calls all other checks on parsed certs producing version
 func ZLintResultTestHandler(cert *x509.Certificate) (*lints.ZLintResult) {
 	if cert == nil {
-		return nil, errors.New("zlint: nil pointer passed in, no data returned")
+		return nil
 	}
 	//run all tests
 	ZLintResult := lints.ZLintResult{}

--- a/zlint/zlint.go
+++ b/zlint/zlint.go
@@ -19,15 +19,16 @@ func ZLintResultTestHandler(cert *x509.Certificate) (*lints.ZLintResult, error) 
 	}
 	//run all tests
 	var ZLintResult lints.ZLintResult
-	var ZLintOut map[string]string = make(map[string]string)
+	var ZLintOut lints.ZLints
+
 	for _, l := range lints.Lints {
 		result, err := l.ExecuteTest(cert)
 		if err != nil {
 			return &ZLintResult, err
 		}
-		ZLintOut[l.Name] = lints.EnumToString(result.Result)
+		lints.UpdateLintStruct(l.Name, &result, &ZLintOut)
 	}
-	ZLintResult.ZLints = ZLintOut
+	ZLintResult.ZLints = &ZLintOut
 	ZLintResult.ZLintVersion = lints.ZLintVersion
 	ZLintResult.Timestamp = time.Now().Unix()
 	return &ZLintResult, nil

--- a/zlint/zlint.go
+++ b/zlint/zlint.go
@@ -19,16 +19,8 @@ func ZLintResultTestHandler(cert *x509.Certificate) (*lints.ZLintResult, error) 
 	}
 	//run all tests
 	var ZLintResult lints.ZLintResult
-	var ZLintOut lints.ZLints
-
-	for _, l := range lints.Lints {
-		result, err := l.ExecuteTest(cert)
-		if err != nil {
-			return &ZLintResult, err
-		}
-		lints.UpdateLintStruct(l.Name, &result, &ZLintOut)
-	}
-	ZLintResult.ZLints = &ZLintOut
+	var ZLintReport lints.LintReport
+	ZLintReport.Execute(cert)
 	ZLintResult.ZLintVersion = lints.ZLintVersion
 	ZLintResult.Timestamp = time.Now().Unix()
 	return &ZLintResult, nil

--- a/zlint/zlint.go
+++ b/zlint/zlint.go
@@ -9,7 +9,29 @@ import (
 	"errors"
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/lints"
+	"time"
 )
+
+//Calls all other checks on parsed certs producing version
+func ZLintResultTestHandler(cert *x509.Certificate) (*lints.ZLintResult, error) {
+	if cert == nil {
+		return nil, errors.New("zlint: nil pointer passed in, no data returned")
+	}
+	//run all tests
+	var ZLintResult lints.ZLintResult
+	var ZLintOut map[string]string = make(map[string]string)
+	for _, l := range lints.Lints {
+		result, err := l.ExecuteTest(cert)
+		if err != nil {
+			return &ZLintResult, err
+		}
+		ZLintOut[l.Name] = lints.EnumToString(result.Result)
+	}
+	ZLintResult.ZLints = ZLintOut
+	ZLintResult.ZLintVersion = lints.ZLintVersion
+	ZLintResult.Timestamp = time.Now().Unix()
+	return &ZLintResult, nil
+}
 
 //Calls all other checks on parsed certs
 func ParsedTestHandler(cert *x509.Certificate) (map[string]string, error) {

--- a/zlint/zlint.go
+++ b/zlint/zlint.go
@@ -18,11 +18,12 @@ func ZLintResultTestHandler(cert *x509.Certificate) (*lints.ZLintResult, error) 
 		return nil, errors.New("zlint: nil pointer passed in, no data returned")
 	}
 	//run all tests
-	var ZLintResult lints.ZLintResult
-	var ZLintReport lints.LintReport
+	ZLintResult := lints.ZLintResult{}
+	ZLintReport := lints.LintReport{}
 	ZLintReport.Execute(cert)
 	ZLintResult.ZLintVersion = lints.ZLintVersion
 	ZLintResult.Timestamp = time.Now().Unix()
+	ZLintResult.ZLints = &ZLintReport
 	return &ZLintResult, nil
 }
 


### PR DESCRIPTION
Based on a conversation w/ @zakird , we want to keep tracking of lints in a struct rather than a dynamic map so we catch errors at compile time rather than runtime. 

Looking for feedback on the best way to do this. I don't want to couple the lint code to a specific struct field, so right now I'm just checking the name and updating the appropriate field, but not sure if there's a better to handle this. 