### PR TITLE
Add an example of binding Lints to struct fields

### DIFF
--- a/lints/lint_basic_constraints_not_critical.go
+++ b/lints/lint_basic_constraints_not_critical.go
@@ -51,5 +51,7 @@ func init() {
 		Description:   "Conforming CAs must mark Basic Constraints as critical when it is included in CA certs",
 		Providence:    "RFC 5280: 4.2.1.9",
 		EffectiveDate: util.RFC2459Date,
-		Test:          &basicConstCrit{}})
+		Test:          &basicConstCrit{},
+		updateReport:  func(report *LintReport, result *ResultStruct) { report.EBasicConstraintsNotCritical = result },
+	})
 }


### PR DESCRIPTION
This isn't meant to be merged, but is just an example of one way to achieve what I think you're trying to achieve in #35.

There's some wiggle room here with the details, for example the `updateReport` function could become a private interface with a private single function which would have to be defined by each lint. 

Alternatively, you could make `Result` and interface and declare the `updateReport` there. Then each Lint would implement its own `Result` capable of updating a `LintReport` with a `ResultStruct`. This might end up being a lot of duplicate code in each individual Lint, although perhaps embedded structs would make this easier?