### PR TITLE
Lints that only apply to subscriber certs should not apply to CA certs

### DIFF
--- a/lints/lint_cab_dv_conflicts_with_locality.go
+++ b/lints/lint_cab_dv_conflicts_with_locality.go
@@ -18,7 +18,7 @@ func (l *certPolicyConflictsWithLocality) Initialize() error {
 }
 
 func (l *certPolicyConflictsWithLocality) CheckApplies(cert *x509.Certificate) bool {
-	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRDomainValidatedOID)
+	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRDomainValidatedOID) && !util.IsCaCert(cert)
 }
 
 func (l *certPolicyConflictsWithLocality) RunTest(cert *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_cab_dv_conflicts_with_org.go
+++ b/lints/lint_cab_dv_conflicts_with_org.go
@@ -18,7 +18,7 @@ func (l *certPolicyConflictsWithOrg) Initialize() error {
 }
 
 func (l *certPolicyConflictsWithOrg) CheckApplies(cert *x509.Certificate) bool {
-	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRDomainValidatedOID)
+	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRDomainValidatedOID) && !util.IsCaCert(cert)
 }
 
 func (l *certPolicyConflictsWithOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_cab_dv_conflicts_with_postal.go
+++ b/lints/lint_cab_dv_conflicts_with_postal.go
@@ -18,7 +18,7 @@ func (l *certPolicyConflictsWithPostal) Initialize() error {
 }
 
 func (l *certPolicyConflictsWithPostal) CheckApplies(cert *x509.Certificate) bool {
-	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRDomainValidatedOID)
+	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRDomainValidatedOID) && !util.IsCaCert(cert)
 }
 
 func (l *certPolicyConflictsWithPostal) RunTest(cert *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_cab_dv_conflicts_with_province.go
+++ b/lints/lint_cab_dv_conflicts_with_province.go
@@ -18,7 +18,7 @@ func (l *certPolicyConflictsWithProvince) Initialize() error {
 }
 
 func (l *certPolicyConflictsWithProvince) CheckApplies(cert *x509.Certificate) bool {
-	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRDomainValidatedOID)
+	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRDomainValidatedOID) && !util.IsCaCert(cert)
 }
 
 func (l *certPolicyConflictsWithProvince) RunTest(cert *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_cab_dv_conflicts_with_street.go
+++ b/lints/lint_cab_dv_conflicts_with_street.go
@@ -18,7 +18,7 @@ func (l *certPolicyConflictsWithStreet) Initialize() error {
 }
 
 func (l *certPolicyConflictsWithStreet) CheckApplies(cert *x509.Certificate) bool {
-	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRDomainValidatedOID)
+	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRDomainValidatedOID) && !util.IsCaCert(cert)
 }
 
 func (l *certPolicyConflictsWithStreet) RunTest(cert *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_cab_iv_requires_personal_name.go
+++ b/lints/lint_cab_iv_requires_personal_name.go
@@ -17,7 +17,7 @@ func (l *CertPolicyRequiresPersonalName) Initialize() error {
 }
 
 func (l *CertPolicyRequiresPersonalName) CheckApplies(cert *x509.Certificate) bool {
-	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRIndividualValidatedOID)
+	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRIndividualValidatedOID) && !util.IsCaCert(cert)
 }
 
 func (l *CertPolicyRequiresPersonalName) RunTest(cert *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_cab_ov_requires_org.go
+++ b/lints/lint_cab_ov_requires_org.go
@@ -17,7 +17,7 @@ func (l *CertPolicyRequiresOrg) Initialize() error {
 }
 
 func (l *CertPolicyRequiresOrg) CheckApplies(cert *x509.Certificate) bool {
-	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BROrganizationValidatedOID)
+	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BROrganizationValidatedOID) && !util.IsCaCert(cert)
 }
 
 func (l *CertPolicyRequiresOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_ext_san_missing.go
+++ b/lints/lint_ext_san_missing.go
@@ -22,7 +22,7 @@ func (l *SANMissing) Initialize() error {
 }
 
 func (l *SANMissing) CheckApplies(c *x509.Certificate) bool {
-	return true
+	return !util.IsCaCert(c)
 }
 
 func (l *SANMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
@@ -36,7 +36,7 @@ func (l *SANMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_missing",
-		Description:   "Certificates must contain the Subject Alternate Name extension.",
+		Description:   "Subscriber certificates must contain the Subject Alternate Name extension.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANMissing{},

--- a/lints/lint_sub_cert_eku_missing.go
+++ b/lints/lint_sub_cert_eku_missing.go
@@ -22,7 +22,7 @@ func (l *subExtKeyUsage) Initialize() error {
 
 func (l *subExtKeyUsage) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return true
+	return !util.IsCaCert(c)
 }
 
 func (l *subExtKeyUsage) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
@@ -21,7 +21,7 @@ func (l *subCertKeyUsageBitSet) Initialize() error {
 
 func (l *subCertKeyUsageBitSet) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return util.IsExtInCert(c, util.KeyUsageOID)
+	return util.IsExtInCert(c, util.KeyUsageOID) && !util.IsCaCert(c)
 }
 
 func (l *subCertKeyUsageBitSet) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
@@ -22,7 +22,7 @@ func (l *subCrlSignAllowed) Initialize() error {
 
 func (l *subCrlSignAllowed) CheckApplies(c *x509.Certificate) bool {
 	// Add conditions for application here
-	return util.IsExtInCert(c, util.KeyUsageOID)
+	return util.IsExtInCert(c, util.KeyUsageOID) && !util.IsCaCert(c)
 }
 
 func (l *subCrlSignAllowed) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_subject_common_name_disallowed.go
+++ b/lints/lint_subject_common_name_disallowed.go
@@ -24,7 +24,7 @@ func (l *BadCommonName) Initialize() error {
 }
 
 func (l *BadCommonName) CheckApplies(c *x509.Certificate) bool {
-	return len(c.Subject.CommonName) != 0
+	return len(c.Subject.CommonName) != 0 && !util.IsCaCert(c)
 }
 
 func (l *BadCommonName) RunTest(c *x509.Certificate) (ResultStruct, error) {
@@ -44,7 +44,7 @@ func (l *BadCommonName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_common_name_disallowed",
-		Description:   "If present Common name MUST contain a single IP address or Fully‐Qualified Domain Name that is one of the values contained in the Certificate’s subjectAltName extension",
+		Description:   "For subscriber certitifcates, if present, common name MUST contain a single IP address or Fully‐Qualified Domain Name that is one of the values contained in the Certificate’s subjectAltName extension",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &BadCommonName{},

--- a/lints/lint_subject_common_name_not_from_san.go
+++ b/lints/lint_subject_common_name_not_from_san.go
@@ -22,7 +22,7 @@ func (l *subjectCommonNameNotFromSAN) Initialize() error {
 }
 
 func (l *subjectCommonNameNotFromSAN) CheckApplies(c *x509.Certificate) bool {
-	return c.Subject.CommonName != ""
+	return c.Subject.CommonName != "" && !util.IsCaCert(c)
 }
 
 func (l *subjectCommonNameNotFromSAN) RunTest(c *x509.Certificate) (ResultStruct, error) {
@@ -46,7 +46,7 @@ func (l *subjectCommonNameNotFromSAN) RunTest(c *x509.Certificate) (ResultStruct
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_common_name_not_from_san",
-		Description:   "The common name field must include only names from the SAN extension.",
+		Description:   "For subscriber certificate, the common name field must include only names from the SAN extension.",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subjectCommonNameNotFromSAN{},

--- a/lints/lint_subject_org_without_locality_or_province.go
+++ b/lints/lint_subject_org_without_locality_or_province.go
@@ -19,7 +19,7 @@ func (l *orgNoLocalOrProvince) Initialize() error {
 }
 
 func (l *orgNoLocalOrProvince) CheckApplies(cert *x509.Certificate) bool {
-	return true
+	return !util.IsCaCert(cert)
 }
 
 func (l *orgNoLocalOrProvince) RunTest(cert *x509.Certificate) (ResultStruct, error) {
@@ -33,7 +33,7 @@ func (l *orgNoLocalOrProvince) RunTest(cert *x509.Certificate) (ResultStruct, er
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_org_without_locality_or_province",
-		Description:   "If organiation is included, either stateOrProvince or locality must be included.",
+		Description:   "For subscriber certificates, if organization is included, either stateOrProvince or locality must be included.",
 		Providence:    "CAB: 7.1.4.2.2 (d&e)",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &orgNoLocalOrProvince{},


### PR DESCRIPTION
Many lints don't properly check if a lint applies to a CA cert; this adds that check to the offending lints.