### PR TITLE
adding check for sub cert lints

### DIFF
--- a/lints/lint_sub_cert_certificate_policies_marked_critical.go
+++ b/lints/lint_sub_cert_certificate_policies_marked_critical.go
@@ -20,7 +20,7 @@ func (l *subCertPolicyCrit) Initialize() error {
 }
 
 func (l *subCertPolicyCrit) CheckApplies(c *x509.Certificate) bool {
-	return util.IsExtInCert(c, util.CertPolicyOID)
+	return util.IsExtInCert(c, util.CertPolicyOID) && !util.IsCaCert(c)
 }
 
 func (l *subCertPolicyCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
@@ -24,7 +24,7 @@ func (l *subCRLDistNoURL) Initialize() error {
 
 func (l *subCRLDistNoURL) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return util.IsExtInCert(c, util.CrlDistOID)
+	return util.IsExtInCert(c, util.CrlDistOID) && !util.IsCaCert()
 }
 
 func (l *subCRLDistNoURL) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
@@ -24,7 +24,7 @@ func (l *subCRLDistNoURL) Initialize() error {
 
 func (l *subCRLDistNoURL) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return util.IsExtInCert(c, util.CrlDistOID) && !util.IsCaCert()
+	return util.IsExtInCert(c, util.CrlDistOID) && !util.IsCaCert(c)
 }
 
 func (l *subCRLDistNoURL) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
+++ b/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
@@ -23,7 +23,7 @@ func (l *subCrlDistCrit) Initialize() error {
 
 func (l *subCrlDistCrit) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return util.IsExtInCert(c, util.CrlDistOID)
+	return util.IsExtInCert(c, util.CrlDistOID) && !util.IsCaCert(c)
 }
 
 func (l *subCrlDistCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_eku_extra_values.go
+++ b/lints/lint_sub_cert_eku_extra_values.go
@@ -22,7 +22,7 @@ func (l *subExtKeyUsageLegalUsage) Initialize() error {
 
 func (l *subExtKeyUsageLegalUsage) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return c.ExtKeyUsage != nil
+	return c.ExtKeyUsage != nil && !util.IsCaCert(c)
 }
 
 func (l *subExtKeyUsageLegalUsage) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_eku_missing.go
+++ b/lints/lint_sub_cert_eku_missing.go
@@ -22,7 +22,7 @@ func (l *subExtKeyUsage) Initialize() error {
 
 func (l *subExtKeyUsage) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return true
+	return !util.IsCaCert(c)
 }
 
 func (l *subExtKeyUsage) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_eku_server_auth_client_auth_missing.go
+++ b/lints/lint_sub_cert_eku_server_auth_client_auth_missing.go
@@ -22,7 +22,7 @@ func (l *subExtKeyUsageClientOrServer) Initialize() error {
 
 func (l *subExtKeyUsageClientOrServer) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return c.ExtKeyUsage != nil
+	return c.ExtKeyUsage != nil && !util.IsCaCert(c)
 }
 
 func (l *subExtKeyUsageClientOrServer) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
@@ -21,7 +21,7 @@ func (l *subCertKeyUsageBitSet) Initialize() error {
 
 func (l *subCertKeyUsageBitSet) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return util.IsExtInCert(c, util.KeyUsageOID)
+	return util.IsExtInCert(c, util.KeyUsageOID) && !util.IsCaCert(c)
 }
 
 func (l *subCertKeyUsageBitSet) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
@@ -22,7 +22,7 @@ func (l *subCrlSignAllowed) Initialize() error {
 
 func (l *subCrlSignAllowed) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return util.IsExtInCert(c, util.KeyUsageOID)
+	return util.IsExtInCert(c, util.KeyUsageOID) && !util.IsCaCert(c)
 }
 
 func (l *subCrlSignAllowed) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_or_sub_ca_using_sha1.go
+++ b/lints/lint_sub_cert_or_sub_ca_using_sha1.go
@@ -20,7 +20,7 @@ func (l *sigAlgTestsSHA1) Initialize() error {
 
 func (l *sigAlgTestsSHA1) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return !util.IsCaCert(c)
+	return true
 }
 
 func (l *sigAlgTestsSHA1) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_or_sub_ca_using_sha1.go
+++ b/lints/lint_sub_cert_or_sub_ca_using_sha1.go
@@ -20,7 +20,7 @@ func (l *sigAlgTestsSHA1) Initialize() error {
 
 func (l *sigAlgTestsSHA1) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return true
+	return !util.IsCaCert(c)
 }
 
 func (l *sigAlgTestsSHA1) RunTest(c *x509.Certificate) (ResultStruct, error) {


### PR DESCRIPTION
Build error is fixed by #35. This fixes lints that do not properly check if they are CA certs before checking sub_cert specific tests. 