### PR TITLE
Switch AIA missing issuing CA URL from error to warn

### DIFF
--- a/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
@@ -30,7 +30,7 @@ func (l *subCertIssuerUrl) RunTest(c *x509.Certificate) (ResultStruct, error) {
 	if c.IssuingCertificateURL != nil {
 		return ResultStruct{Result: Pass}, nil
 	} else {
-		return ResultStruct{Result: Error}, nil
+		return ResultStruct{Result: Warn}, nil
 	}
 }
 

--- a/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url_test.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestSubCertNoIssuerUrl(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertWOcspURL.pem"
-	desEnum := Error
+	desEnum := Warn
 	out, _ := Lints["e_sub_cert_aia_does_not_contain_issuing_ca_url"].ExecuteTest(ReadCertificate(inputPath))
 	if out.Result != desEnum {
 		t.Error(


### PR DESCRIPTION
This is a SHOULD, not a MUST so it should be a warning.