### PR TITLE
Fix 1024-bit RSA sunset dates

### DIFF
--- a/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
+++ b/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
@@ -7,6 +7,7 @@ package lints
 
 import (
 	"crypto/rsa"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )
@@ -22,7 +23,7 @@ func (l *rootCaModSize) Initialize() error {
 func (l *rootCaModSize) CheckApplies(c *x509.Certificate) bool {
 	issueDate := c.NotBefore
 	_, ok := c.PublicKey.(*rsa.PublicKey)
-	return ok && c.PublicKeyAlgorithm == x509.RSA && util.IsRootCA(c) && issueDate.Before(util.RsaDate2)
+	return ok && c.PublicKeyAlgorithm == x509.RSA && util.IsRootCA(c) && issueDate.Before(util.NoRSA1024RootDate)
 }
 
 func (l *rootCaModSize) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
+++ b/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
@@ -5,6 +5,7 @@ package lints
 
 import (
 	"crypto/rsa"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )
@@ -21,7 +22,7 @@ func (l *subCaModSize) CheckApplies(c *x509.Certificate) bool {
 	issueDate := c.NotBefore
 	endDate := c.NotAfter
 	_, ok := c.PublicKey.(*rsa.PublicKey)
-	return ok && util.IsSubCA(c) && issueDate.Before(util.RsaDate2) && endDate.Before(util.RsaDate3)
+	return ok && util.IsSubCA(c) && issueDate.Before(util.NoRSA1024RootDate) && endDate.Before(util.NoRSA1024Date)
 }
 
 func (l *subCaModSize) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
+++ b/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
@@ -20,7 +20,7 @@ func (l *subModSize) Initialize() error {
 func (l *subModSize) CheckApplies(c *x509.Certificate) bool {
 	endDate := c.NotAfter
 	_, ok := c.PublicKey.(*rsa.PublicKey)
-	return ok && c.PublicKeyAlgorithm == x509.RSA && !util.IsCACert(c) && endDate.Before(util.RsaDate3)
+	return ok && c.PublicKeyAlgorithm == x509.RSA && !util.IsCACert(c) && endDate.Before(util.NoRSA1024Date)
 }
 
 func (l *subModSize) RunTest(c *x509.Certificate) (ResultStruct, error) {

--- a/lints/lint_rsa_mod_less_than_2048_bits.go
+++ b/lints/lint_rsa_mod_less_than_2048_bits.go
@@ -7,6 +7,7 @@ package lints
 
 import (
 	"crypto/rsa"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )
@@ -21,7 +22,7 @@ func (l *rsaParsedTestsKeySize) Initialize() error {
 
 func (l *rsaParsedTestsKeySize) CheckApplies(c *x509.Certificate) bool {
 	_, ok := c.PublicKey.(*rsa.PublicKey)
-	return ok && c.PublicKeyAlgorithm == x509.RSA
+	return ok && c.PublicKeyAlgorithm == x509.RSA && c.NotAfter.After(util.NoRSA1024Date.Add(-1))
 }
 
 func (l *rsaParsedTestsKeySize) RunTest(c *x509.Certificate) (ResultStruct, error) {
@@ -36,9 +37,9 @@ func (l *rsaParsedTestsKeySize) RunTest(c *x509.Certificate) (ResultStruct, erro
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_rsa_mod_less_than_2048_bits",
-		Description:   "In the validity period beginning after 31 Dec 2010, all certificates using RSA public key algorithm MUST have 2048 bits of modulus",
+		Description:   "For certificates valid after 31 Dec 2013, all certificates using RSA public key algorithm MUST have 2048 bits of modulus",
 		Provenance:    "CAB: 6.1.5",
-		EffectiveDate: util.RsaDate, // CA/B BR is retroactive here
+		EffectiveDate: util.ZeroDate,
 		Test:          &rsaParsedTestsKeySize{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ERsaModLessThan_2048Bits = result },
 	})

--- a/util/time.go
+++ b/util/time.go
@@ -2,31 +2,31 @@ package util
 
 import (
 	"encoding/asn1"
-	"github.com/zmap/zcrypto/x509"
 	"time"
+
+	"github.com/zmap/zcrypto/x509"
 )
 
 var (
-	ZeroDate         = time.Date(0000, time.January, 1, 0, 0, 0, 0, time.UTC)
-	RFC2459Date      = time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)
-	RFC3280Date      = time.Date(2002, time.April, 1, 0, 0, 0, 0, time.UTC)
-	RFC4325Date      = time.Date(2005, time.December, 1, 0, 0, 0, 0, time.UTC)
-	RFC4630Date      = time.Date(2006, time.August, 1, 0, 0, 0, 0, time.UTC)
-	RFC5280Date      = time.Date(2008, time.May, 1, 0, 0, 0, 0, time.UTC)
-	RFC6818Date      = time.Date(2013, time.January, 1, 0, 0, 0, 0, time.UTC)
-	CABEffectiveDate = time.Date(2012, time.July, 1, 0, 0, 0, 0, time.UTC)
-	CABV102Date      = time.Date(2012, time.June, 8, 0, 0, 0, 0, time.UTC)
-	CABV113Date      = time.Date(2013, time.February, 21, 0, 0, 0, 0, time.UTC)
-	CABV114Date      = time.Date(2013, time.May, 3, 0, 0, 0, 0, time.UTC)
-	CABV116Date      = time.Date(2013, time.July, 29, 0, 0, 0, 0, time.UTC)
-	CABV130Date      = time.Date(2015, time.April, 16, 0, 0, 0, 0, time.UTC)
-	CABV131Date      = time.Date(2015, time.September, 28, 0, 0, 0, 0, time.UTC)
-	NO_SHA1          = time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC)
-	RsaDate          = time.Date(2010, time.December, 31, 0, 0, 0, 0, time.UTC)
-	RsaDate2         = time.Date(2011, time.January, 1, 0, 0, 0, 0, time.UTC)
-	RsaDate3         = time.Date(2014, time.January, 1, 0, 0, 0, 0, time.UTC)
-	GeneralizedDate  = time.Date(2050, time.January, 1, 0, 0, 0, 0, time.UTC)
-	NoReservedIP     = time.Date(2015, time.November, 1, 0, 0, 0, 0, time.UTC)
+	ZeroDate          = time.Date(0000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	RFC2459Date       = time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)
+	RFC3280Date       = time.Date(2002, time.April, 1, 0, 0, 0, 0, time.UTC)
+	RFC4325Date       = time.Date(2005, time.December, 1, 0, 0, 0, 0, time.UTC)
+	RFC4630Date       = time.Date(2006, time.August, 1, 0, 0, 0, 0, time.UTC)
+	RFC5280Date       = time.Date(2008, time.May, 1, 0, 0, 0, 0, time.UTC)
+	RFC6818Date       = time.Date(2013, time.January, 1, 0, 0, 0, 0, time.UTC)
+	CABEffectiveDate  = time.Date(2012, time.July, 1, 0, 0, 0, 0, time.UTC)
+	CABV102Date       = time.Date(2012, time.June, 8, 0, 0, 0, 0, time.UTC)
+	CABV113Date       = time.Date(2013, time.February, 21, 0, 0, 0, 0, time.UTC)
+	CABV114Date       = time.Date(2013, time.May, 3, 0, 0, 0, 0, time.UTC)
+	CABV116Date       = time.Date(2013, time.July, 29, 0, 0, 0, 0, time.UTC)
+	CABV130Date       = time.Date(2015, time.April, 16, 0, 0, 0, 0, time.UTC)
+	CABV131Date       = time.Date(2015, time.September, 28, 0, 0, 0, 0, time.UTC)
+	NO_SHA1           = time.Date(2016, time.January, 1, 0, 0, 0, 0, time.UTC)
+	NoRSA1024RootDate = time.Date(2011, time.January, 1, 0, 0, 0, 0, time.UTC)
+	NoRSA1024Date     = time.Date(2014, time.January, 1, 0, 0, 0, 0, time.UTC)
+	GeneralizedDate   = time.Date(2050, time.January, 1, 0, 0, 0, 0, time.UTC)
+	NoReservedIP      = time.Date(2015, time.November, 1, 0, 0, 0, 0, time.UTC)
 )
 
 func FindTimeType(firstDate, secondDate asn1.RawValue) (int, int) {


### PR DESCRIPTION
- Delete `RsaDate` (unused)
- Rename `RsaDate2` to `NoRSA1024RootDate`
- Rename `RsaDate3` to `NoRSA1024Date`
- Fix `e_rsa_mod_less_than_2048_bits` to check the notAfter date against `NoRSA1024Date` and change the associated description to match the BRs.

Closes #12.