### PR TITLE
Cosmetic Fixes to Lint Descriptions

### DIFF
--- a/lints/lint_basic_constraints_not_critical.go
+++ b/lints/lint_basic_constraints_not_critical.go
@@ -48,7 +48,7 @@ func (l *basicConstCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_basic_constraints_not_critical",
-		Description:   "Conforming CAs must mark Basic Constraints as critical when it is included in CA certs",
+		Description:   "Conforming CAs MUST mark Basic Constraints as critical when included in CA certficates",
 		Providence:    "RFC 5280: 4.2.1.9",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &basicConstCrit{},

--- a/lints/lint_ca_country_name_invalid.go
+++ b/lints/lint_ca_country_name_invalid.go
@@ -42,7 +42,7 @@ func (l *caCountryNameInvalid) RunTest(c *x509.Certificate) (ResultStruct, error
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_country_name_invalid",
-		Description:   "Root & Subordinate CA certificates must have a two-letter country code that is in ISO 3166-1",
+		Description:   "Root and Subordinate CA certificates MUST have a two-letter country code specified in ISO 3166-1",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caCountryNameInvalid{},

--- a/lints/lint_ca_country_name_missing.go
+++ b/lints/lint_ca_country_name_missing.go
@@ -37,7 +37,7 @@ func (l *caCountryNameMissing) RunTest(c *x509.Certificate) (ResultStruct, error
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_country_name_missing",
-		Description:   "Root & Subordinate CA certificates must have a countryName present in subject information",
+		Description:   "Root and Subordinate CA certificates MUST have a countryName present in subject information",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caCountryNameMissing{},

--- a/lints/lint_ca_crl_sign_not_set.go
+++ b/lints/lint_ca_crl_sign_not_set.go
@@ -36,7 +36,7 @@ func (l *caCRLSignNotSet) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_crl_sign_not_set",
-		Description:   "Root & Subordinate CA certificate keyUsage extension's crlSign bit must be set",
+		Description:   "Root and Subordinate CA certificate keyUsage extension's crlSign bit MUST be set",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caCRLSignNotSet{},

--- a/lints/lint_ca_digital_signature_not_set.go
+++ b/lints/lint_ca_digital_signature_not_set.go
@@ -36,7 +36,7 @@ func (l *caDigSignNotSet) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "n_ca_digital_signature_not_set",
-		Description:   "Root & Subordinate CA Certificates that wish to use their private key for signing OCSP responses will not be able to with out digital signature set",
+		Description:   "Root and Subordinate CA Certificates that wish to use their private key for signing OCSP responses will not be able to without their digital signature set",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caDigSignNotSet{},

--- a/lints/lint_ca_key_cert_sign_not_set.go
+++ b/lints/lint_ca_key_cert_sign_not_set.go
@@ -36,7 +36,7 @@ func (l *caKeyCertSignNotSet) RunTest(c *x509.Certificate) (ResultStruct, error)
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_key_cert_sign_not_set",
-		Description:   "Root & Subordinate CA certificate keyUsage extension's keyCertSign bit must be set",
+		Description:   "Root and Subordinate CA certificate keyUsage extension's keyCertSign bit MUST be set",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caKeyCertSignNotSet{},

--- a/lints/lint_ca_key_usage_missing.go
+++ b/lints/lint_ca_key_usage_missing.go
@@ -38,7 +38,7 @@ func (l *caKeyUsageMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_key_usage_missing",
-		Description:   "Root & Subordinate CA certificate keyUsage extension must be present",
+		Description:   "Root and Subordinate CA certificate keyUsage extension MUST be present",
 		Providence:    "CAB: 7.1.2.1, RFC 5280: 4.2.1.3",
 		EffectiveDate: util.RFC3280Date,
 		Test:          &caKeyUsageMissing{},

--- a/lints/lint_ca_key_usage_not_critical.go
+++ b/lints/lint_ca_key_usage_not_critical.go
@@ -36,7 +36,7 @@ func (l *caKeyUsageNotCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_key_usage_not_critical",
-		Description:   "Root & Subordinate CA certificate keyUsage extension must be marked as critical",
+		Description:   "Root and Subordinate CA certificate keyUsage extension MUST be marked as critical",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caKeyUsageNotCrit{},

--- a/lints/lint_ca_organization_name_missing.go
+++ b/lints/lint_ca_organization_name_missing.go
@@ -35,7 +35,7 @@ func (l *caOrganizationNameMissing) RunTest(c *x509.Certificate) (ResultStruct, 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_organization_name_missing",
-		Description:   "Root & Subordinate CA certificates must have a organizationName present in subject information",
+		Description:   "Root and Subordinate CA certificates MUST have a organizationName present in subject information",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caOrganizationNameMissing{},

--- a/lints/lint_ca_subject_field_empty.go
+++ b/lints/lint_ca_subject_field_empty.go
@@ -42,7 +42,7 @@ func (l *caSubjectEmpty) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_subject_field_empty",
-		Description:   "CA Certificates subject field must not be empty and must have a non-empty distingushed name",
+		Description:   "CA Certificates subject field MUST not be empty and MUST have a non-empty distingushed name",
 		Providence:    "RFC 5280: 4.1.2.6",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &caSubjectEmpty{},

--- a/lints/lint_cab_dv_conflicts_with_locality.go
+++ b/lints/lint_cab_dv_conflicts_with_locality.go
@@ -34,7 +34,7 @@ func (l *certPolicyConflictsWithLocality) RunTest(cert *x509.Certificate) (Resul
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_dv_conflicts_with_locality",
-		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, locality name must not be included in subject.",
+		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, locality name MUST NOT be included in subject",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &certPolicyConflictsWithLocality{},

--- a/lints/lint_cab_dv_conflicts_with_org.go
+++ b/lints/lint_cab_dv_conflicts_with_org.go
@@ -34,7 +34,7 @@ func (l *certPolicyConflictsWithOrg) RunTest(cert *x509.Certificate) (ResultStru
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_dv_conflicts_with_org",
-		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, organization name must not be included in subject.",
+		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, organization name MUST NOT be included in subject",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &certPolicyConflictsWithOrg{},

--- a/lints/lint_cab_dv_conflicts_with_postal.go
+++ b/lints/lint_cab_dv_conflicts_with_postal.go
@@ -34,7 +34,7 @@ func (l *certPolicyConflictsWithPostal) RunTest(cert *x509.Certificate) (ResultS
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_dv_conflicts_with_postal",
-		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, postalCode must not be included in subject.",
+		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, postalCode MUST NOT be included in subject",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &certPolicyConflictsWithPostal{},

--- a/lints/lint_cab_dv_conflicts_with_province.go
+++ b/lints/lint_cab_dv_conflicts_with_province.go
@@ -34,7 +34,7 @@ func (l *certPolicyConflictsWithProvince) RunTest(cert *x509.Certificate) (Resul
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_dv_conflicts_with_province",
-		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, stateOrProvinceName must not be included in subject.",
+		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, stateOrProvinceName MUST NOT be included in subject",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &certPolicyConflictsWithProvince{},

--- a/lints/lint_cab_dv_conflicts_with_street.go
+++ b/lints/lint_cab_dv_conflicts_with_street.go
@@ -34,7 +34,7 @@ func (l *certPolicyConflictsWithStreet) RunTest(cert *x509.Certificate) (ResultS
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_dv_conflicts_with_street",
-		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, streetAddress must not be included in subject.",
+		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, streetAddress MUST NOT be included in subject",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &certPolicyConflictsWithStreet{},

--- a/lints/lint_cab_iv_requires_personal_name.go
+++ b/lints/lint_cab_iv_requires_personal_name.go
@@ -33,7 +33,7 @@ func (l *CertPolicyRequiresPersonalName) RunTest(cert *x509.Certificate) (Result
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_iv_requires_personal_name",
-		Description:   "If certificate policy 2.23.140.1.2.3 is included, either organizationName or givenName and surname must be included in subject.",
+		Description:   "If certificate policy 2.23.140.1.2.3 is included, either organizationName or givenName and surname MUST be included in subject",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,
 		Test:          &CertPolicyRequiresPersonalName{},

--- a/lints/lint_cab_ov_requires_org.go
+++ b/lints/lint_cab_ov_requires_org.go
@@ -33,7 +33,7 @@ func (l *CertPolicyRequiresOrg) RunTest(cert *x509.Certificate) (ResultStruct, e
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_ov_requires_org",
-		Description:   "If certificate policy 2.23.140.1.2.2 is included, organizationName must be included in subject.",
+		Description:   "If certificate policy 2.23.140.1.2.2 is included, organizationName MUST be included in subject",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &CertPolicyRequiresOrg{},

--- a/lints/lint_cert_contains_unique_identifier.go
+++ b/lints/lint_cert_contains_unique_identifier.go
@@ -41,7 +41,7 @@ func (l *CertContainsUniqueIdentifier) RunTest(cert *x509.Certificate) (ResultSt
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cert_contains_unique_identifier",
-		Description:   "CAs must not generate certificate with unique identifiers.",
+		Description:   "CAs MUST NOT generate certificate with unique identifiers",
 		Providence:    "RFC 5280: 4.1.2.8",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &CertContainsUniqueIdentifier{},

--- a/lints/lint_cert_extensions_version_not_3.go
+++ b/lints/lint_cert_extensions_version_not_3.go
@@ -47,7 +47,7 @@ func (l *CertExtensionsVersonNot3) RunTest(cert *x509.Certificate) (ResultStruct
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cert_extensions_version_not_3",
-		Description:   "The extensions field must only appear in version 3 certificates.",
+		Description:   "The extensions field MUST only appear in version 3 certificates",
 		Providence:    "RFC 5280: 4.1.2.9",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &CertExtensionsVersonNot3{},

--- a/lints/lint_cert_policy_iv_requires_country.go
+++ b/lints/lint_cert_policy_iv_requires_country.go
@@ -33,7 +33,7 @@ func (l *CertPolicyIVRequiresCountry) RunTest(cert *x509.Certificate) (ResultStr
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cert_policy_iv_requires_country",
-		Description:   "If certificate policy 2.23.140.1.2.3 is included, countryName must be included in subject.",
+		Description:   "If certificate policy 2.23.140.1.2.3 is included, countryName MUST be included in subject",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,
 		Test:          &CertPolicyIVRequiresCountry{},

--- a/lints/lint_cert_policy_iv_requires_province_or_locality.go
+++ b/lints/lint_cert_policy_iv_requires_province_or_locality.go
@@ -33,7 +33,7 @@ func (l *CertPolicyIVRequiresProvinceOrLocal) RunTest(cert *x509.Certificate) (R
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cert_policy_iv_requires_province_or_locality",
-		Description:   "If certificate policy 2.23.140.1.2.3 is included, localityName or stateOrProvinceName must be included in subject.",
+		Description:   "If certificate policy 2.23.140.1.2.3 is included, localityName or stateOrProvinceName MUST be included in subject",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,
 		Test:          &CertPolicyIVRequiresProvinceOrLocal{},

--- a/lints/lint_cert_policy_ov_requires_country.go
+++ b/lints/lint_cert_policy_ov_requires_country.go
@@ -33,7 +33,7 @@ func (l *CertPolicyOVRequiresCountry) RunTest(cert *x509.Certificate) (ResultStr
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cert_policy_ov_requires_country",
-		Description:   "If certificate policy 2.23.140.1.2.2 is included, countryName must be included in subject.",
+		Description:   "If certificate policy 2.23.140.1.2.2 is included, countryName MUST be included in subject",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &CertPolicyOVRequiresCountry{},

--- a/lints/lint_cert_policy_ov_requires_province_or_locality.go
+++ b/lints/lint_cert_policy_ov_requires_province_or_locality.go
@@ -33,7 +33,7 @@ func (l *CertPolicyOVRequiresProvinceOrLocal) RunTest(cert *x509.Certificate) (R
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cert_policy_ov_requires_province_or_locality",
-		Description:   "If certificate policy 2.23.140.1.2.2 is included, localityName or stateOrProvinceName must be included in subject.",
+		Description:   "If certificate policy 2.23.140.1.2.2 is included, localityName or stateOrProvinceName MUST be included in subject",
 		Providence:    "CAB: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &CertPolicyOVRequiresProvinceOrLocal{},

--- a/lints/lint_cert_unique_identifier_version_not_2_or_3.go
+++ b/lints/lint_cert_unique_identifier_version_not_2_or_3.go
@@ -43,7 +43,7 @@ func (l *certUniqueIdVersion) RunTest(c *x509.Certificate) (ResultStruct, error)
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cert_unique_identifier_version_not_2_or_3",
-		Description:   "Unique identifiers must only appear if the version is 2 or 3.",
+		Description:   "Unique identifiers MUST only appear if the X.509 version is 2 or 3",
 		Providence:    "RFC 5280: 4.1.2.8",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &certUniqueIdVersion{},

--- a/lints/lint_distribution_point_missing_ldap_or_uri.go
+++ b/lints/lint_distribution_point_missing_ldap_or_uri.go
@@ -37,7 +37,7 @@ func (l *distribNoLDAPorURI) RunTest(c *x509.Certificate) (ResultStruct, error) 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_distribution_point_missing_ldap_or_uri",
-		Description:   "When present in the CRLDistributionPoints extension, DistributionPointName SHOULD include at least one LDAP or HTTP URI.",
+		Description:   "When present in the CRLDistributionPoints extension, DistributionPointName SHOULD include at least one LDAP or HTTP URI",
 		Providence:    "RFC 5280: 4.2.1.13",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &distribNoLDAPorURI{},

--- a/lints/lint_dsa_improper_modulus_or_divisor_size.go
+++ b/lints/lint_dsa_improper_modulus_or_divisor_size.go
@@ -43,7 +43,7 @@ func (l *dsaImproperSize) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:        "e_dsa_improper_modulus_or_divisor_size",
-		Description: "Minimum DSA modulus and divisor size is either L= 2048, N= 224 or L= 2048, N= 256 (extras come from FIPS 186-4)",
+		Description: "The minimum DSA modulus and divisor size is either L=2048, N=224 or L=2048, N=256 (extras come from FIPS 186-4)",
 		Providence:  "CAB: 6.1.5",
 		// Refer to CAB: 6.1.5, taking the statement "Before 31 Dec 2010" literally
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ec_improper_curves.go
+++ b/lints/lint_ec_improper_curves.go
@@ -50,7 +50,7 @@ func (l *ecImproperCurves) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:        "e_ec_improper_curves",
-		Description: "Only one of NIST P‐256, P‐384, or P‐521 can be used for all types of certificate",
+		Description: "Only one of NIST P‐256, P‐384, or P‐521 can be used",
 		Providence:  "CAB: 6.1.5",
 		// Refer to CAB: 6.1.5, taking the statement "Before 31 Dec 2010" literally
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_ext_aia_access_location_missing.go
+++ b/lints/lint_ext_aia_access_location_missing.go
@@ -43,7 +43,7 @@ func (l *aiaNoHTTPorLDAP) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_ext_aia_access_location_missing",
-		Description:   "When the id-ad-caIssuers accessMethod is used, at least one instance SHOULD specify an accessLocation that is an HTTP or LDAP URI.",
+		Description:   "When the id-ad-caIssuers accessMethod is used, at least one instance SHOULD specify an accessLocation that is an HTTP or LDAP URI",
 		Providence:    "RFC 5280: 4.2.2.1",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &aiaNoHTTPorLDAP{},

--- a/lints/lint_ext_authority_key_identifier_critical.go
+++ b/lints/lint_ext_authority_key_identifier_critical.go
@@ -35,7 +35,7 @@ func (l *authorityKeyIdCritical) RunTest(c *x509.Certificate) (ResultStruct, err
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_authority_key_identifier_critical",
-		Description:   "The authority key identifier extension must be non-critical.",
+		Description:   "The authority key identifier extension must be non-critical",
 		Providence:    "RFC 5280: 4.2.1.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &authorityKeyIdCritical{},

--- a/lints/lint_ext_authority_key_identifier_missing.go
+++ b/lints/lint_ext_authority_key_identifier_missing.go
@@ -44,7 +44,7 @@ func (l *authorityKeyIdMissing) RunTest(c *x509.Certificate) (ResultStruct, erro
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_authority_key_identifier_missing",
-		Description:   "CAs must support key identifiers and include them in all certs",
+		Description:   "CAs must support key identifiers and include them in all certificates",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &authorityKeyIdMissing{},

--- a/lints/lint_ext_authority_key_identifier_no_key_identifier.go
+++ b/lints/lint_ext_authority_key_identifier_no_key_identifier.go
@@ -44,7 +44,7 @@ func (l *authorityKeyIdNoKeyIdField) RunTest(c *x509.Certificate) (ResultStruct,
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_authority_key_identifier_no_key_identifier",
-		Description:   "CAs must include keyIdentifer field of aki in all non-self-issued certs",
+		Description:   "CAs must include keyIdentifer field of AKI in all non-self-issued certificates",
 		Providence:    "RFC 5280: 4.2.1.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &authorityKeyIdNoKeyIdField{},

--- a/lints/lint_ext_cert_policy_contains_noticeref.go
+++ b/lints/lint_ext_cert_policy_contains_noticeref.go
@@ -46,7 +46,7 @@ func (l *noticeRefPres) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_ext_cert_policy_contains_noticeref",
-		Description:   "Compliant certificates should not use the noticeRef option",
+		Description:   "Compliant certificates SHOULD NOT use the noticeRef option",
 		Providence:    "RFC 5280: 4.2.1.4",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &noticeRefPres{},

--- a/lints/lint_ext_cert_policy_disallowed_any_policy_qualifier.go
+++ b/lints/lint_ext_cert_policy_disallowed_any_policy_qualifier.go
@@ -43,7 +43,7 @@ func (l *unrecommendedQualifier) RunTest(c *x509.Certificate) (ResultStruct, err
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_cert_policy_disallowed_any_policy_qualifier",
-		Description:   "when qualifiers are used with the special policy anyPolicy, the must be limited to qualifiers identified in this section (4.2.1.4)",
+		Description:   "When qualifiers are used with the special policy anyPolicy, they must be limited to qualifiers identified in this section: (4.2.1.4)",
 		Providence:    "RFC 5280: 4.2.1.4",
 		EffectiveDate: util.RFC3280Date,
 		Test:          &unrecommendedQualifier{},

--- a/lints/lint_ext_cert_policy_duplicate.go
+++ b/lints/lint_ext_cert_policy_duplicate.go
@@ -44,7 +44,7 @@ func (l *ExtCertPolicyDuplicate) RunTest(cert *x509.Certificate) (ResultStruct, 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_cert_policy_duplicate",
-		Description:   "a cert policy OID must not appear more than once in the extension",
+		Description:   "A certificate policy OID must not appear more than once in the extension",
 		Providence:    "RFC 5280: 4.2.1.4",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &ExtCertPolicyDuplicate{},

--- a/lints/lint_ext_cert_policy_explicit_text_ia5_string.go
+++ b/lints/lint_ext_cert_policy_explicit_text_ia5_string.go
@@ -51,7 +51,7 @@ func (l *explicitTextIA5String) RunTest(c *x509.Certificate) (ResultStruct, erro
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_cert_policy_explicit_text_ia5_string",
-		Description:   "Compliant certificates must not encode explicitTest as IA5String",
+		Description:   "Compliant certificates must not encode explicitTest as an IA5String",
 		Providence:    "RFC 6818: 3",
 		EffectiveDate: util.RFC6818Date,
 		Test:          &explicitTextIA5String{},

--- a/lints/lint_ext_cert_policy_explicit_text_not_nfc.go
+++ b/lints/lint_ext_cert_policy_explicit_text_not_nfc.go
@@ -45,7 +45,7 @@ func (l *ExtCertPolicyExplicitTextNotNFC) RunTest(c *x509.Certificate) (ResultSt
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_ext_cert_policy_explicit_text_not_nfc",
-		Description:   "When utf8string or bmpstring encoding is used for explicitText field in cert policy, it SHOULD BE normalized by NFC format",
+		Description:   "When utf8string or bmpstring encoding is used for explicitText field in certificate policy, it SHOULD be normalized by NFC format",
 		Providence:    "Fill this in...",
 		EffectiveDate: util.RFC6818Date,
 		Test:          &ExtCertPolicyExplicitTextNotNFC{},

--- a/lints/lint_ext_cert_policy_explicit_text_too_long.go
+++ b/lints/lint_ext_cert_policy_explicit_text_too_long.go
@@ -50,7 +50,7 @@ func (l *explicitTextTooLong) RunTest(c *x509.Certificate) (ResultStruct, error)
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_cert_policy_explicit_text_too_long",
-		Description:   "explicit text has a maximum size of 200 characters",
+		Description:   "Explicit text has a maximum size of 200 characters",
 		Providence:    "RFC 6818: 3",
 		EffectiveDate: util.RFC6818Date,
 		Test:          &explicitTextTooLong{},

--- a/lints/lint_ext_crl_distribution_marked_critical.go
+++ b/lints/lint_ext_crl_distribution_marked_critical.go
@@ -36,7 +36,7 @@ func (l *ExtCrlDistributionMarkedCritical) RunTest(cert *x509.Certificate) (Resu
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_ext_crl_distribution_marked_critical",
-		Description:   "If included, the CRL Distribution Points extension SHOULD NOT be marked critical.",
+		Description:   "If included, the CRL Distribution Points extension SHOULD NOT be marked critical",
 		Providence:    "RFC 5280: 4.2.1.13",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &ExtCrlDistributionMarkedCritical{},

--- a/lints/lint_ext_duplicate_extension.go
+++ b/lints/lint_ext_duplicate_extension.go
@@ -38,7 +38,7 @@ func (l *ExtDuplicateExtension) RunTest(cert *x509.Certificate) (ResultStruct, e
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_duplicate_extension",
-		Description:   "A certificate MUST NOT include more than one instance of a particular extension.",
+		Description:   "A certificate MUST NOT include more than one instance of a particular extension",
 		Providence:    "RFC 5280: 4.2",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &ExtDuplicateExtension{},

--- a/lints/lint_ext_freshest_crl_marked_critical.go
+++ b/lints/lint_ext_freshest_crl_marked_critical.go
@@ -36,7 +36,7 @@ func (l *ExtFreshestCrlMarkedCritical) RunTest(cert *x509.Certificate) (ResultSt
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_freshest_crl_marked_critical",
-		Description:   "Freshest CRL MUST be marked as non-critical by conforming CAs.",
+		Description:   "Freshest CRL MUST be marked as non-critical by conforming CAs",
 		Providence:    "RFC 5280: 4.2.1.15",
 		EffectiveDate: util.RFC3280Date,
 		Test:          &ExtFreshestCrlMarkedCritical{},

--- a/lints/lint_ext_ian_critical.go
+++ b/lints/lint_ext_ian_critical.go
@@ -35,7 +35,7 @@ func (l *ExtIANCritical) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_ext_ian_critical",
-		Description:   "issuer alternate name should be marked as non-critical",
+		Description:   "Issuer alternate name should be marked as non-critical",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &ExtIANCritical{},

--- a/lints/lint_ext_ian_dns_not_ia5_string.go
+++ b/lints/lint_ext_ian_dns_not_ia5_string.go
@@ -69,7 +69,7 @@ func (l *IANDNSNotIA5String) RunTest(c *x509.Certificate) (ResultStruct, error) 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_ian_dns_not_ia5_string",
-		Description:   "dNSNames are IA5 strings",
+		Description:   "DNSNames MUST be IA5 strings",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &IANDNSNotIA5String{},

--- a/lints/lint_ext_ian_empty_name.go
+++ b/lints/lint_ext_ian_empty_name.go
@@ -62,7 +62,7 @@ func (l *IANEmptyName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_ian_empty_name",
-		Description:   "general name fields must not be empty in IAN",
+		Description:   "General name fields must not be empty in IAN",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &IANEmptyName{},

--- a/lints/lint_ext_ian_no_entries.go
+++ b/lints/lint_ext_ian_no_entries.go
@@ -42,7 +42,7 @@ func (l *IANNoEntry) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_ian_no_entries",
-		Description:   "if present, the IAN extension must contain at least one entry",
+		Description:   "If present, the IAN extension must contain at least one entry",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &IANNoEntry{},

--- a/lints/lint_ext_ian_rfc822_format_invalid.go
+++ b/lints/lint_ext_ian_rfc822_format_invalid.go
@@ -48,7 +48,7 @@ func (l *IANEmail) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_ian_rfc822_format_invalid",
-		Description:   "email must not be surrounded with `<>`, and there must be no trailing comments in `()`",
+		Description:   "Email must not be surrounded with `<>`, and there MUST NOT be trailing comments in `()`",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &IANEmail{},

--- a/lints/lint_ext_ian_space_dns_name.go
+++ b/lints/lint_ext_ian_space_dns_name.go
@@ -46,7 +46,7 @@ func (l *IANSpace) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_ian_space_dns_name",
-		Description:   "the dNSName ` ` must not be used",
+		Description:   "dNSName ' ' MUST NOT be used",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &IANSpace{},

--- a/lints/lint_ext_ian_uri_format_invalid.go
+++ b/lints/lint_ext_ian_uri_format_invalid.go
@@ -48,7 +48,7 @@ func (l *IANURIFormat) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_ian_uri_format_invalid",
-		Description:   "URIs in SAN extension must have a scheme and scheme specific part",
+		Description:   "URIs in the subjectAltName extension MUST have a scheme and scheme specific part",
 		Providence:    "RFC5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &IANURIFormat{},

--- a/lints/lint_ext_ian_uri_host_not_fqdn_or_ip.go
+++ b/lints/lint_ext_ian_uri_host_not_fqdn_or_ip.go
@@ -47,7 +47,7 @@ func (l *IANURIFQDNOrIP) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_ian_uri_host_not_fqdn_or_ip",
-		Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host.",
+		Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &IANURIFQDNOrIP{},

--- a/lints/lint_ext_ian_uri_not_ia5.go
+++ b/lints/lint_ext_ian_uri_not_ia5.go
@@ -38,7 +38,7 @@ func (l *IANURIIA5String) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_ian_uri_not_ia5",
-		Description:   "When SAN contains a URI, the name must be an IA5 string",
+		Description:   "When subjectAltName contains a URI, the name MUST be an IA5 string",
 		Providence:    "RFC5280: 4.2.1.7",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &IANURIIA5String{},

--- a/lints/lint_ext_ian_uri_relative.go
+++ b/lints/lint_ext_ian_uri_relative.go
@@ -49,7 +49,7 @@ func (l *uriRelative) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_ian_uri_relative",
-		Description:   "When IAN extension is present and URI is used, the name must not be a relative URI ",
+		Description:   "When issuerAltName extension is present and the URI is used, the name MUST NOT be a relative URI",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &uriRelative{},

--- a/lints/lint_ext_key_usage_cert_sign_without_ca.go
+++ b/lints/lint_ext_key_usage_cert_sign_without_ca.go
@@ -44,7 +44,7 @@ func (l *keyUsageCertSignNoCa) RunTest(c *x509.Certificate) (ResultStruct, error
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_key_usage_cert_sign_without_ca",
-		Description:   "if the keyCertSign bit is asserted, then the cA bit MUST also be asserted",
+		Description:   "if the keyCertSign bit is asserted, then the cA bit in the basic constraints extension MUST also be asserted",
 		Providence:    "RFC 5280: 4.2.1.3 & 4.2.1.9",
 		EffectiveDate: util.RFC3280Date,
 		Test:          &keyUsageCertSignNoCa{},

--- a/lints/lint_ext_key_usage_not_critical.go
+++ b/lints/lint_ext_key_usage_not_critical.go
@@ -36,7 +36,7 @@ func (l *checkKeyUsageCritical) RunTest(c *x509.Certificate) (ResultStruct, erro
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_ext_key_usage_not_critical",
-		Description:   "The keyUsage extension SHOULD be critical.",
+		Description:   "The keyUsage extension SHOULD be critical",
 		Providence:    "RFC 5280: 4.2.1.3",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &checkKeyUsageCritical{},

--- a/lints/lint_ext_key_usage_without_bits.go
+++ b/lints/lint_ext_key_usage_without_bits.go
@@ -38,7 +38,7 @@ func (l *keyUsageBitsSet) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_key_usage_without_bits",
-		Description:   "when included, at least one bit must be set to 1",
+		Description:   "When the keyUsage extension is included, at least one bit MUST be set to 1",
 		Providence:    "RFC 5280: 4.2.1.3",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &keyUsageBitsSet{},

--- a/lints/lint_ext_name_constraints_not_critical.go
+++ b/lints/lint_ext_name_constraints_not_critical.go
@@ -42,7 +42,7 @@ func (l *nameConstraintCrit) RunTest(c *x509.Certificate) (ResultStruct, error) 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_name_constraints_not_critical",
-		Description:   "If it is included, conforming CAs must mark the name constrains extension as critical.",
+		Description:   "If it is included, conforming CAs MUST mark the name constrains extension as critical",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &nameConstraintCrit{},

--- a/lints/lint_ext_name_constraints_not_in_ca.go
+++ b/lints/lint_ext_name_constraints_not_in_ca.go
@@ -40,7 +40,7 @@ func (l *nameConstraintNotCa) RunTest(c *x509.Certificate) (ResultStruct, error)
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_name_constraints_not_in_ca",
-		Description:   "The name constraints extension must only be used in CA certificates",
+		Description:   "The name constraints extension MUST only be used in CA certificates",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &nameConstraintNotCa{},

--- a/lints/lint_ext_policy_constraints_not_critical.go
+++ b/lints/lint_ext_policy_constraints_not_critical.go
@@ -35,7 +35,7 @@ func (l *policyConstraintsCritical) RunTest(c *x509.Certificate) (ResultStruct, 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_policy_constraints_not_critical",
-		Description:   "Conforming CAs must mark the policy constraints extension as critical.",
+		Description:   "Conforming CAs MUST mark the policy constraints extension as critical",
 		Providence:    "RFC 5280: 4.2.1.11",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &policyConstraintsCritical{},

--- a/lints/lint_ext_policy_map_any_policy.go
+++ b/lints/lint_ext_policy_map_any_policy.go
@@ -44,7 +44,7 @@ func (l *policyMapAnyPolicy) RunTest(c *x509.Certificate) (ResultStruct, error) 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_policy_map_any_policy",
-		Description:   "policies must not be mapped to or from the anyPolicy value",
+		Description:   "Policies must not be mapped to or from the anyPolicy value",
 		Providence:    "RFC 5280: 4.2.1.5",
 		EffectiveDate: util.RFC3280Date,
 		Test:          &policyMapAnyPolicy{},

--- a/lints/lint_ext_policy_map_not_in_cert_policy.go
+++ b/lints/lint_ext_policy_map_not_in_cert_policy.go
@@ -44,7 +44,7 @@ func (l *policyMapMatchesCertPolicy) RunTest(c *x509.Certificate) (ResultStruct,
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_ext_policy_map_not_in_cert_policy",
-		Description:   "each issuerDomainPolicy named in policy mappings extension should also be asserted in a certificate policies extension",
+		Description:   "Each issuerDomainPolicy named in the policy mappings extension should also be asserted in a certificate policies extension",
 		Providence:    "RFC 5280: 4.2.1.5",
 		EffectiveDate: util.RFC3280Date,
 		Test:          &policyMapMatchesCertPolicy{},

--- a/lints/lint_ext_san_contains_reserved_ip.go
+++ b/lints/lint_ext_san_contains_reserved_ip.go
@@ -40,7 +40,7 @@ func (l *SANReservedIP) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_contains_reserved_ip",
-		Description:   "Certs and expiring after 2015-11-01 must not contain a reserved ip address in the subjectAlternativeName extension.",
+		Description:   "Certificates expiring after 1 Nov 2015 MUST NOT contain a reserved IP address in the subjectAlternativeName extension",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANReservedIP{},

--- a/lints/lint_ext_san_critical_with_subject_dn.go
+++ b/lints/lint_ext_san_critical_with_subject_dn.go
@@ -40,7 +40,7 @@ func (l *ExtSANCriticalWithSubjectDN) RunTest(cert *x509.Certificate) (ResultStr
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_ext_san_critical_with_subject_dn",
-		Description:   "If the subject contains a distinguished name SAN should be non-critical.",
+		Description:   "If the subject contains a distinguished name, subjectAlternateName SHOULD be non-critical",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &ExtSANCriticalWithSubjectDN{},

--- a/lints/lint_ext_san_directory_name_present.go
+++ b/lints/lint_ext_san_directory_name_present.go
@@ -39,7 +39,7 @@ func (l *SANDirName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_directory_name_present",
-		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
+		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANDirName{},

--- a/lints/lint_ext_san_dns_not_ia5_string.go
+++ b/lints/lint_ext_san_dns_not_ia5_string.go
@@ -69,7 +69,7 @@ func (l *SANDNSNotIA5String) RunTest(c *x509.Certificate) (ResultStruct, error) 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_dns_not_ia5_string",
-		Description:   "dNSNames are IA5 strings",
+		Description:   "dNSNames MUST be IA5 strings",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &SANDNSNotIA5String{},

--- a/lints/lint_ext_san_dnsname_not_fqdn.go
+++ b/lints/lint_ext_san_dnsname_not_fqdn.go
@@ -41,7 +41,7 @@ func (l *DNSFQDN) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_dnsname_not_fqdn",
-		Description:   "SAN dnsnames must be a fully qualified domain name.",
+		Description:   "SAN dnsnames MUST be Fully-Qualified Domain Names",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &DNSFQDN{},

--- a/lints/lint_ext_san_edi_party_name_present.go
+++ b/lints/lint_ext_san_edi_party_name_present.go
@@ -39,7 +39,7 @@ func (l *SANEDI) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_edi_party_name_present",
-		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
+		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANEDI{},

--- a/lints/lint_ext_san_empty_name.go
+++ b/lints/lint_ext_san_empty_name.go
@@ -62,7 +62,7 @@ func (l *SANEmptyName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_empty_name",
-		Description:   "general name fields must not be empty in SAN",
+		Description:   "General name fields MUST NOT be empty in subjectAlternateNames",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &SANEmptyName{},

--- a/lints/lint_ext_san_missing.go
+++ b/lints/lint_ext_san_missing.go
@@ -36,7 +36,7 @@ func (l *SANMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_missing",
-		Description:   "Certificates must contain the Subject Alternate Name extension.",
+		Description:   "Certificates MUST contain the Subject Alternate Name extension",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANMissing{},

--- a/lints/lint_ext_san_no_entries.go
+++ b/lints/lint_ext_san_no_entries.go
@@ -42,7 +42,7 @@ func (l *SANNoEntry) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_no_entries",
-		Description:   "if present, the SAN extension must contain at least one entry",
+		Description:   "If present, the SAN extension MUST contain at least one entry",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &SANNoEntry{},

--- a/lints/lint_ext_san_not_critical_without_subject.go
+++ b/lints/lint_ext_san_not_critical_without_subject.go
@@ -42,7 +42,7 @@ func (l *extSANNotCritNoSubject) RunTest(c *x509.Certificate) (ResultStruct, err
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_not_critical_without_subject",
-		Description:   "If there is an empty subject field, then the SAN extension must be critical",
+		Description:   "If there is an empty subject field, then the SAN extension MUST be critical",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &extSANNotCritNoSubject{},

--- a/lints/lint_ext_san_other_name_present.go
+++ b/lints/lint_ext_san_other_name_present.go
@@ -39,7 +39,7 @@ func (l *SANOtherName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_other_name_present",
-		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
+		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANOtherName{},

--- a/lints/lint_ext_san_registered_id_present.go
+++ b/lints/lint_ext_san_registered_id_present.go
@@ -39,7 +39,7 @@ func (l *SANRegId) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_registered_id_present",
-		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
+		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANRegId{},

--- a/lints/lint_ext_san_rfc822_format_invalid.go
+++ b/lints/lint_ext_san_rfc822_format_invalid.go
@@ -48,7 +48,7 @@ func (l *invalidEmail) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_rfc822_format_invalid",
-		Description:   "email must not be surrounded with `<>`, and there must be no trailing comments in `()`",
+		Description:   "Email MUST NOT be surrounded with `<>`, and there must be no trailing comments in `()`",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &invalidEmail{},

--- a/lints/lint_ext_san_rfc822_name_present.go
+++ b/lints/lint_ext_san_rfc822_name_present.go
@@ -39,7 +39,7 @@ func (l *SANRfc822) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_rfc822_name_present",
-		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
+		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANRfc822{},

--- a/lints/lint_ext_san_space_dns_name.go
+++ b/lints/lint_ext_san_space_dns_name.go
@@ -46,7 +46,7 @@ func (l *SANIsSpaceDNS) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_space_dns_name",
-		Description:   "the dNSName ` ` must not be used",
+		Description:   "The dNSName ` ` MUST NOT be used",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &SANIsSpaceDNS{},

--- a/lints/lint_ext_san_uniform_resource_identifier_present.go
+++ b/lints/lint_ext_san_uniform_resource_identifier_present.go
@@ -39,7 +39,7 @@ func (l *SANURI) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_uniform_resource_identifier_present",
-		Description:   "The Subject Alternate Name extension must contain only dnsName and ipaddress name types.",
+		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANURI{},

--- a/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
+++ b/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
@@ -45,7 +45,7 @@ func (l *SANURIHost) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_uri_host_not_fqdn_or_ip",
-		Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host.",
+		Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host",
 		Providence:    "RFC 5280: 4.2.1.7",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &SANURIHost{},

--- a/lints/lint_ext_san_uri_not_ia5.go
+++ b/lints/lint_ext_san_uri_not_ia5.go
@@ -38,7 +38,7 @@ func (l *extSANURINotIA5) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_uri_not_ia5",
-		Description:   "When SAN contains a URI, the name must be an IA5 string",
+		Description:   "When subjectAlternateName contains a URI, the name MUST be an IA5 string",
 		Providence:    "RFC5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &extSANURINotIA5{},

--- a/lints/lint_ext_san_uri_relative.go
+++ b/lints/lint_ext_san_uri_relative.go
@@ -49,7 +49,7 @@ func (l *extSANURIRelative) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_uri_relative",
-		Description:   "When SAN extension is present and URI is used, the name must not be a relative URI ",
+		Description:   "When the subjectAlternateName extension is present and a URI is used, the name MUST NOT be a relative URI",
 		Providence:    "RFC 5280: 4.2.1.6",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &extSANURIRelative{},

--- a/lints/lint_ext_subject_directory_attr_critical.go
+++ b/lints/lint_ext_subject_directory_attr_critical.go
@@ -37,7 +37,7 @@ func (l *subDirAttrCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_subject_directory_attr_critical",
-		Description:   "Conforming CAs must mark the Subject Directory Attributes extension as not critical",
+		Description:   "Conforming CAs MUST mark the Subject Directory Attributes extension as not critical",
 		Providence:    "RFC 5280: 4.2.1.8",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subDirAttrCrit{},

--- a/lints/lint_ext_subject_key_identifier_critical.go
+++ b/lints/lint_ext_subject_key_identifier_critical.go
@@ -35,7 +35,7 @@ func (l *subjectKeyIdCritical) RunTest(c *x509.Certificate) (ResultStruct, error
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_subject_key_identifier_critical",
-		Description:   "The subject key identifier extension must be non-critical.",
+		Description:   "The subject key identifier extension MUST be non-critical",
 		Providence:    "RFC 5280: 4.2.1.2",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectKeyIdCritical{},

--- a/lints/lint_ext_subject_key_identifier_missing_ca.go
+++ b/lints/lint_ext_subject_key_identifier_missing_ca.go
@@ -49,7 +49,7 @@ func (l *subjectKeyIdMissingCA) RunTest(cert *x509.Certificate) (ResultStruct, e
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_subject_key_identifier_missing_ca",
-		Description:   "CAs must include ski in all CA certificates.",
+		Description:   "CAs MUST include a Subject Key Identifier in all CA certificates",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.2",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectKeyIdMissingCA{},

--- a/lints/lint_ext_subject_key_identifier_missing_sub_cert.go
+++ b/lints/lint_ext_subject_key_identifier_missing_sub_cert.go
@@ -49,7 +49,7 @@ func (l *subjectKeyIdMissingSubscriber) RunTest(cert *x509.Certificate) (ResultS
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_ext_subject_key_identifier_missing_sub_cert",
-		Description:   "Sub certs should include ski in end entity certs",
+		Description:   "Sub certificates SHOULD include Subject Key Identifier in end entity certs",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.2",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectKeyIdMissingSubscriber{},

--- a/lints/lint_generalized_time_does_not_include_seconds.go
+++ b/lints/lint_generalized_time_does_not_include_seconds.go
@@ -72,7 +72,7 @@ func checkSeconds(r *ResultEnum, t asn1.RawValue) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_generalized_time_does_not_include_seconds",
-		Description:   "Generalized time values must include seconds",
+		Description:   "Generalized time values MUST include seconds",
 		Providence:    "RFC 5280: 4.1.2.5.2",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &generalizedNoSeconds{},

--- a/lints/lint_generalized_time_includes_fraction_seconds.go
+++ b/lints/lint_generalized_time_includes_fraction_seconds.go
@@ -72,7 +72,7 @@ func checkFraction(r *ResultEnum, t asn1.RawValue) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_generalized_time_includes_fraction_seconds",
-		Description:   "Generalized time values must not include fraction seconds",
+		Description:   "Generalized time values MUST NOT include fractional seconds",
 		Providence:    "RFC 5280: 4.1.2.5.2",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &generalizedTimeFraction{},

--- a/lints/lint_generalized_time_not_in_zulu.go
+++ b/lints/lint_generalized_time_not_in_zulu.go
@@ -54,7 +54,7 @@ func (l *generalizedNotZulu) RunTest(c *x509.Certificate) (ResultStruct, error) 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_generalized_time_not_in_zulu",
-		Description:   "Generalized time values must be expressed in Greenwich Mean Time (Zulu)",
+		Description:   "Generalized time values MUST be expressed in Greenwich Mean Time (Zulu)",
 		Providence:    "RFC 5280: 4.1.2.5.2",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &generalizedNotZulu{},

--- a/lints/lint_gtld_under_consideration.go
+++ b/lints/lint_gtld_under_consideration.go
@@ -47,7 +47,7 @@ func (l *gtldUnderConsideration) RunTest(c *x509.Certificate) (ResultStruct, err
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_gtld_under_consideration",
-		Description:   "CAs SHOULD NOT issue Certificates containing a new gTLD under consideration by ICANN.",
+		Description:   "CAs SHOULD NOT issue Certificates containing a new gTLD under consideration by ICANN",
 		Providence:    "CAB: 4.2.2",
 		EffectiveDate: util.CABV113Date,
 		Test:          &gtldUnderConsideration{},

--- a/lints/lint_gtld_under_consideration.go
+++ b/lints/lint_gtld_under_consideration.go
@@ -47,7 +47,7 @@ func (l *gtldUnderConsideration) RunTest(c *x509.Certificate) (ResultStruct, err
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_gtld_under_consideration",
-		Description:   "CAs SHOULD NOT issue Certificates containing a new gTLD under consideration by ICANN",
+		Description:   "CAs SHOULD NOT issue certificates containing a new gTLD under consideration by ICANN",
 		Providence:    "CAB: 4.2.2",
 		EffectiveDate: util.CABV113Date,
 		Test:          &gtldUnderConsideration{},

--- a/lints/lint_ian_bare_wildcard.go
+++ b/lints/lint_ian_bare_wildcard.go
@@ -32,7 +32,7 @@ func (l *brIANBareWildcard) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ian_bare_wildcard",
-		Description:   "Wildcard MUST be accompanied by other data to it's right (Only checks DNSName)",
+		Description:   "Wildcard MUST be accompanied by other data to its right (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &brIANBareWildcard{},

--- a/lints/lint_ian_bare_wildcard.go
+++ b/lints/lint_ian_bare_wildcard.go
@@ -32,7 +32,7 @@ func (l *brIANBareWildcard) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ian_bare_wildcard",
-		Description:   "Wildcard MUST be accompanied by other data to its right (Only checks DNSName)",
+		Description:   "A wildcard MUST be accompanied by other data to its right (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &brIANBareWildcard{},

--- a/lints/lint_ian_dns_name_includes_null_char.go
+++ b/lints/lint_ian_dns_name_includes_null_char.go
@@ -33,7 +33,7 @@ func (l *IANDNSNull) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ian_dns_name_includes_null_char",
-		Description:   "DNSNames MUST NOT include a null character ",
+		Description:   "DNSName MUST NOT include a null character",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &IANDNSNull{},

--- a/lints/lint_ian_iana_pub_suffix_empty.go
+++ b/lints/lint_ian_iana_pub_suffix_empty.go
@@ -32,7 +32,7 @@ func (l *IANPubSuffix) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_ian_iana_pub_suffix_empty",
-		Description:   "Domain SHOULD NOT have bare public suffix",
+		Description:   "Domain SHOULD NOT have a bare public suffix",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &IANPubSuffix{},

--- a/lints/lint_ian_wildcard_not_first.go
+++ b/lints/lint_ian_wildcard_not_first.go
@@ -33,7 +33,7 @@ func (l *brIANWildcardFirst) RunTest(c *x509.Certificate) (ResultStruct, error) 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ian_wildcard_not_first",
-		Description:   "Wildcard MUST be in the first label of FQDN, ie not: www.*.com (Only checks DNSName)",
+		Description:   "Wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &brIANWildcardFirst{},

--- a/lints/lint_ian_wildcard_not_first.go
+++ b/lints/lint_ian_wildcard_not_first.go
@@ -33,7 +33,7 @@ func (l *brIANWildcardFirst) RunTest(c *x509.Certificate) (ResultStruct, error) 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ian_wildcard_not_first",
-		Description:   "Wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks DNSName)",
+		Description:   "A wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &brIANWildcardFirst{},

--- a/lints/lint_inhibit_any_policy_not_critical.go
+++ b/lints/lint_inhibit_any_policy_not_critical.go
@@ -43,7 +43,7 @@ func (l *InhibitAnyPolicyNotCritical) RunTest(cert *x509.Certificate) (ResultStr
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_inhibit_any_policy_not_critical",
-		Description:   "CAs must mark the inhibitAnyPolicy extension as critical",
+		Description:   "CAs MUST mark the inhibitAnyPolicy extension as critical",
 		Providence:    "RFC 5280: 4.2.1.14",
 		EffectiveDate: util.RFC3280Date,
 		Test:          &InhibitAnyPolicyNotCritical{},

--- a/lints/lint_invalid_certificate_version.go
+++ b/lints/lint_invalid_certificate_version.go
@@ -33,7 +33,7 @@ func (l *InvalidCertificateVersion) RunTest(cert *x509.Certificate) (ResultStruc
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_invalid_certificate_version",
-		Description:   "Certificate must be version 3 (encoded as 2)",
+		Description:   "Certificate MUST be X.509 version 3 (encoded as 2)",
 		Providence:    "CAB: 7.1.1",
 		EffectiveDate: util.CABV130Date,
 		Test:          &InvalidCertificateVersion{},

--- a/lints/lint_invalid_certificate_version.go
+++ b/lints/lint_invalid_certificate_version.go
@@ -33,7 +33,7 @@ func (l *InvalidCertificateVersion) RunTest(cert *x509.Certificate) (ResultStruc
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_invalid_certificate_version",
-		Description:   "Certificate MUST be X.509 version 3 (encoded as 2)",
+		Description:   "Certificate MUST be version 3 (encoded as 2)",
 		Providence:    "CAB: 7.1.1",
 		EffectiveDate: util.CABV130Date,
 		Test:          &InvalidCertificateVersion{},

--- a/lints/lint_issuer_field_empty.go
+++ b/lints/lint_issuer_field_empty.go
@@ -38,7 +38,7 @@ func (l *issuerFieldEmpty) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_issuer_field_empty",
-		Description:   "Certificates issuer field must not be empty and must have a non-empty distingushed name",
+		Description:   "Certificate issuer field MUST NOT be empty and must have a non-empty distingushed name",
 		Providence:    "RFC 5280: 4.1.2.4",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &issuerFieldEmpty{},

--- a/lints/lint_name_constraint_empty.go
+++ b/lints/lint_name_constraint_empty.go
@@ -54,7 +54,7 @@ func (l *nameConstraintEmpty) RunTest(c *x509.Certificate) (ResultStruct, error)
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_name_constraint_empty",
-		Description:   "Conforming CAs must not issue certificates where name constraints is an empty sequence. That is, either the permittedSubtree or excludedSubtree fields must be present",
+		Description:   "Conforming CAs MUST NOT issue certificates where name constraints is an empty sequence. That is, either the permittedSubtree or excludedSubtree fields must be present",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC5280Date,
 		Test:          &nameConstraintEmpty{},

--- a/lints/lint_name_constraint_maximum_not_absent.go
+++ b/lints/lint_name_constraint_maximum_not_absent.go
@@ -106,7 +106,7 @@ func (l *nameConstraintMax) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_name_constraint_maximum_not_absent",
-		Description:   "In the name constraints name forms the maximum is not used and therefore MUST be absent",
+		Description:   "Within the name constraints name form, the maximum field is not used and therefore MUST be absent",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &nameConstraintMax{},

--- a/lints/lint_name_constraint_minimum_non_zero.go
+++ b/lints/lint_name_constraint_minimum_non_zero.go
@@ -106,7 +106,7 @@ func (l *nameConstMin) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_name_constraint_minimum_non_zero",
-		Description:   "In the name constraints name forms the minimum is not used and therefore MUST be zero",
+		Description:   "Within the name constraints name forms, the minimum field is not used and therefore MUST be zero",
 		Providence:    "RFC 5280: 4.2.1.10",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &nameConstMin{},

--- a/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
+++ b/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
@@ -37,7 +37,7 @@ func (l *rootCaModSize) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_old_root_ca_rsa_mod_less_than_2048_bits",
-		Description:   "In a validity period beginning on or before 31 dec 2010, root CA certificates using RSA public key algorithm must have 2048 bits of modulus",
+		Description:   "In a validity period beginning on or before 31 Dec 2010, root CA certificates using RSA public key algorithm MUST use a 2048 bit modulus",
 		Providence:    "CAB: 6.1.5",
 		EffectiveDate: util.ZeroDate,
 		Test:          &rootCaModSize{},

--- a/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
+++ b/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
@@ -36,7 +36,7 @@ func (l *subCaModSize) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:        "e_old_sub_ca_rsa_mod_less_than_1024_bits",
-		Description: "In a validity period beginning on or before 31 dec 2010 and ending on or before 31 dec 2013, subordinate CA certificates using RSA public key algorithm must have 1024 bits of modulus",
+		Description: "In a validity period beginning on or before 31 Dec 2010 and ending on or before 31 Dec 2013, subordinate CA certificates using RSA public key algorithm MUST use a 1024 bit modulus",
 		Providence:  "CAB: 6.1.5",
 		// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
+++ b/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
@@ -35,7 +35,7 @@ func (l *subModSize) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:        "e_old_sub_cert_rsa_mod_less_than_1024_bits",
-		Description: "In a validity period ending on or before 31 dec 2013, subscriber certificates using RSA public key algorithm must have 1024 bits of modulus",
+		Description: "In a validity period ending on or before 31 Dec 2013, subscriber certificates using RSA public key algorithm MUST use a 1024 bit modulus",
 		Providence:  "CAB: 6.1.5",
 		// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test
 		EffectiveDate: util.ZeroDate,

--- a/lints/lint_path_len_constraint_improperly_included.go
+++ b/lints/lint_path_len_constraint_improperly_included.go
@@ -48,7 +48,7 @@ func (l *pathLenIncluded) RunTest(cert *x509.Certificate) (ResultStruct, error) 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_path_len_constraint_improperly_included",
-		Description:   "CAs MUST NOT include the pathLenConstraint field unless the CA boolean is asserted and the keyCertSign bit is set.",
+		Description:   "CAs MUST NOT include the pathLenConstraint field unless the CA boolean is asserted and the keyCertSign bit is set",
 		Providence:    "RFC 5280: 4.2.1.9",
 		EffectiveDate: util.RFC3280Date,
 		Test:          &pathLenIncluded{},

--- a/lints/lint_path_len_constraint_zero_or_less.go
+++ b/lints/lint_path_len_constraint_zero_or_less.go
@@ -55,7 +55,7 @@ func (l *pathLenNonPositive) RunTest(cert *x509.Certificate) (ResultStruct, erro
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_path_len_constraint_zero_or_less",
-		Description:   "Where it appears, the pathLenConstraint field must be greater than or equal to zero",
+		Description:   "Where it appears, the pathLenConstraint field MUST be greater than or equal to zero",
 		Providence:    "RFC 5280: 4.2.1.9",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &pathLenNonPositive{},

--- a/lints/lint_public_key_type_not_allowed.go
+++ b/lints/lint_public_key_type_not_allowed.go
@@ -31,7 +31,7 @@ func (l *publicKeyAllowed) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_public_key_type_not_allowed",
-		Description:   "Certificates must have RSA, DSA, or ECDSA public key type.",
+		Description:   "Certificates MUST have RSA, DSA, or ECDSA public key type",
 		Providence:    "CAB: 6.1.5",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &publicKeyAllowed{},

--- a/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
+++ b/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
@@ -43,7 +43,7 @@ func (l *rootCaPathLenPresent) RunTest(c *x509.Certificate) (ResultStruct, error
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_root_ca_basic_constraints_path_len_constraint_field_present",
-		Description:   "Root CA certificate basicConstraint extension pathLenConstraint field should not be present",
+		Description:   "Root CA certificate basicConstraint extension pathLenConstraint field SHOULD NOT be present",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &rootCaPathLenPresent{},

--- a/lints/lint_root_ca_contains_cert_policy.go
+++ b/lints/lint_root_ca_contains_cert_policy.go
@@ -35,7 +35,7 @@ func (l *rootCAContainsCertPolicy) RunTest(c *x509.Certificate) (ResultStruct, e
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_root_ca_contains_cert_policy",
-		Description:   "Root CA certs SHOULD NOT contain the certificat policies extension.",
+		Description:   "Root CA certs SHOULD NOT contain the certificate policies extension",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &rootCAContainsCertPolicy{},

--- a/lints/lint_root_ca_extended_key_usage_present.go
+++ b/lints/lint_root_ca_extended_key_usage_present.go
@@ -36,7 +36,7 @@ func (l *rootCAContainsEKU) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_root_ca_extended_key_usage_present",
-		Description:   "Root CA certificates must not have the extendedKeyUsage extension present",
+		Description:   "Root CA certificates MUST NOT have the extendedKeyUsage extension present",
 		Providence:    "CAB: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &rootCAContainsEKU{},

--- a/lints/lint_rsa_exp_negative.go
+++ b/lints/lint_rsa_exp_negative.go
@@ -32,7 +32,7 @@ func (l *rsaExpNegative) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_rsa_exp_negative",
-		Description:   "RSA public key exponent must be positive",
+		Description:   "RSA public key exponent MUST be positive",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &rsaExpNegative{},

--- a/lints/lint_rsa_mod_factors_smaller_than_752_bits.go
+++ b/lints/lint_rsa_mod_factors_smaller_than_752_bits.go
@@ -36,7 +36,7 @@ func (l *rsaModSmallFactor) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_rsa_mod_factors_smaller_than_752",
-		Description:   "The modulus of a RSA public key should have no factors smaller than 752",
+		Description:   "The modulus of a RSA public key SHOULD NOT have factors smaller than 752",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,
 		Test:          &rsaModSmallFactor{},

--- a/lints/lint_rsa_mod_less_than_2048_bits.go
+++ b/lints/lint_rsa_mod_less_than_2048_bits.go
@@ -36,7 +36,7 @@ func (l *rsaParsedTestsKeySize) RunTest(c *x509.Certificate) (ResultStruct, erro
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_rsa_mod_less_than_2048_bits",
-		Description:   "in validity period beginning after 31 Dec 2010, all certificates using RSA public key algorithm must have 2048 bits of modulus",
+		Description:   "In the validity period beginning after 31 Dec 2010, all certificates using RSA public key algorithm MUST have 2048 bits of modulus",
 		Providence:    "CAB: 6.1.5",
 		EffectiveDate: util.RsaDate, // CA/B BR is retroactive here
 		Test:          &rsaParsedTestsKeySize{},

--- a/lints/lint_rsa_public_exponent_not_in_range.go
+++ b/lints/lint_rsa_public_exponent_not_in_range.go
@@ -45,7 +45,7 @@ func (l *rsaParsedTestsExpInRange) RunTest(c *x509.Certificate) (ResultStruct, e
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_rsa_public_exponent_not_in_range",
-		Description:   "The RSA public exponent SHOULD be in the range between 2^16 + 1 and 2^256 - 1",
+		Description:   "The RSA public exponent SHOULD be between 2^16 + 1 and 2^256 - 1",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,
 		Test:          &rsaParsedTestsExpInRange{},

--- a/lints/lint_rsa_public_exponent_too_small.go
+++ b/lints/lint_rsa_public_exponent_too_small.go
@@ -37,7 +37,7 @@ func (l *rsaParsedTestsExpBounds) RunTest(c *x509.Certificate) (ResultStruct, er
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_rsa_public_exponent_too_small",
-		Description:   "RSA public key has to be greater or equal to 3",
+		Description:   "RSA public key MUST be greater or equal to 3",
 		Providence:    "CAB: 6.1.6",
 		EffectiveDate: util.CABV113Date,
 		Test:          &rsaParsedTestsExpBounds{},

--- a/lints/lint_san_bare_wildcard.go
+++ b/lints/lint_san_bare_wildcard.go
@@ -32,7 +32,7 @@ func (l *brSANBareWildcard) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_san_bare_wildcard",
-		Description:   "Wildcard MUST be accompanied by other data to its right (Only checks DNSName)",
+		Description:   "A wildcard MUST be accompanied by other data to its right (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &brSANBareWildcard{},

--- a/lints/lint_san_bare_wildcard.go
+++ b/lints/lint_san_bare_wildcard.go
@@ -32,7 +32,7 @@ func (l *brSANBareWildcard) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_san_bare_wildcard",
-		Description:   "Wildcard MUST be accompanied by other data to it's right (Only checks DNSName)",
+		Description:   "Wildcard MUST be accompanied by other data to its right (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &brSANBareWildcard{},

--- a/lints/lint_san_dns_name_includes_null_char.go
+++ b/lints/lint_san_dns_name_includes_null_char.go
@@ -33,7 +33,7 @@ func (l *SANDNSNull) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_san_dns_name_includes_null_char",
-		Description:   "DNSNames MUST NOT include a null character ",
+		Description:   "DNSName MUST NOT include a null character",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &SANDNSNull{},

--- a/lints/lint_san_iana_pub_suffix_empty.go
+++ b/lints/lint_san_iana_pub_suffix_empty.go
@@ -33,7 +33,7 @@ func (l *pubSuffix) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_san_iana_pub_suffix_empty",
-		Description:   "Domain SHOULD NOT have a bare public suffix",
+		Description:   "The domain SHOULD NOT have a bare public suffix",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &pubSuffix{},

--- a/lints/lint_san_iana_pub_suffix_empty.go
+++ b/lints/lint_san_iana_pub_suffix_empty.go
@@ -33,7 +33,7 @@ func (l *pubSuffix) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_san_iana_pub_suffix_empty",
-		Description:   "Domain SHOULD NOT have bare public suffix",
+		Description:   "Domain SHOULD NOT have a bare public suffix",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &pubSuffix{},

--- a/lints/lint_san_wildcard_not_first.go
+++ b/lints/lint_san_wildcard_not_first.go
@@ -33,7 +33,7 @@ func (l *SANWildCardFirst) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_san_wildcard_not_first",
-		Description:   "Wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks DNSName)",
+		Description:   "A wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &SANWildCardFirst{},

--- a/lints/lint_san_wildcard_not_first.go
+++ b/lints/lint_san_wildcard_not_first.go
@@ -33,7 +33,7 @@ func (l *SANWildCardFirst) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_san_wildcard_not_first",
-		Description:   "Wildcard MUST be in the first label of FQDN, ie not: www.*.com (Only checks DNSName)",
+		Description:   "Wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks DNSName)",
 		Providence:    "",
 		EffectiveDate: util.ZeroDate,
 		Test:          &SANWildCardFirst{},

--- a/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
@@ -38,7 +38,7 @@ func (l *subCaIssuerUrl) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_ca_aia_does_not_contain_issuing_ca_url",
-		Description:   "Subordinate CA certificates authorityInformationAccess extension should contain the HTTP URL of the Issuing CA’s certificate",
+		Description:   "Subordinate CA certificates authorityInformationAccess extension should contain the HTTP URL of the issuing CA’s certificate",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCaIssuerUrl{},

--- a/lints/lint_sub_ca_aia_does_not_contain_ocsp_url.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_ocsp_url.go
@@ -38,7 +38,7 @@ func (l *subCaOcspUrl) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_aia_does_not_contain_ocsp_url",
-		Description:   "Subordinate CA certificates authorityInformationAccess extension must contain the HTTP URL of the Issuing CA’s OCSP responder",
+		Description:   "Subordinate CA certificates authorityInformationAccess extension must contain the HTTP URL of the issuing CA’s OCSP responder",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCaOcspUrl{},

--- a/lints/lint_sub_ca_aia_missing.go
+++ b/lints/lint_sub_ca_aia_missing.go
@@ -38,7 +38,7 @@ func (l *caAiaMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_aia_missing",
-		Description:   "Subordinate CA certificates must have a authorityInformationAccess extension.",
+		Description:   "Subordinate CA certificates must have a authorityInformationAccess extension",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caAiaMissing{},

--- a/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
@@ -37,7 +37,7 @@ func (l *subCACRLDistNoUrl) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_crl_distribution_points_does_not_contain_url",
-		Description:   "Subordinate CA certificates cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service.",
+		Description:   "Subordinate CA certificates cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCACRLDistNoUrl{},

--- a/lints/lint_sub_ca_eku_critical.go
+++ b/lints/lint_sub_ca_eku_critical.go
@@ -38,7 +38,7 @@ func (l *subCAEKUCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_ca_eku_critical",
-		Description:   "Subordinate CA certificate extkeyUsage extension should be marked non-critical if present.",
+		Description:   "Subordinate CA certificate extkeyUsage extension should be marked non-critical if present",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABV116Date,
 		Test:          &subCAEKUCrit{},

--- a/lints/lint_sub_ca_no_dns_name_contstraints.go
+++ b/lints/lint_sub_ca_no_dns_name_contstraints.go
@@ -40,7 +40,7 @@ func (l *subCaBadDNSConstraint) RunTest(c *x509.Certificate) (ResultStruct, erro
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_no_dns_name_constraints",
-		Description:   "Subordanate CA certificates MUST be accompanied by other data to it's right must include in the name contraints extension either premitted DNS names or prohibit the empty DNS name",
+		Description:   "Subordinate CA certificates MUST be accompanied by other data to it's right must include in the name contraints extension either permitted DNS names or prohibit the empty DNS name",
 		Providence:    "CAB: 7.1.5",
 		EffectiveDate: util.CABV116Date,
 		Test:          &subCaBadDNSConstraint{},

--- a/lints/lint_sub_ca_no_dns_name_contstraints.go
+++ b/lints/lint_sub_ca_no_dns_name_contstraints.go
@@ -40,7 +40,7 @@ func (l *subCaBadDNSConstraint) RunTest(c *x509.Certificate) (ResultStruct, erro
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_no_dns_name_constraints",
-		Description:   "Subordanate CA certs must include in the name contraints extension either premitted dns names or prohibit the empty DNS name.",
+		Description:   "Subordanate CA certificates MUST be accompanied by other data to it's right must include in the name contraints extension either premitted DNS names or prohibit the empty DNS name",
 		Providence:    "CAB: 7.1.5",
 		EffectiveDate: util.CABV116Date,
 		Test:          &subCaBadDNSConstraint{},

--- a/lints/lint_sub_ca_no_ip_name_contstraints.go
+++ b/lints/lint_sub_ca_no_ip_name_contstraints.go
@@ -56,7 +56,7 @@ func (l *subCaBadIPConstraint) RunTest(c *x509.Certificate) (ResultStruct, error
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_no_ip_name_constraints",
-		Description:   "Subordanate CA certs must include in the name contraints extension either premitted ip ranges or prohibit all ip addresses.",
+		Description:   "Subordinate CA certs must include in the name contraints extension either permitted IP ranges or prohibit all IP addresses",
 		Providence:    "CAB: 7.1.5",
 		EffectiveDate: util.CABV116Date,
 		Test:          &subCaBadIPConstraint{},

--- a/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
@@ -37,7 +37,7 @@ func (l *subCertIssuerUrl) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_aia_does_not_contain_issuing_ca_url",
-		Description:   "Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the Issuing CA’s certificate",
+		Description:   "Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the issuing CA’s certificate",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertIssuerUrl{},

--- a/lints/lint_sub_cert_aia_does_not_contain_ocsp_url.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_ocsp_url.go
@@ -39,7 +39,7 @@ func (l *subCertOcspUrl) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_aia_does_not_contain_ocsp_url",
-		Description:   "Subscriber certificates authorityInformationAccess extension must contain the HTTP URL of the Issuing CA’s OCSP responder",
+		Description:   "Subscriber certificates authorityInformationAccess extension must contain the HTTP URL of the issuing CA’s OCSP responder",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertOcspUrl{},

--- a/lints/lint_sub_cert_aia_missing.go
+++ b/lints/lint_sub_cert_aia_missing.go
@@ -39,7 +39,7 @@ func (l *subCertAiaMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_aia_missing",
-		Description:   "Subscriber certificates must have a authorityInformationAccess extension.",
+		Description:   "Subscriber certificates must have a authorityInformationAccess extension",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertAiaMissing{},

--- a/lints/lint_sub_cert_aia_missing.go
+++ b/lints/lint_sub_cert_aia_missing.go
@@ -39,7 +39,7 @@ func (l *subCertAiaMissing) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_aia_missing",
-		Description:   "Subscriber certificates must have a authorityInformationAccess extension",
+		Description:   "Subscriber certificates must have an authorityInformationAccess extension",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertAiaMissing{},

--- a/lints/lint_sub_cert_certificate_policies_marked_critical.go
+++ b/lints/lint_sub_cert_certificate_policies_marked_critical.go
@@ -35,7 +35,7 @@ func (l *subCertPolicyCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_cert_certificate_policies_marked_critical",
-		Description:   "Subscriber certificate should have policies extension marked non-critical",
+		Description:   "Subscriber certificates should have the policies extension marked non-critical",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertPolicyCrit{},

--- a/lints/lint_sub_cert_certificate_policies_missing.go
+++ b/lints/lint_sub_cert_certificate_policies_missing.go
@@ -37,7 +37,7 @@ func (l *subCertPolicy) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_certificate_policies_missing",
-		Description:   "Subscriber certificates should have certificates policies extension present",
+		Description:   "Subscriber certificates should have the certificates policies extension present",
 		Providence:    "CAB: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertPolicy{},

--- a/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
@@ -40,7 +40,7 @@ func (l *subCRLDistNoURL) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_crl_distribution_points_does_not_contain_url",
-		Description:   "Subscriber certificate cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service.",
+		Description:   "Subscriber certificate cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCRLDistNoURL{},

--- a/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
+++ b/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
@@ -39,7 +39,7 @@ func (l *subCrlDistCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_crl_distribution_points_marked_critical",
-		Description:   "Subscriber certificate cRLDistributionPoints extension must not be marked critical if present",
+		Description:   "Subscriber certificate cRLDistributionPoints extension MUST NOT be marked critical if present",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCrlDistCrit{},

--- a/lints/lint_sub_cert_eku_extra_values.go
+++ b/lints/lint_sub_cert_eku_extra_values.go
@@ -45,7 +45,7 @@ func (l *subExtKeyUsageLegalUsage) RunTest(c *x509.Certificate) (ResultStruct, e
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_cert_eku_extra_values",
-		Description:   "Subscriber certificates should have only id-kp-serverAuth, id-kp-clientAuth, or id-kp-emailProtection in extKeyUsage",
+		Description:   "Subscriber certificates SHOULD have only id-kp-serverAuth, id-kp-clientAuth, or id-kp-emailProtection in extKeyUsage",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subExtKeyUsageLegalUsage{},

--- a/lints/lint_sub_cert_eku_extra_values.go
+++ b/lints/lint_sub_cert_eku_extra_values.go
@@ -45,7 +45,7 @@ func (l *subExtKeyUsageLegalUsage) RunTest(c *x509.Certificate) (ResultStruct, e
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_cert_eku_extra_values",
-		Description:   "Subscriber certificates should have only id-kp-serverAuth, id-kp-clientAuth, or id-kp-emailProtection in extKeyUsage. Anything should not be included.",
+		Description:   "Subscriber certificates should have only id-kp-serverAuth, id-kp-clientAuth, or id-kp-emailProtection in extKeyUsage",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subExtKeyUsageLegalUsage{},

--- a/lints/lint_sub_cert_eku_missing.go
+++ b/lints/lint_sub_cert_eku_missing.go
@@ -37,7 +37,7 @@ func (l *subExtKeyUsage) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_eku_missing",
-		Description:   "Subscriber certificates must have the extended key usage extension present",
+		Description:   "Subscriber certificates MUST have the extended key usage extension present",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subExtKeyUsage{},

--- a/lints/lint_sub_cert_eku_server_auth_client_auth_missing.go
+++ b/lints/lint_sub_cert_eku_server_auth_client_auth_missing.go
@@ -40,7 +40,7 @@ func (l *subExtKeyUsageClientOrServer) RunTest(c *x509.Certificate) (ResultStruc
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_eku_server_auth_client_auth_missing",
-		Description:   "Subscriber certificates must have have either id-kp-serverAuth or id-kp-clientAuth or both present in extKeyUsage",
+		Description:   "Subscriber certificates MUST have have either id-kp-serverAuth or id-kp-clientAuth or both present in extKeyUsage",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subExtKeyUsageClientOrServer{},

--- a/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
@@ -36,7 +36,7 @@ func (l *subCertKeyUsageBitSet) RunTest(c *x509.Certificate) (ResultStruct, erro
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_key_usage_cert_sign_bit_set",
-		Description:   "Subscriber certificates keyUsage extension keyCertSign bit must not be set",
+		Description:   "Subscriber certificates keyUsage extension keyCertSign bit MUST NOT be set",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertKeyUsageBitSet{},

--- a/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
@@ -37,7 +37,7 @@ func (l *subCrlSignAllowed) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_key_usage_crl_sign_bit_set",
-		Description:   "Subscriber certificates keyUsage extension cRLSign bit must not be set",
+		Description:   "Subscriber certificates keyUsage extension cRLSign bit MUST NOT be set",
 		Providence:    "CAB: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCrlSignAllowed{},

--- a/lints/lint_sub_cert_or_sub_ca_using_sha1.go
+++ b/lints/lint_sub_cert_or_sub_ca_using_sha1.go
@@ -40,7 +40,7 @@ func (l *sigAlgTestsSHA1) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_or_sub_ca_using_sha1",
-		Description:   "Subscriber certificates and subordinate CA certificates must not use the SHA-1 hash algorithm on a certificate with a NotBefore date later than 1 Jan 2016",
+		Description:   "Subscriber certificates and subordinate CA certificates MUST NOT use the SHA-1 hash algorithm on a certificate with a NotBefore date later than 1 Jan 2016",
 		Providence:    "CAB: 7.1.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &sigAlgTestsSHA1{},

--- a/lints/lint_sub_cert_or_sub_ca_using_sha1.go
+++ b/lints/lint_sub_cert_or_sub_ca_using_sha1.go
@@ -40,7 +40,7 @@ func (l *sigAlgTestsSHA1) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_or_sub_ca_using_sha1",
-		Description:   "Subscriber certificates and subordinate CA certificates must not use the SHA-1 hash algorithm on a certificate with a NotBefore date after 1 Jan 2016",
+		Description:   "Subscriber certificates and subordinate CA certificates must not use the SHA-1 hash algorithm on a certificate with a NotBefore date later than 1 Jan 2016",
 		Providence:    "CAB: 7.1.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &sigAlgTestsSHA1{},

--- a/lints/lint_sub_cert_sha1_expiration_too_long.go
+++ b/lints/lint_sub_cert_sha1_expiration_too_long.go
@@ -37,7 +37,7 @@ func (l *sha1ExpireLong) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_cert_sha1_expiration_too_long",
-		Description:   "Subscriber certificates using the SHA-1 algorithm should not have an expiration date later than 1 Jan 2017",
+		Description:   "Subscriber certificates using the SHA-1 algorithm SHOULD NOT have an expiration date later than 1 Jan 2017",
 		Providence:    "CAB: 7.1.3",
 		EffectiveDate: time.Date(2015, time.January, 16, 0, 0, 0, 0, time.UTC),
 		Test:          &sha1ExpireLong{},

--- a/lints/lint_sub_cert_sha1_expiration_too_long.go
+++ b/lints/lint_sub_cert_sha1_expiration_too_long.go
@@ -37,7 +37,7 @@ func (l *sha1ExpireLong) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_cert_sha1_expiration_too_long",
-		Description:   "Subscriber certificates using the SHA1 algorithm should not have an expiration date greater than 1 Jan 2017",
+		Description:   "Subscriber certificates using the SHA-1 algorithm should not have an expiration date later than 1 Jan 2017",
 		Providence:    "CAB: 7.1.3",
 		EffectiveDate: time.Date(2015, time.January, 16, 0, 0, 0, 0, time.UTC),
 		Test:          &sha1ExpireLong{},

--- a/lints/lint_subject_common_name_disallowed.go
+++ b/lints/lint_subject_common_name_disallowed.go
@@ -44,7 +44,7 @@ func (l *BadCommonName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_common_name_disallowed",
-		Description:   "If present Common name MUST contain a single IP address or Fully‐Qualified Domain Name that is one of the values contained in the Certificate’s subjectAltName extension",
+		Description:   "If present, commonName MUST contain a single IP address or Fully‐Qualified Domain Name that is one of the values contained in the certificate’s subjectAltName extension",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &BadCommonName{},

--- a/lints/lint_subject_common_name_included.go
+++ b/lints/lint_subject_common_name_included.go
@@ -34,7 +34,7 @@ func (l *commonNames) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "n_subject_common_name_included",
-		Description:   "Use of the common name field is discouraged.",
+		Description:   "Use of the commonName field is discouraged",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &commonNames{},

--- a/lints/lint_subject_common_name_max_length.go
+++ b/lints/lint_subject_common_name_max_length.go
@@ -36,7 +36,7 @@ func (l *subjectCommonNameMaxLength) RunTest(c *x509.Certificate) (ResultStruct,
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_common_name_max_length",
-		Description:   "The 'Common Name' field of the subject must be less than 64 characters.",
+		Description:   "The commonName field of the subject must be less than 64 characters",
 		Providence:    "RFC 5280: A.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectCommonNameMaxLength{},

--- a/lints/lint_subject_common_name_max_length.go
+++ b/lints/lint_subject_common_name_max_length.go
@@ -36,7 +36,7 @@ func (l *subjectCommonNameMaxLength) RunTest(c *x509.Certificate) (ResultStruct,
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_common_name_max_length",
-		Description:   "The commonName field of the subject must be less than 64 characters",
+		Description:   "The commonName field of the subject MUST be less than 64 characters",
 		Providence:    "RFC 5280: A.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectCommonNameMaxLength{},

--- a/lints/lint_subject_common_name_not_from_san.go
+++ b/lints/lint_subject_common_name_not_from_san.go
@@ -46,7 +46,7 @@ func (l *subjectCommonNameNotFromSAN) RunTest(c *x509.Certificate) (ResultStruct
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_common_name_not_from_san",
-		Description:   "The common name field must include only names from the SAN extension.",
+		Description:   "The commonName field must include only names from the SAN extension",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subjectCommonNameNotFromSAN{},

--- a/lints/lint_subject_common_name_not_from_san.go
+++ b/lints/lint_subject_common_name_not_from_san.go
@@ -46,7 +46,7 @@ func (l *subjectCommonNameNotFromSAN) RunTest(c *x509.Certificate) (ResultStruct
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_common_name_not_from_san",
-		Description:   "The commonName field must include only names from the SAN extension",
+		Description:   "The commonName field must include only names from the subjectAlternateName extension",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subjectCommonNameNotFromSAN{},

--- a/lints/lint_subject_contains_noninformational_value.go
+++ b/lints/lint_subject_contains_noninformational_value.go
@@ -57,7 +57,7 @@ func (l *illegalChar) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_contains_noninformational_value",
-		Description:   "Subject name fields must not contain '.','-',' ' or any other indication that the field has been omitted.",
+		Description:   "Subject name fields must not contain '.','-',' ' or any other indication that the field has been omitted",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &illegalChar{},

--- a/lints/lint_subject_contains_reserved_ip.go
+++ b/lints/lint_subject_contains_reserved_ip.go
@@ -43,7 +43,7 @@ func (l *subjectReservedIP) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_contains_reserved_ip",
-		Description:   "Certs and expiring after 2015-11-01 must not contain a reserved ip address in the common name field.",
+		Description:   "Certificates expiring later than 11 Jan 2015 MUST NOT contain a reserved IP address in the common name field",
 		Providence:    "CAB: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subjectReservedIP{},

--- a/lints/lint_subject_country_not_iso.go
+++ b/lints/lint_subject_country_not_iso.go
@@ -39,7 +39,7 @@ func (l *countryNotIso) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_country_not_iso",
-		Description:   "The country name field must contain the two-letter ISO code for the country or XX.",
+		Description:   "The country name field MUST contain the two-letter ISO code for the country or XX",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &countryNotIso{},

--- a/lints/lint_subject_empty_without_san.go
+++ b/lints/lint_subject_empty_without_san.go
@@ -48,7 +48,7 @@ func subjectIsEmpty(cert *x509.Certificate) bool {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_empty_without_san",
-		Description:   "CAs must support subject alternative name if the subject field is an empty sequence.",
+		Description:   "CAs must support subject alternative name if the subject field is an empty sequence",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &emptyWithoutSAN{},

--- a/lints/lint_subject_empty_without_san.go
+++ b/lints/lint_subject_empty_without_san.go
@@ -48,7 +48,7 @@ func subjectIsEmpty(cert *x509.Certificate) bool {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_empty_without_san",
-		Description:   "CAs must support subject alternative name if the subject field is an empty sequence",
+		Description:   "CAs MUST support subject alternative name if the subject field is an empty sequence",
 		Providence:    "RFC 5280: 4.2 & 4.2.1.6",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &emptyWithoutSAN{},

--- a/lints/lint_subject_info_access_marked_critical.go
+++ b/lints/lint_subject_info_access_marked_critical.go
@@ -32,7 +32,7 @@ func (l *siaCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_info_access_marked_critical",
-		Description:   "Conforming CAs must mark the Subject Info Access extension as non-critical",
+		Description:   "Conforming CAs MUST mark the Subject Info Access extension as non-critical",
 		Providence:    "RFC 5280: 4.2.2.2",
 		EffectiveDate: util.RFC3280Date,
 		Test:          &siaCrit{},

--- a/lints/lint_subject_info_access_marked_critical.go
+++ b/lints/lint_subject_info_access_marked_critical.go
@@ -32,7 +32,7 @@ func (l *siaCrit) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_info_access_marked_critical",
-		Description:   "Conforming CAs must mark the Subject Info Access extension as non-critical.",
+		Description:   "Conforming CAs must mark the Subject Info Access extension as non-critical",
 		Providence:    "RFC 5280: 4.2.2.2",
 		EffectiveDate: util.RFC3280Date,
 		Test:          &siaCrit{},

--- a/lints/lint_subject_locality_name_max_length.go
+++ b/lints/lint_subject_locality_name_max_length.go
@@ -39,7 +39,7 @@ func (l *subjectLocalityNameMaxLength) RunTest(c *x509.Certificate) (ResultStruc
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_locality_name_max_length",
-		Description:   "The 'Locality Name' field of the subject must be less than 128 characters",
+		Description:   "The 'Locality Name' field of the subject MUST be less than 128 characters",
 		Providence:    "RFC 5280: A.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectLocalityNameMaxLength{},

--- a/lints/lint_subject_locality_name_max_length.go
+++ b/lints/lint_subject_locality_name_max_length.go
@@ -39,7 +39,7 @@ func (l *subjectLocalityNameMaxLength) RunTest(c *x509.Certificate) (ResultStruc
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_locality_name_max_length",
-		Description:   "The 'Locality Name' field of the subject must be less than 128 characters.",
+		Description:   "The 'Locality Name' field of the subject must be less than 128 characters",
 		Providence:    "RFC 5280: A.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectLocalityNameMaxLength{},

--- a/lints/lint_subject_locality_without_org.go
+++ b/lints/lint_subject_locality_without_org.go
@@ -38,7 +38,7 @@ func (l *localNoOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_locality_without_org",
-		Description:   "The locality field must not be included without an organization name.",
+		Description:   "The Locality field MUST NOT be included without an organization name",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &localNoOrg{},

--- a/lints/lint_subject_not_dn.go
+++ b/lints/lint_subject_not_dn.go
@@ -39,7 +39,7 @@ func (l *subjectDN) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_not_dn",
-		Description:   "When not empty, the subject field must be a distinguished name",
+		Description:   "When not empty, the subject field MUST be a distinguished name",
 		Providence:    "RFC 5280: 4.1.2.6",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectDN{},

--- a/lints/lint_subject_org_without_country.go
+++ b/lints/lint_subject_org_without_country.go
@@ -37,7 +37,7 @@ func (l *orgNoCountry) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_org_without_country",
-		Description:   "The organization name field must not be included without a country name.",
+		Description:   "The organization name field MUST not be included without a country name",
 		Providence:    "CAB: 7.1.4.2.2 (d&e)",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &orgNoCountry{},

--- a/lints/lint_subject_org_without_locality_or_province.go
+++ b/lints/lint_subject_org_without_locality_or_province.go
@@ -33,7 +33,7 @@ func (l *orgNoLocalOrProvince) RunTest(cert *x509.Certificate) (ResultStruct, er
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_org_without_locality_or_province",
-		Description:   "If organiation is included, either stateOrProvince or locality must be included.",
+		Description:   "If organiation is included, either stateOrProvince or locality MUST be included",
 		Providence:    "CAB: 7.1.4.2.2 (d&e)",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &orgNoLocalOrProvince{},

--- a/lints/lint_subject_organization_name_max_length.go
+++ b/lints/lint_subject_organization_name_max_length.go
@@ -39,7 +39,7 @@ func (l *subjectOrganizationNameMaxLength) RunTest(c *x509.Certificate) (ResultS
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_organization_name_max_length",
-		Description:   "The 'Organization Name' field of the subject must be less than 64 characters.",
+		Description:   "The 'Organization Name' field of the subject must be less than 64 characters",
 		Providence:    "RFC 5280: A.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectOrganizationNameMaxLength{},

--- a/lints/lint_subject_organization_name_max_length.go
+++ b/lints/lint_subject_organization_name_max_length.go
@@ -39,7 +39,7 @@ func (l *subjectOrganizationNameMaxLength) RunTest(c *x509.Certificate) (ResultS
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_organization_name_max_length",
-		Description:   "The 'Organization Name' field of the subject must be less than 64 characters",
+		Description:   "The 'Organization Name' field of the subject MUST be less than 64 characters",
 		Providence:    "RFC 5280: A.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectOrganizationNameMaxLength{},

--- a/lints/lint_subject_organizational_unit_name_max_length.go
+++ b/lints/lint_subject_organizational_unit_name_max_length.go
@@ -39,7 +39,7 @@ func (l *subjectOrganizationalUnitNameMaxLength) RunTest(c *x509.Certificate) (R
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_organizational_unit_name_max_length",
-		Description:   "The 'Organizational Unit Name' field of the subject must be less than 64 characters",
+		Description:   "The 'Organizational Unit Name' field of the subject MUST be less than 64 characters",
 		Providence:    "RFC 5280: A.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectOrganizationalUnitNameMaxLength{},

--- a/lints/lint_subject_organizational_unit_name_max_length.go
+++ b/lints/lint_subject_organizational_unit_name_max_length.go
@@ -39,7 +39,7 @@ func (l *subjectOrganizationalUnitNameMaxLength) RunTest(c *x509.Certificate) (R
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_organizational_unit_name_max_length",
-		Description:   "The 'Organizational Unit Name' field of the subject must be less than 64 characters.",
+		Description:   "The 'Organizational Unit Name' field of the subject must be less than 64 characters",
 		Providence:    "RFC 5280: A.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectOrganizationalUnitNameMaxLength{},

--- a/lints/lint_subject_postal_without_org.go
+++ b/lints/lint_subject_postal_without_org.go
@@ -37,7 +37,7 @@ func (l *postalNoOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_postal_without_org",
-		Description:   "The postal code must not be included without an organization name",
+		Description:   "The postal code MUST NOT be included without an organization name",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &postalNoOrg{},

--- a/lints/lint_subject_postal_without_org.go
+++ b/lints/lint_subject_postal_without_org.go
@@ -37,7 +37,7 @@ func (l *postalNoOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_postal_without_org",
-		Description:   "The postal code must not be included without an organization name.",
+		Description:   "The postal code must not be included without an organization name",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &postalNoOrg{},

--- a/lints/lint_subject_province_without_org.go
+++ b/lints/lint_subject_province_without_org.go
@@ -37,7 +37,7 @@ func (l *provinceNoOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_province_without_org",
-		Description:   "The stateOrProvince name must not be included without an organization name",
+		Description:   "The stateOrProvince name MUST NOT be included without an organization name",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &provinceNoOrg{},

--- a/lints/lint_subject_province_without_org.go
+++ b/lints/lint_subject_province_without_org.go
@@ -37,7 +37,7 @@ func (l *provinceNoOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_province_without_org",
-		Description:   "The stateOrProvince name must not be included without an organization name.",
+		Description:   "The stateOrProvince name must not be included without an organization name",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &provinceNoOrg{},

--- a/lints/lint_subject_state_name_max_length.go
+++ b/lints/lint_subject_state_name_max_length.go
@@ -39,7 +39,7 @@ func (l *subjectStateNameMaxLength) RunTest(c *x509.Certificate) (ResultStruct, 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_state_name_max_length",
-		Description:   "The 'State Name' field of the subject must be less than 128 characters",
+		Description:   "The 'State Name' field of the subject MUST be less than 128 characters",
 		Providence:    "RFC 5280: A.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectStateNameMaxLength{},

--- a/lints/lint_subject_state_name_max_length.go
+++ b/lints/lint_subject_state_name_max_length.go
@@ -39,7 +39,7 @@ func (l *subjectStateNameMaxLength) RunTest(c *x509.Certificate) (ResultStruct, 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_state_name_max_length",
-		Description:   "The 'State Name' field of the subject must be less than 128 characters.",
+		Description:   "The 'State Name' field of the subject must be less than 128 characters",
 		Providence:    "RFC 5280: A.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &subjectStateNameMaxLength{},

--- a/lints/lint_subject_street_without_org.go
+++ b/lints/lint_subject_street_without_org.go
@@ -37,7 +37,7 @@ func (l *streetNoOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_street_without_org",
-		Description:   "The 'Street Address' field must not be included without an organization name",
+		Description:   "The 'Street Address' field MUST NOT be included without an organization name",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &streetNoOrg{},

--- a/lints/lint_subject_street_without_org.go
+++ b/lints/lint_subject_street_without_org.go
@@ -37,7 +37,7 @@ func (l *streetNoOrg) RunTest(cert *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_street_without_org",
-		Description:   "The street address field must not be included without an organization name.",
+		Description:   "The 'Street Address' field must not be included without an organization name",
 		Providence:    "CAB: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &streetNoOrg{},

--- a/lints/lint_utc_time_does_not_include_seconds.go
+++ b/lints/lint_utc_time_does_not_include_seconds.go
@@ -59,7 +59,7 @@ func (l *utcNoSecond) RunTest(c *x509.Certificate) (ResultStruct, error) {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_utc_time_does_not_include_seconds",
-		Description:   "UTCTime values must include seconds",
+		Description:   "UTCTime values MUST include seconds",
 		Providence:    "RFC 5280: 4.1.2.5.1",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &utcNoSecond{},

--- a/lints/lint_wrong_time_format_pre2050.go
+++ b/lints/lint_wrong_time_format_pre2050.go
@@ -52,7 +52,7 @@ func (l *generalizedPre2050) RunTest(c *x509.Certificate) (ResultStruct, error) 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_wrong_time_format_pre2050",
-		Description:   "Certificates valid through the year 2049 must be encoded in UTC time",
+		Description:   "Certificates valid through the year 2049 MUST be encoded in UTC time",
 		Providence:    "RFC 5280: 4.1.2.5",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &generalizedPre2050{},

--- a/lints/lint_wrong_time_format_pre2050.go
+++ b/lints/lint_wrong_time_format_pre2050.go
@@ -52,7 +52,7 @@ func (l *generalizedPre2050) RunTest(c *x509.Certificate) (ResultStruct, error) 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_wrong_time_format_pre2050",
-		Description:   "Certificates with validity through the year 2049 must be encoded in UTC time",
+		Description:   "Certificates valid through the year 2049 must be encoded in UTC time",
 		Providence:    "RFC 5280: 4.1.2.5",
 		EffectiveDate: util.RFC2459Date,
 		Test:          &generalizedPre2050{},


### PR DESCRIPTION
Standardized some conventions in the description text that displays when tests fail. No periods at the end of lines, MUST/SHOULD capitalized, etc.... I also fixed some typos and tried to clarify some of the less obvious descriptions.