### PR TITLE
ignoring error because its in the damn lint itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ go:
 - 1.8.1
 before_install:
 - go get gopkg.in/check.v1
-- go get github.com/zmap/zcrypto
 - go get golang.org/x/text
 before_script:
 - mkdir -p $GOPATH/src/github.com/zmap

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.8.2
+- 1.8.1
 before_install:
 - go get gopkg.in/check.v1
 - go get github.com/zmap/zcrypto

--- a/lints/base.go
+++ b/lints/base.go
@@ -220,10 +220,8 @@ type LintReport struct {
 
 func (result *ZLintResult) Execute(cert *x509.Certificate) error {
 	for _, l := range Lints {
-		res, err := l.ExecuteTest(cert)
-		if err != nil {
-			return err
-		}
+		res, _ := l.ExecuteTest(cert)
+		l.updateReport(result.ZLint, res)
 		l.updateReport(result.ZLint, res)
 		result.updateErrorStatePresent(res)
 	}

--- a/lints/base.go
+++ b/lints/base.go
@@ -222,7 +222,6 @@ func (result *ZLintResult) Execute(cert *x509.Certificate) error {
 	for _, l := range Lints {
 		res, _ := l.ExecuteTest(cert)
 		l.updateReport(result.ZLint, res)
-		l.updateReport(result.ZLint, res)
 		result.updateErrorStatePresent(res)
 	}
 	return nil


### PR DESCRIPTION
Some lints (<5%) return an `error` in the call to ExecuteTest along with their ZLintResult status (which is Fatal). We use Fatal to mark these anyway, so I shouldn't be throwing the error up. An issue I need to add is to fix the API call to that function in the future.