### PR TITLE
adding defense checks to lints where the did not appear

### DIFF
--- a/lints/lint_distribution_point_incomplete.go
+++ b/lints/lint_distribution_point_incomplete.go
@@ -47,7 +47,10 @@ func (l *dpIncomplete) CheckApplies(c *x509.Certificate) bool {
 func (l *dpIncomplete) RunTest(c *x509.Certificate) (ResultStruct, error) {
 	dp := util.GetExtFromCert(c, util.CrlDistOID)
 	var cdp []distributionPoint
-	asn1.Unmarshal(dp.Value, &cdp)
+	_, err := asn1.Unmarshal(dp.Value, &cdp)
+	if err != nil {
+		return ResultStruct{Result: Fatal}, nil
+	}
 	for _, dp := range cdp {
 		if dp.Reason.BitLength != 0 && len(dp.DistributionPoint.FullName.Bytes) == 0 &&
 			dp.DistributionPoint.RelativeName == nil && len(dp.CRLIssuer.Bytes) == 0 {

--- a/lints/lint_ext_ian_dns_not_ia5_string.go
+++ b/lints/lint_ext_ian_dns_not_ia5_string.go
@@ -44,8 +44,8 @@ func (l *IANDNSNotIA5String) RunTest(c *x509.Certificate) (ResultStruct, error) 
 		return ResultStruct{Result: NA}, err
 	}
 	if !seq.IsCompound || seq.Tag != 16 || seq.Class != 0 {
-		err = asn1.StructuralError{Msg: "bad SAN sequence"}
-		return ResultStruct{Result: NA}, err
+		err = asn1.StructuralError{Msg: "bad IAN sequence"}
+		return ResultStruct{Result: Fatal}, err
 	}
 
 	rest := seq.Bytes

--- a/lints/lint_ext_ian_empty_name.go
+++ b/lints/lint_ext_ian_empty_name.go
@@ -40,8 +40,8 @@ func (l *IANEmptyName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 		return ResultStruct{Result: NA}, err
 	}
 	if !seq.IsCompound || seq.Tag != 16 || seq.Class != 0 {
-		err = asn1.StructuralError{Msg: "bad SAN sequence"}
-		return ResultStruct{Result: NA}, err
+		err = asn1.StructuralError{Msg: "bad IAN sequence"}
+		return ResultStruct{Result: Fatal}, err
 	}
 
 	rest := seq.Bytes

--- a/lints/lint_ext_ian_uri_host_not_fqdn_or_ip.go
+++ b/lints/lint_ext_ian_uri_host_not_fqdn_or_ip.go
@@ -34,7 +34,10 @@ func (l *IANURIFQDNOrIP) CheckApplies(c *x509.Certificate) bool {
 func (l *IANURIFQDNOrIP) RunTest(c *x509.Certificate) (ResultStruct, error) {
 	for _, uri := range c.IANURIs {
 		if uri != "" {
-			parsedUrl, _ := url.Parse(uri)
+			parsedUrl, err := url.Parse(uri)
+			if err != nil {
+				return ResultStruct{Result: Error}, nil
+			}
 			host := parsedUrl.Host
 			if !util.AuthIsFQDNOrIP(host) {
 				return ResultStruct{Result: Error}, nil

--- a/lints/lint_ext_policy_constraints_empty.go
+++ b/lints/lint_ext_policy_constraints_empty.go
@@ -40,7 +40,10 @@ func (l *policyConstraintsContents) CheckApplies(c *x509.Certificate) bool {
 func (l *policyConstraintsContents) RunTest(c *x509.Certificate) (ResultStruct, error) {
 	pc := util.GetExtFromCert(c, util.PolicyConstOID)
 	var seq asn1.RawValue
-	asn1.Unmarshal(pc.Value, &seq) //only one sequence, so rest should be empty
+	_, err := asn1.Unmarshal(pc.Value, &seq) //only one sequence, so rest should be empty
+	if err != nil {
+		return ResultStruct{Result: Fatal}, nil
+	}
 	if len(seq.Bytes) == 0 {
 		return ResultStruct{Result: Error}, nil
 	}

--- a/lints/lint_ext_san_dns_not_ia5_string.go
+++ b/lints/lint_ext_san_dns_not_ia5_string.go
@@ -45,7 +45,7 @@ func (l *SANDNSNotIA5String) RunTest(c *x509.Certificate) (ResultStruct, error) 
 	}
 	if !seq.IsCompound || seq.Tag != 16 || seq.Class != 0 {
 		err = asn1.StructuralError{Msg: "bad SAN sequence"}
-		return ResultStruct{Result: NA}, err
+		return ResultStruct{Result: Fatal}, err
 	}
 
 	rest := seq.Bytes

--- a/lints/lint_ext_san_empty_name.go
+++ b/lints/lint_ext_san_empty_name.go
@@ -41,7 +41,7 @@ func (l *SANEmptyName) RunTest(c *x509.Certificate) (ResultStruct, error) {
 	}
 	if !seq.IsCompound || seq.Tag != 16 || seq.Class != 0 {
 		err = asn1.StructuralError{Msg: "bad SAN sequence"}
-		return ResultStruct{Result: NA}, err
+		return ResultStruct{Result: Fatal}, err
 	}
 
 	rest := seq.Bytes

--- a/lints/lint_name_constraint_empty.go
+++ b/lints/lint_name_constraint_empty.go
@@ -43,7 +43,10 @@ func (l *nameConstraintEmpty) CheckApplies(c *x509.Certificate) bool {
 func (l *nameConstraintEmpty) RunTest(c *x509.Certificate) (ResultStruct, error) {
 	nc := util.GetExtFromCert(c, util.NameConstOID)
 	var seq asn1.RawValue
-	asn1.Unmarshal(nc.Value, &seq) //only one sequence, so rest should be empty
+	_, err := asn1.Unmarshal(nc.Value, &seq) //only one sequence, so rest should be empty
+	if err != nil {
+		return ResultStruct{Result: Fatal}, nil
+	}
 	if len(seq.Bytes) == 0 {
 		return ResultStruct{Result: Error}, nil
 	}

--- a/lints/lint_path_len_constraint_improperly_included.go
+++ b/lints/lint_path_len_constraint_improperly_included.go
@@ -30,7 +30,10 @@ func (l *pathLenIncluded) RunTest(cert *x509.Certificate) (ResultStruct, error) 
 	bc := util.GetExtFromCert(cert, util.BasicConstOID)
 	var seq asn1.RawValue
 	var isCa bool
-	asn1.Unmarshal(bc.Value, &seq)
+	_, err := asn1.Unmarshal(bc.Value, &seq)
+	if err != nil {
+		return ResultStruct{Result: Fatal}, nil
+	}
 	if len(seq.Bytes) == 0 {
 		return ResultStruct{Result: Pass}, nil
 	}

--- a/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
+++ b/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
@@ -29,11 +29,17 @@ func (l *rootCaPathLenPresent) RunTest(c *x509.Certificate) (ResultStruct, error
 	bc := util.GetExtFromCert(c, util.BasicConstOID)
 	var seq asn1.RawValue
 	var isCa bool
-	asn1.Unmarshal(bc.Value, &seq)
+	_, err := asn1.Unmarshal(bc.Value, &seq)
+	if err != nil {
+		return ResultStruct{Result: Fatal}, nil
+	}
 	if len(seq.Bytes) == 0 {
 		return ResultStruct{Result: Pass}, nil
 	}
-	rest, _ := asn1.Unmarshal(seq.Bytes, &isCa)
+	rest, err := asn1.Unmarshal(seq.Bytes, &isCa)
+	if err != nil {
+		return ResultStruct{Result: Fatal}, nil
+	}
 	if len(rest) > 0 {
 		return ResultStruct{Result: Warn}, nil
 	}

--- a/lints/lint_wrong_time_format_pre2050.go
+++ b/lints/lint_wrong_time_format_pre2050.go
@@ -33,15 +33,27 @@ func (l *generalizedPre2050) RunTest(c *x509.Certificate) (ResultStruct, error) 
 	var t time.Time
 	type1, type2 := util.FindTimeType(date1, date2)
 	if type1 == 24 {
-		temp, _ := asn1.Marshal(date1)
-		asn1.Unmarshal(temp, &t)
+		temp, err := asn1.Marshal(date1)
+		if err != nil {
+			return ResultStruct{Result: Fatal}, nil
+		}
+		_, err = asn1.Unmarshal(temp, &t)
+		if err != nil {
+			return ResultStruct{Result: Fatal}, nil
+		}
 		if t.Before(util.GeneralizedDate) {
 			return ResultStruct{Result: Error}, nil
 		}
 	}
 	if type2 == 24 {
-		temp, _ := asn1.Marshal(date2)
-		asn1.Unmarshal(temp, &t)
+		temp, err := asn1.Marshal(date2)
+		if err != nil {
+			return ResultStruct{Result: Fatal}, nil
+		}
+		_, err = asn1.Unmarshal(temp, &t)
+		if err != nil {
+			return ResultStruct{Result: Fatal}, nil
+		}
 		if t.Before(util.GeneralizedDate) {
 			return ResultStruct{Result: Error}, nil
 		}


### PR DESCRIPTION
Sometimes, errors wouldn't be checked, probably causing runtime bugs.