### PR TITLE
Rename CAB -> BRs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,28 +7,28 @@ The following is a list of lints run on each certificate at this time.
 basic_constraints_not_critical | Conforming CAs must mark Basic Constraints as critical when it is included in CA certs | RFC 5280: 4.2.1.9
 br_san_bare_wildcard | Wildcard MUST be accompanied by other data to it's right (Only checks DNSName) | -
 br_san_wildcard_not_first | Wildcard MUST be in the first label of FQDN, ie not: www.\*.com (Only checks DNSName) | -
-ca_country_name_invalid  | Root & Subordinate CA certificates must have a two-letter country code that is in ISO 3166-1 | CAB: 7.1.2.1
-ca_country_name_missing | Root & Subordinate CA certificates must have a countryName present in subject information | CAB: 7.1.2.1
-ca_crl_sign_not_set | Root & Subordinate CA certificate keyUsage extension's crlSign bit must be set | CAB: 7.1.2.1
-ca_dig_sign_not_set | Root & Subordinate CA Certificates that wish to use their private key for signing OCSP responses will not be able to with out digital signature set | CAB: 7.1.2.1, 7.1.6.2
-ca_key_cert_sign_not_set | Root & Subordinate CA certificate keyUsage extension's keyCertSign bit must be set | CAB: 7.1.2.1
-ca_key_usage_missing | Root & Subordinate CA certificate keyUsage extension must be present | CAB: 7.1.2.1, RFC 5280: 4.2.1.3
-ca_key_usage_not_critical | Root & Subordinate CA certificate keyUsage extension must be marked as critical | CAB: 7.1.2.1
-ca_organization_name_missing | Root & Subordinate CA certificates must have a organizationName present in subject information | CAB: 7.1.2.1
+ca_country_name_invalid  | Root & Subordinate CA certificates must have a two-letter country code that is in ISO 3166-1 | BRs: 7.1.2.1
+ca_country_name_missing | Root & Subordinate CA certificates must have a countryName present in subject information | BRs: 7.1.2.1
+ca_crl_sign_not_set | Root & Subordinate CA certificate keyUsage extension's crlSign bit must be set | BRs: 7.1.2.1
+ca_dig_sign_not_set | Root & Subordinate CA Certificates that wish to use their private key for signing OCSP responses will not be able to with out digital signature set | BRs: 7.1.2.1, 7.1.6.2
+ca_key_cert_sign_not_set | Root & Subordinate CA certificate keyUsage extension's keyCertSign bit must be set | BRs: 7.1.2.1
+ca_key_usage_missing | Root & Subordinate CA certificate keyUsage extension must be present | BRs: 7.1.2.1, RFC 5280: 4.2.1.3
+ca_key_usage_not_critical | Root & Subordinate CA certificate keyUsage extension must be marked as critical | BRs: 7.1.2.1
+ca_organization_name_missing | Root & Subordinate CA certificates must have a organizationName present in subject information | BRs: 7.1.2.1
 ca_subject_field_empty | CA Certificates subject field must not be empty and must have a non-empty distingushed name | RFC 5280: 4.1.2.6
 cert_contains_unique_identifier | CAs must not generate certificates with unique identifiers. | RFC 5280: 4.1.2.8
 cert_extensions_verson_not_3 | The extensions field must only appear in version 3 certificates. | RFC 5280: 4.1.2.9
-cert_policy_conflicts_with_locality | If certificate policy 2.23.140.1.2.1 is included, locality name must not be included in subject. | CAB: 7.1.6.1
-cert_policy_conflicts_with_org | If certificate policy 2.23.140.1.2.1 is included, organization name must not be included in subject. | CAB: 7.1.6.1
-cert_policy_conflicts_with_postal | If certificate policy 2.23.140.1.2.1 is included, postal code must not be included in subject. | CAB: 7.1.6.1
-cert_policy_conflicts_with_province | If certificate policy 2.23.140.1.2.1 is included, stateOrProvince name must not be included in subject. | CAB: 7.1.6.1
-cert_policy_conflicts_with_street | If certificate policy 2.23.140.1.2.1 is included, street address must not be included in subject. | CAB: 7.1.6.1
-cert_policy_iv_requires_country | If certificate policy 2.23.140.1.2.3 is included, country name must be included in subject. | CAB: 7.1.6.1
-cert_policy_iv_requires_province_or_locality | If certificate policy 2.23.140.1.2.3 is included, locality or stateOrProvince must be included in subject. | CAB: 7.1.6.1
-cert_policy_ov_requires_country | If certificate policy 2.23.140.1.2.2 is included, country name must be included in subject. | CAB: 7.1.6.1
-cert_policy_ov_requires_province_or_locality | If certificate policy 2.23.140.1.2.2 is included, locality or stateOrProvince must be included in subject. | CAB: 7.1.6.1
-cert_policy_requires_org | If certificate policy 2.23.140.1.2.2 is included, organization name must be included in subject. | CAB: 7.1.6.1
-cert_policy_requires_personal_name | If certificate policy 2.23.140.1.2.3 is included, organization or givenName AND surname must be included in subject. | CAB: 7.1.6.1
+cert_policy_conflicts_with_locality | If certificate policy 2.23.140.1.2.1 is included, locality name must not be included in subject. | BRs: 7.1.6.1
+cert_policy_conflicts_with_org | If certificate policy 2.23.140.1.2.1 is included, organization name must not be included in subject. | BRs: 7.1.6.1
+cert_policy_conflicts_with_postal | If certificate policy 2.23.140.1.2.1 is included, postal code must not be included in subject. | BRs: 7.1.6.1
+cert_policy_conflicts_with_province | If certificate policy 2.23.140.1.2.1 is included, stateOrProvince name must not be included in subject. | BRs: 7.1.6.1
+cert_policy_conflicts_with_street | If certificate policy 2.23.140.1.2.1 is included, street address must not be included in subject. | BRs: 7.1.6.1
+cert_policy_iv_requires_country | If certificate policy 2.23.140.1.2.3 is included, country name must be included in subject. | BRs: 7.1.6.1
+cert_policy_iv_requires_province_or_locality | If certificate policy 2.23.140.1.2.3 is included, locality or stateOrProvince must be included in subject. | BRs: 7.1.6.1
+cert_policy_ov_requires_country | If certificate policy 2.23.140.1.2.2 is included, country name must be included in subject. | BRs: 7.1.6.1
+cert_policy_ov_requires_province_or_locality | If certificate policy 2.23.140.1.2.2 is included, locality or stateOrProvince must be included in subject. | BRs: 7.1.6.1
+cert_policy_requires_org | If certificate policy 2.23.140.1.2.2 is included, organization name must be included in subject. | BRs: 7.1.6.1
+cert_policy_requires_personal_name | If certificate policy 2.23.140.1.2.3 is included, organization or givenName AND surname must be included in subject. | BRs: 7.1.6.1
 cert_unique_identifier_version_not_2_or_3 | Unique identifiers must only appear if the version is 2 or 3. | RFC 5280: 4.1.2.8
 dh_params_missing | DH keys must have parameters | -
 distribution_point_incomplete | A DistributionPoint from the CRLDistributionPoints extension MUST NOT consist of only the reasons field; either distributionPoint or CRLIssuer must be present | RFC 5280: 4.2.1.13
@@ -36,9 +36,9 @@ distribution_point_missing_ldap_or_uri | When present in the CRLDistributionPoin
 dns_name_empty | DNSNames MUST NOT be empty if included | -
 dns_name_includes_null_char | DNSNames MUST NOT include a null character  | -
 dns_name_starts_with_period | DNSName MUST NOT start with a period | -
-dsa_improper_modulus_or_divisor_size | minimum DSA modulus and divisor size is either L= 2048, N= 224 or L= 2048, N= 256 | CAB: 6.1.5
-dsa_shorter_than_2048_bits | DSA modulus size must be at least 2048 bits | CAB: 6.1.5
-ec_improper_curves | only one of NIST P‐256, P‐384, or P‐521 can be used for all types of certificate | CAB: 6.1.5
+dsa_improper_modulus_or_divisor_size | minimum DSA modulus and divisor size is either L= 2048, N= 224 or L= 2048, N= 256 | BRs: 6.1.5
+dsa_shorter_than_2048_bits | DSA modulus size must be at least 2048 bits | BRs: 6.1.5
+ec_improper_curves | only one of NIST P‐256, P‐384, or P‐521 can be used for all types of certificate | BRs: 6.1.5
 eku_critical_improperly | Conforming CAs SHOULD NOT mark extended key usage extension as critical if the anyExtendedKeyUsage KeyPurposedID is present | RFC 5280: 4.2.1.12
 ev_business_category_missing | EV certificates must include businessCategory in subject | -
 ev_country_name_missing | EV certificates must include countryName in subject | -
@@ -82,23 +82,23 @@ ext_policy_constraints_not_critical | Conforming CAs must mark the policy constr
 ext_policy_map_any_policy | policies must not be mapped to or from the anyPolicy value | RFC 5280: 4.2.1.5
 ext_policy_map_not_critical | Policy mappings should be marked as critical | RFC 5280: 4.2.1.5
 ext_policy_map_not_in_cert_policy | each issuerDomainPolicy named in policy mappings extension should also be asserted in a certificate policies extension | RFC 5280: 4.2.1.5
-ext_san_contains_reserved_ip | Certs issued after 2012-07-01 and expireing after 2015-11-01 must not contain a reserved ip address in the SAN extension. | CAB: 7.1.4.2.1
+ext_san_contains_reserved_ip | Certs issued after 2012-07-01 and expireing after 2015-11-01 must not contain a reserved ip address in the SAN extension. | BRs: 7.1.4.2.1
 ext_san_critical_with_subject_dn | if the subject contains a distinguished name SAN should be non-critical | RFC 5280: 4.2.1.6
-ext_san_directory_name_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | CAB: 7.1.4.2.1
-ext_san_dnsname_not_fqdn | SAN dnsnames must be a fully qualified domain name. | CAB: 7.1.4.2.1
+ext_san_directory_name_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | BRs: 7.1.4.2.1
+ext_san_dnsname_not_fqdn | SAN dnsnames must be a fully qualified domain name. | BRs: 7.1.4.2.1
 ext_san_dns_not_ia5_string | dNSNames are IA5 strings | RFC 5280: 4.2.1.6
 ext_san_dns_syntax_incorrect | dns name must be in preferred name syntax | RFC 5280: 4.2.1.6
-ext_san_edi_party_name_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | CAB: 7.1.4.2.1
+ext_san_edi_party_name_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | BRs: 7.1.4.2.1
 ext_san_empty_name | general name fields must not be empty in san | RFC 5280: 4.2.1.6
-ext_san_missing | Certificates must contain the Subject Alternate Name extension. | CAB: 7.1.4.2.1
+ext_san_missing | Certificates must contain the Subject Alternate Name extension. | BRs: 7.1.4.2.1
 ext_san_no_entries | if present, the san extension must contain at least one entry | RFC 5280: 4.2.1.6
 ext_san_not_critical_without_subject | if there is an empty subject feild, then the san extension must be critical | RFC 5280: 4.2.1.6 & 4.1.2.6
-ext_san_other_name_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | CAB: 7.1.4.2.1
-ext_san_registered_id_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | CAB: 7.1.4.2.1
+ext_san_other_name_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | BRs: 7.1.4.2.1
+ext_san_registered_id_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | BRs: 7.1.4.2.1
 ext_san_rfc822_format_invalid | email must be stored as a mailbox@domain.tld rfc822 name without "<>()" and "." before the "@" | RFC 5280: 4.2.1.6
-ext_san_rfc822_name_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | CAB: 7.1.4.2.1
+ext_san_rfc822_name_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | BRs: 7.1.4.2.1
 ext_san_space_dns_name | the dNSName " " must not be used | RFC 5280: 4.2.1.6
-ext_san_uniform_resource_identifier_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | CAB: 7.1.4.2.1
+ext_san_uniform_resource_identifier_present | The Subject Alternate Name extension must contain only dnsName and ipaddress name types. | BRs: 7.1.4.2.1
 ext_san_uri_format_invalid | The name MUST include both a  scheme (e.g., "http" or "ftp") and a scheme-specific-part. | RFC 5280: 4.2.1.6
 ext_san_uri_host_not_fqdn_or_ip | URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host. | RFC 5280: 4.2.1.6
 ext_san_uri_not_ia5 | URIs must be encoded as IA5 string in uniformResourceIdentifier | RFC 5280: 4.2.1.6
@@ -110,10 +110,10 @@ ext_subject_key_identifier_missing_sub_cert | CAs should include ski in end enti
 generalized_time_does_not_include_seconds | Generalized time values must include seconds | RFC 5280: 4.1.2.5.2
 generalized_time_includes_fraction_seconds | Generalized time values must not include fraction seconds | RFC 5280: 4.1.2.5.2
 generalized_time_not_in_zulu | Generalized time values must be expressed in Greenwich Mean Time (Zulu) | RFC 5280: 4.1.2.5.2
-gtld_under_consideration | CAs SHOULD NOT issue Certificates containing a new gTLD under consideration by ICANN. | CAB: 4.2.2
+gtld_under_consideration | CAs SHOULD NOT issue Certificates containing a new gTLD under consideration by ICANN. | BRs: 4.2.2
 iana_pub_suffix_empty | Domain SHOULD NOT have bare public suffix | -
 inhibit_any_policy_not_critical | Conforming CAs must mark this extension as critical | RFC 5280: 4.2.1.14
-invalid_certificate_version | Certificate must be version 3 | CAB: 7.1.1
+invalid_certificate_version | Certificate must be version 3 | BRs: 7.1.1
 issuer_field_empty | Certificates issuer field must not be empty and must have a non-empty distingushed name | RFC 5280: 4.1.2.4
 name_constraint_empty | Conforming CAs must not issue certificates where name constraints is an empty sequence. That is, either the permittedSubtree or excludedSubtree fields must be present | RFC 5280: 4.2.1.10
 name_constraint_maximum_not_absent | In the name constraints name forms the maximum is not used and therefore MUST be absent | RFC 5280: 4.2.1.10
@@ -121,65 +121,65 @@ name_constraint_minimum_non_zero | In the name constraints name forms the minimu
 name_constraint_on_edi_party_name | The name constraints extension SHOULD NOT impose constraints on the ediPartyName name form | RFC 5280: 4.2.1.10
 name_constraint_on_registered_id | The name constraints extension SHOULD NOT impose constraints on the registeredID name form | RFC 5280: 4.2.1.10
 name_constraint_on_x400 | The name constraints extension SHOULD NOT impose constraints on the x400Address name form | RFC 5280: 4.2.1.10
-old_root_ca_rsa_mod_less_than_2048_bits | In a validity period beginning on or before 31 dec 2010, root CA certificates using RSA public key algorithm must have 2048 bits of modulus | CAB: 6.1.5
-old_sub_ca_rsa_mod_less_than_1024_bits | In a validity period beginning on or before 31 dec 2010 and ending on or before 31 dec 2013, subordinate CA certificates using RSA public key algorithm must have 1024 bits of modulus | CAB: 6.1.5
-old_sub_cert_rsa_mod_less_than_1024_bits | In a validity period ending on or before 31 dec 2013, subscriber certificates using RSA public key algorithm must have 1024 bits of modulus | CAB: 6.1.5
+old_root_ca_rsa_mod_less_than_2048_bits | In a validity period beginning on or before 31 dec 2010, root CA certificates using RSA public key algorithm must have 2048 bits of modulus | BRs: 6.1.5
+old_sub_ca_rsa_mod_less_than_1024_bits | In a validity period beginning on or before 31 dec 2010 and ending on or before 31 dec 2013, subordinate CA certificates using RSA public key algorithm must have 1024 bits of modulus | BRs: 6.1.5
+old_sub_cert_rsa_mod_less_than_1024_bits | In a validity period ending on or before 31 dec 2013, subscriber certificates using RSA public key algorithm must have 1024 bits of modulus | BRs: 6.1.5
 path_len_constraint_improperly_included | CAs MUST NOT include the pathLenConstraint field unless the CA boolean is asserted and the keyCertSign bit is set. | RFC 5280: 4.2.1.9
 path_len_constraint_zero_or_less | Where it appears, the pathLenConstraint field must be greater than or equal to zero | RFC 5280: 4.2.1.9
-public_key_type_not_allowed | Certificates must have RSA, DSA, or ECDSA public key type. | CAB: 6.1.5
-root_ca_basic_constraints_path_len_constraint_field_present | Root CA certificate basicConstraint extension pathLenConstraint field should not be present | CAB: 7.1.2.1
-root_ca_contains_cert_policy | Root CA certs SHOULD NOT contain the certificate policies extension. | CAB: 7.1.2.1, 7.1.6.2
-root_ca_extended_key_usage_present | Root CA certificates must not have the extendedKeyUsage extension present | CAB: 7.1.2.1
+public_key_type_not_allowed | Certificates must have RSA, DSA, or ECDSA public key type. | BRs: 6.1.5
+root_ca_basic_constraints_path_len_constraint_field_present | Root CA certificate basicConstraint extension pathLenConstraint field should not be present | BRs: 7.1.2.1
+root_ca_contains_cert_policy | Root CA certs SHOULD NOT contain the certificate policies extension. | BRs: 7.1.2.1, 7.1.6.2
+root_ca_extended_key_usage_present | Root CA certificates must not have the extendedKeyUsage extension present | BRs: 7.1.2.1
 rsa_exp_negative | “RSA public key exponent must be positive” (negative exponent found) | -
-rsa_mod_factors_smaller_than_752 | The modulus of a RSA public key should have no factors smaller than 752 | CAB: 6.1.6
-rsa_mod_less_than_2048_bits | in validity period beginning after 31 Dec 2010, all certificates using RSA public key algorithm must have 2048 bits of modulus | CAB: 6.1.5
-rsa_mod_not_odd | The modulus of a RSA public key should be an odd number | CAB: 6.1.6
-rsa_public_exponent_not_in_range | The RSA public exponent SHOULD be in the range between 2^16 + 1 and 2^256 - 1 | CAB: 6.1.6
-rsa_public_exponent_not_odd | RSA public key has to be an odd number | CAB: 6.1.5
-rsa_public_exponent_too_small | RSA public key has to be greater or equal to 3 | CAB: 6.1.5
+rsa_mod_factors_smaller_than_752 | The modulus of a RSA public key should have no factors smaller than 752 | BRs: 6.1.6
+rsa_mod_less_than_2048_bits | in validity period beginning after 31 Dec 2010, all certificates using RSA public key algorithm must have 2048 bits of modulus | BRs: 6.1.5
+rsa_mod_not_odd | The modulus of a RSA public key should be an odd number | BRs: 6.1.6
+rsa_public_exponent_not_in_range | The RSA public exponent SHOULD be in the range between 2^16 + 1 and 2^256 - 1 | BRs: 6.1.6
+rsa_public_exponent_not_odd | RSA public key has to be an odd number | BRs: 6.1.5
+rsa_public_exponent_too_small | RSA public key has to be greater or equal to 3 | BRs: 6.1.5
 serial_number_longer_than_20_octets | Certificates must not have a serial number longer than 20 octets | RFC 5280: 4.1.2.2
 serial_number_not_positive | Certificates must have a positive serial number | RFC 5280: 4.1.2.2
-sub_ca_aia_does_not_contain_issuing_ca_url | Subordinate CA certificates authorityInformationAccess extension should contain the HTTP URL of the Issuing CA’s certificate | CAB: 7.1.2.2
-sub_ca_aia_does_not_contain_oscp_URL | Subordinate CA certificates authorityInformationAccess extension must contain the HTTP URL of the Issuing CA’s OCSP responder | CAB: 7.1.2.2
-sub_ca_aia_missing | Subordinate CA certificates must have a authorityInformationAccess extension | CAB: 7.1.2.2
-sub_ca_certificate_policies_marked_critical | Subordinate CA certificates certificatePolicies extension should not be marked as critical | CAB: 7.1.2.2
-sub_ca_certificate_policies_missing | Subordinate CA certificates must have a certificatePolicies extension | CAB: 7.1.2.2
-sub_ca_crl_distribution_points_does_not_contain_url | Subordinate CA certificates cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service. | CAB: 7.1.2.2
-sub_ca_crl_distribution_points_marked_critical | Subordinate CA certificates must not mark the cRLDistributionPoints extension as critical | CAB: 7.1.2.2
-sub_ca_crl_distribution_points_missing | Subordinate CA certificates must have a cRLDistributionPoints extension | CAB: 7.1.2.2
-sub_ca_eku_critical | Subordinate CA certificate extkeyUsage extension should be marked non-critical if present | CAB: 7.1.2.2
-sub_ca_name_constraints_not_critical | Subordinate CA certificate nameConstraints extension should be marked critical if present | CAB: 7.1.2.2
-sub_ca_no_dns_name_contstraints | Subordanate CA certs must include in the name contraints extension either premitted dns names or prohibit the empty DNS name. | CAB: 7.1.5
-sub_ca_no_ip_name_contstraints | Subordanate CA certs must include in the name contraints extension either premitted ip ranges or prohibit all ip addresses. | CAB: 7.1.5
-sub_cert_aia_does_not_contain_issuing_CA_url | Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the Issuing CA’s certificate | CAB: 7.1.2.3
-sub_cert_aia_does_not_contain_ocsp_URL | Subscriber certificates authorityInformationAccess extension must contain the HTTP URL of the Issuing CA’s OCSP responder | CAB: 7.1.2.3
-sub_cert_aia_missing | Subscriber certificates must have a authorityInformationAccess extension | CAB: 7.1.2.3
-sub_cert_certificate_policies_marked_critical | Subscriber certificate certificatePolicies extension should not be marked critical | CAB: 7.1.2.3
-sub_cert_certificate_policies_missing | Subscriber certificate must include the certificatePolicies extension | CAB: 7.1.2.3
-sub_cert_cert_policy_empty | Subscriber certificates must contain at least one policy identifier that indicates adherance to CAB standards | CAB: 7.1.6.4
-sub_cert_crl_distribution_points_does_not_contain_url | Subscriber certificate cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service. | CAB: 7.1.2.3
-sub_cert_crl_distribution_points_marked_critical | Subscriber certificate cRLDistributionPoints extension must not be marked critical if present | CAB: 7.1.2.3
-sub_cert_eku_extra_values | Subscriber certificates should have only id-kp-serverAuth, id-kp-clientAuth, or id-kp-emailProtection in extKeyUsage. Anything should not be included. | CAB: 7.1.2.3
-sub_cert_eku_missing | Subscriber certificates must have the extended key usage extension present | CAB: 7.1.2.3
-sub_cert_eku_server_auth_client_auth_missing | Subscriber certificates must have have either id-kp-serverAuth or id-kp-clientAuth or both present in extKeyUsage | CAB: 7.1.2.3
-sub_cert_key_usage_cert_sign_bit_set | Subscriber certificates keyUsage extension keyCertSign bit must not be set | CAB: 7.1.2.3
-sub_cert_key_usage_crl_sign_bit_set | Subscriber certificates keyUsage extension cRLSign bit must not be set | CAB: 7.1.2.3
-sub_cert_or_sub_ca_using_sha1 | Subscriber certificates and subordinate CA certificates must not use the SHA-1 hash algorithm on a certificate with a NotBefore date after 1 Jan 2016 | CAB: 7.1.3
-sub_cert_sha1_expiration_too_long | Subscriber certificates using the SHA1 algorithm should not have an expiration date greater than 1 Jan 2017 | CAB: 7.1.3
-subject_common_name_disallowed | If present Common name MUST contain a single IP address or Fully‐Qualified Domain Name that is one of the values contained in the Certificate’s subjectAltName extension | CAB: 7.1.4.2.2
-subject_common_name_included | Use of the common name field is discouraged. | CAB: 7.1.4.2.2
-subject_common_name_not_from_san | The common name field must include only names from the SAN extension. | CAB: 7.1.4.2.2
-subject_contains_noninformational_value | Subject name fields must not contain ".","-"," " or any other indication that the field has been ommited. | CAB: 7.1.4.2.2
-subject_contains_reserved_ip | Certs issued after 2012-07-01 and expireing after 2015-11-01 must not conatain a reserved ip address in the common name field. | CAB: 7.1.4.2.1
-subject_country_not_iso | The country name field must contain the two-letter ISO code for the country or XX. | CAB: 7.1.4.2.2
+sub_ca_aia_does_not_contain_issuing_ca_url | Subordinate CA certificates authorityInformationAccess extension should contain the HTTP URL of the Issuing CA’s certificate | BRs: 7.1.2.2
+sub_ca_aia_does_not_contain_oscp_URL | Subordinate CA certificates authorityInformationAccess extension must contain the HTTP URL of the Issuing CA’s OCSP responder | BRs: 7.1.2.2
+sub_ca_aia_missing | Subordinate CA certificates must have a authorityInformationAccess extension | BRs: 7.1.2.2
+sub_ca_certificate_policies_marked_critical | Subordinate CA certificates certificatePolicies extension should not be marked as critical | BRs: 7.1.2.2
+sub_ca_certificate_policies_missing | Subordinate CA certificates must have a certificatePolicies extension | BRs: 7.1.2.2
+sub_ca_crl_distribution_points_does_not_contain_url | Subordinate CA certificates cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service. | BRs: 7.1.2.2
+sub_ca_crl_distribution_points_marked_critical | Subordinate CA certificates must not mark the cRLDistributionPoints extension as critical | BRs: 7.1.2.2
+sub_ca_crl_distribution_points_missing | Subordinate CA certificates must have a cRLDistributionPoints extension | BRs: 7.1.2.2
+sub_ca_eku_critical | Subordinate CA certificate extkeyUsage extension should be marked non-critical if present | BRs: 7.1.2.2
+sub_ca_name_constraints_not_critical | Subordinate CA certificate nameConstraints extension should be marked critical if present | BRs: 7.1.2.2
+sub_ca_no_dns_name_contstraints | Subordanate CA certs must include in the name contraints extension either premitted dns names or prohibit the empty DNS name. | BRs: 7.1.5
+sub_ca_no_ip_name_contstraints | Subordanate CA certs must include in the name contraints extension either premitted ip ranges or prohibit all ip addresses. | BRs: 7.1.5
+sub_cert_aia_does_not_contain_issuing_CA_url | Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the Issuing CA’s certificate | BRs: 7.1.2.3
+sub_cert_aia_does_not_contain_ocsp_URL | Subscriber certificates authorityInformationAccess extension must contain the HTTP URL of the Issuing CA’s OCSP responder | BRs: 7.1.2.3
+sub_cert_aia_missing | Subscriber certificates must have a authorityInformationAccess extension | BRs: 7.1.2.3
+sub_cert_certificate_policies_marked_critical | Subscriber certificate certificatePolicies extension should not be marked critical | BRs: 7.1.2.3
+sub_cert_certificate_policies_missing | Subscriber certificate must include the certificatePolicies extension | BRs: 7.1.2.3
+sub_cert_cert_policy_empty | Subscriber certificates must contain at least one policy identifier that indicates adherance to CAB standards | BRs: 7.1.6.4
+sub_cert_crl_distribution_points_does_not_contain_url | Subscriber certificate cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service. | BRs: 7.1.2.3
+sub_cert_crl_distribution_points_marked_critical | Subscriber certificate cRLDistributionPoints extension must not be marked critical if present | BRs: 7.1.2.3
+sub_cert_eku_extra_values | Subscriber certificates should have only id-kp-serverAuth, id-kp-clientAuth, or id-kp-emailProtection in extKeyUsage. Anything should not be included. | BRs: 7.1.2.3
+sub_cert_eku_missing | Subscriber certificates must have the extended key usage extension present | BRs: 7.1.2.3
+sub_cert_eku_server_auth_client_auth_missing | Subscriber certificates must have have either id-kp-serverAuth or id-kp-clientAuth or both present in extKeyUsage | BRs: 7.1.2.3
+sub_cert_key_usage_cert_sign_bit_set | Subscriber certificates keyUsage extension keyCertSign bit must not be set | BRs: 7.1.2.3
+sub_cert_key_usage_crl_sign_bit_set | Subscriber certificates keyUsage extension cRLSign bit must not be set | BRs: 7.1.2.3
+sub_cert_or_sub_ca_using_sha1 | Subscriber certificates and subordinate CA certificates must not use the SHA-1 hash algorithm on a certificate with a NotBefore date after 1 Jan 2016 | BRs: 7.1.3
+sub_cert_sha1_expiration_too_long | Subscriber certificates using the SHA1 algorithm should not have an expiration date greater than 1 Jan 2017 | BRs: 7.1.3
+subject_common_name_disallowed | If present Common name MUST contain a single IP address or Fully‐Qualified Domain Name that is one of the values contained in the Certificate’s subjectAltName extension | BRs: 7.1.4.2.2
+subject_common_name_included | Use of the common name field is discouraged. | BRs: 7.1.4.2.2
+subject_common_name_not_from_san | The common name field must include only names from the SAN extension. | BRs: 7.1.4.2.2
+subject_contains_noninformational_value | Subject name fields must not contain ".","-"," " or any other indication that the field has been ommited. | BRs: 7.1.4.2.2
+subject_contains_reserved_ip | Certs issued after 2012-07-01 and expireing after 2015-11-01 must not conatain a reserved ip address in the common name field. | BRs: 7.1.4.2.1
+subject_country_not_iso | The country name field must contain the two-letter ISO code for the country or XX. | BRs: 7.1.4.2.2
 subject_empty_without_san | CAs must include subject alternative name if the subject field is an empty sequence. | RFC 5280: 4.2 & 4.2.1.6
 subject_info_access_marked_critical | Conforming CAs must mark the Subject Info Access extension as non-critical | RFC 5280: 4.2.2.2
-subject_locality_without_org | The locality field must not be included without an organization name. | CAB: 7.1.4.2.2
-subject_org_without_country | The organization name field must not be included without a country name. | CAB: 7.1.4.2.2
-subject_org_without_locality_or_province | If organiation is included, either stateOrProvince or locality must be included. | CAB: 7.1.4.2.2 (d&e)
-subject_postal_without_org | The postal code must not be included without an organization name. | CAB: 7.1.4.2.2
-subject_province_without_org | The stateOrProvince name must not be included without an organization name. | CAB: 7.1.4.2.2
-subject_street_without_org | The street address field must not be included without an organization name. | CAB: 7.1.4.2.2
+subject_locality_without_org | The locality field must not be included without an organization name. | BRs: 7.1.4.2.2
+subject_org_without_country | The organization name field must not be included without a country name. | BRs: 7.1.4.2.2
+subject_org_without_locality_or_province | If organiation is included, either stateOrProvince or locality must be included. | BRs: 7.1.4.2.2 (d&e)
+subject_postal_without_org | The postal code must not be included without an organization name. | BRs: 7.1.4.2.2
+subject_province_without_org | The stateOrProvince name must not be included without an organization name. | BRs: 7.1.4.2.2
+subject_street_without_org | The street address field must not be included without an organization name. | BRs: 7.1.4.2.2
 UTC_time_does_not_include_seconds | UTCTime values must include seconds | RFC 5280: 4.1.2.5.1
 UTC_time_not_in_zulu | UTCTime values must be expressed in Greenwich Mean Time (Zulu) | RFC 5280: 4.1.2.5.1
 validity_time_not_positive | Certificates MUST have a positive time for which they are valid | -

--- a/lints/lint_ca_country_name_invalid.go
+++ b/lints/lint_ca_country_name_invalid.go
@@ -1,6 +1,6 @@
 // lint_ca_country_name_invalid.go
 /************************************************
-CAB: 7.1.2.1e
+BRs: 7.1.2.1e
 The	Certificate	Subject	MUST contain the following:
 ‐	countryName	(OID 2.5.4.6).	This field MUST	contain	the	two‐letter	ISO	3166‐1 country code	for	the
 country	in which the CA’s place	of business	is located.
@@ -43,7 +43,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_country_name_invalid",
 		Description:   "Root and Subordinate CA certificates MUST have a two-letter country code specified in ISO 3166-1",
-		Provenance:    "CAB: 7.1.2.1",
+		Provenance:    "BRs: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caCountryNameInvalid{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaCountryNameInvalid = result },

--- a/lints/lint_ca_country_name_missing.go
+++ b/lints/lint_ca_country_name_missing.go
@@ -1,6 +1,6 @@
 // lint_ca_country_name_missing.go
 /************************************************
-CAB: 7.1.2.1e
+BRs: 7.1.2.1e
 The	Certificate	Subject	MUST contain the following:
 ‐	countryName	(OID 2.5.4.6).	This field MUST	contain	the	two‐letter	ISO	3166‐1 country code	for	the
 country	in which the CA’s place	of business	is located.
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_country_name_missing",
 		Description:   "Root and Subordinate CA certificates MUST have a countryName present in subject information",
-		Provenance:    "CAB: 7.1.2.1",
+		Provenance:    "BRs: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caCountryNameMissing{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaCountryNameMissing = result },

--- a/lints/lint_ca_crl_sign_not_set.go
+++ b/lints/lint_ca_crl_sign_not_set.go
@@ -1,6 +1,6 @@
 // lint_ca_crl_sign_not_set.go
 /************************************************
-CAB: 7.1.2.1b
+BRs: 7.1.2.1b
 This extension MUST be present and MUST be marked critical. Bit positions for keyCertSign and cRLSign MUST be set.
 If the Root CA Private Key is used for signing OCSP responses, then the digitalSignature bit MUST be set.
 ************************************************/
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_crl_sign_not_set",
 		Description:   "Root and Subordinate CA certificate keyUsage extension's crlSign bit MUST be set",
-		Provenance:    "CAB: 7.1.2.1",
+		Provenance:    "BRs: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caCRLSignNotSet{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaCrlSignNotSet = result },

--- a/lints/lint_ca_digital_signature_not_set.go
+++ b/lints/lint_ca_digital_signature_not_set.go
@@ -1,6 +1,6 @@
 // lint_ca_dig_sign_not_set.go
 /************************************************
-CAB: 7.1.2.1b
+BRs: 7.1.2.1b
 This extension MUST be present and MUST be marked critical. Bit positions for keyCertSign and cRLSign MUST be set.
 If the Root CA Private Key is used for signing OCSP responses, then the digitalSignature bit MUST be set.
 ************************************************/
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "n_ca_digital_signature_not_set",
 		Description:   "Root and Subordinate CA Certificates that wish to use their private key for signing OCSP responses will not be able to without their digital signature set",
-		Provenance:    "CAB: 7.1.2.1",
+		Provenance:    "BRs: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caDigSignNotSet{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.NCaDigitalSignatureNotSet = result },

--- a/lints/lint_ca_key_cert_sign_not_set.go
+++ b/lints/lint_ca_key_cert_sign_not_set.go
@@ -1,6 +1,6 @@
 // lint_ca_key_cert_sign_not_set.go
 /************************************************
-CAB: 7.1.2.1b
+BRs: 7.1.2.1b
 This extension MUST be present and MUST be marked critical. Bit positions for keyCertSign and cRLSign MUST be set.
 If the Root CA Private Key is used for signing OCSP responses, then the digitalSignature bit MUST be set.
 ************************************************/
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_key_cert_sign_not_set",
 		Description:   "Root and Subordinate CA certificate keyUsage extension's keyCertSign bit MUST be set",
-		Provenance:    "CAB: 7.1.2.1",
+		Provenance:    "BRs: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caKeyCertSignNotSet{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaKeyCertSignNotSet = result },

--- a/lints/lint_ca_key_usage_missing.go
+++ b/lints/lint_ca_key_usage_missing.go
@@ -39,7 +39,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_key_usage_missing",
 		Description:   "Root and Subordinate CA certificate keyUsage extension MUST be present",
-		Provenance:    "CAB: 7.1.2.1, RFC 5280: 4.2.1.3",
+		Provenance:    "BRs: 7.1.2.1, RFC 5280: 4.2.1.3",
 		EffectiveDate: util.RFC3280Date,
 		Test:          &caKeyUsageMissing{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaKeyUsageMissing = result },

--- a/lints/lint_ca_key_usage_not_critical.go
+++ b/lints/lint_ca_key_usage_not_critical.go
@@ -1,6 +1,6 @@
 // lint_ca_key_usage_not_critical.go
 /************************************************
-CAB: 7.1.2.1b
+BRs: 7.1.2.1b
 This extension MUST be present and MUST be marked critical. Bit positions for keyCertSign and cRLSign MUST be set.
 If the Root CA Private Key is used for signing OCSP responses, then the digitalSignature bit MUST be set.
 ************************************************/
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_key_usage_not_critical",
 		Description:   "Root and Subordinate CA certificate keyUsage extension MUST be marked as critical",
-		Provenance:    "CAB: 7.1.2.1",
+		Provenance:    "BRs: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caKeyUsageNotCrit{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaKeyUsageNotCritical = result },

--- a/lints/lint_ca_organization_name_missing.go
+++ b/lints/lint_ca_organization_name_missing.go
@@ -1,6 +1,6 @@
 // lint_ca_organization_name_missing.go
 /************************************************
-CAB: 7.1.2.1e
+BRs: 7.1.2.1e
 The Certificate Subject MUST contain the following: organizationName (OID 2.5.4.10): This field MUST be present and the contents MUST contain either the Subject CA’s name or DBA as verified under Section 3.2.2.2.
 ************************************************/
 
@@ -36,7 +36,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ca_organization_name_missing",
 		Description:   "Root and Subordinate CA certificates MUST have a organizationName present in subject information",
-		Provenance:    "CAB: 7.1.2.1",
+		Provenance:    "BRs: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caOrganizationNameMissing{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECaOrganizationNameMissing = result },

--- a/lints/lint_cab_dv_conflicts_with_locality.go
+++ b/lints/lint_cab_dv_conflicts_with_locality.go
@@ -35,7 +35,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_dv_conflicts_with_locality",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, locality name MUST NOT be included in subject",
-		Provenance:    "CAB: 7.1.6.1",
+		Provenance:    "BRs: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &certPolicyConflictsWithLocality{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabDvConflictsWithLocality = result },

--- a/lints/lint_cab_dv_conflicts_with_org.go
+++ b/lints/lint_cab_dv_conflicts_with_org.go
@@ -35,7 +35,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_dv_conflicts_with_org",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, organization name MUST NOT be included in subject",
-		Provenance:    "CAB: 7.1.6.1",
+		Provenance:    "BRs: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &certPolicyConflictsWithOrg{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabDvConflictsWithOrg = result },

--- a/lints/lint_cab_dv_conflicts_with_postal.go
+++ b/lints/lint_cab_dv_conflicts_with_postal.go
@@ -35,7 +35,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_dv_conflicts_with_postal",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, postalCode MUST NOT be included in subject",
-		Provenance:    "CAB: 7.1.6.1",
+		Provenance:    "BRs: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &certPolicyConflictsWithPostal{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabDvConflictsWithPostal = result },

--- a/lints/lint_cab_dv_conflicts_with_province.go
+++ b/lints/lint_cab_dv_conflicts_with_province.go
@@ -35,7 +35,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_dv_conflicts_with_province",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, stateOrProvinceName MUST NOT be included in subject",
-		Provenance:    "CAB: 7.1.6.1",
+		Provenance:    "BRs: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &certPolicyConflictsWithProvince{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabDvConflictsWithProvince = result },

--- a/lints/lint_cab_dv_conflicts_with_street.go
+++ b/lints/lint_cab_dv_conflicts_with_street.go
@@ -35,7 +35,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_dv_conflicts_with_street",
 		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, streetAddress MUST NOT be included in subject",
-		Provenance:    "CAB: 7.1.6.1",
+		Provenance:    "BRs: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &certPolicyConflictsWithStreet{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabDvConflictsWithStreet = result },

--- a/lints/lint_cab_iv_requires_personal_name.go
+++ b/lints/lint_cab_iv_requires_personal_name.go
@@ -34,7 +34,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_iv_requires_personal_name",
 		Description:   "If certificate policy 2.23.140.1.2.3 is included, either organizationName or givenName and surname MUST be included in subject",
-		Provenance:    "CAB: 7.1.6.1",
+		Provenance:    "BRs: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,
 		Test:          &CertPolicyRequiresPersonalName{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabIvRequiresPersonalName = result },

--- a/lints/lint_cab_ov_requires_org.go
+++ b/lints/lint_cab_ov_requires_org.go
@@ -34,7 +34,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cab_ov_requires_org",
 		Description:   "If certificate policy 2.23.140.1.2.2 is included, organizationName MUST be included in subject",
-		Provenance:    "CAB: 7.1.6.1",
+		Provenance:    "BRs: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &CertPolicyRequiresOrg{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECabOvRequiresOrg = result },

--- a/lints/lint_cert_policy_iv_requires_country.go
+++ b/lints/lint_cert_policy_iv_requires_country.go
@@ -34,7 +34,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cert_policy_iv_requires_country",
 		Description:   "If certificate policy 2.23.140.1.2.3 is included, countryName MUST be included in subject",
-		Provenance:    "CAB: 7.1.6.1",
+		Provenance:    "BRs: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,
 		Test:          &CertPolicyIVRequiresCountry{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECertPolicyIvRequiresCountry = result },

--- a/lints/lint_cert_policy_iv_requires_province_or_locality.go
+++ b/lints/lint_cert_policy_iv_requires_province_or_locality.go
@@ -34,7 +34,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cert_policy_iv_requires_province_or_locality",
 		Description:   "If certificate policy 2.23.140.1.2.3 is included, localityName or stateOrProvinceName MUST be included in subject",
-		Provenance:    "CAB: 7.1.6.1",
+		Provenance:    "BRs: 7.1.6.1",
 		EffectiveDate: util.CABV131Date,
 		Test:          &CertPolicyIVRequiresProvinceOrLocal{},
 		updateReport: func(report *LintReport, result ResultStruct) {

--- a/lints/lint_cert_policy_ov_requires_country.go
+++ b/lints/lint_cert_policy_ov_requires_country.go
@@ -34,7 +34,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cert_policy_ov_requires_country",
 		Description:   "If certificate policy 2.23.140.1.2.2 is included, countryName MUST be included in subject",
-		Provenance:    "CAB: 7.1.6.1",
+		Provenance:    "BRs: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &CertPolicyOVRequiresCountry{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ECertPolicyOvRequiresCountry = result },

--- a/lints/lint_cert_policy_ov_requires_province_or_locality.go
+++ b/lints/lint_cert_policy_ov_requires_province_or_locality.go
@@ -34,7 +34,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_cert_policy_ov_requires_province_or_locality",
 		Description:   "If certificate policy 2.23.140.1.2.2 is included, localityName or stateOrProvinceName MUST be included in subject",
-		Provenance:    "CAB: 7.1.6.1",
+		Provenance:    "BRs: 7.1.6.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &CertPolicyOVRequiresProvinceOrLocal{},
 		updateReport: func(report *LintReport, result ResultStruct) {

--- a/lints/lint_dsa_improper_modulus_or_divisor_size.go
+++ b/lints/lint_dsa_improper_modulus_or_divisor_size.go
@@ -1,6 +1,6 @@
 // lint_dsa_improper_modulus_or_divisor_size.go
 /************************************************
-CAB: 6.1.5
+BRs: 6.1.5
 Certificates MUST meet the following requirements for algorithm type and key size.
 Minimum DSA modulus and divisor size (bits)***: L=2048,	N=224 or L=2048, N=256.
 **As a note, this points to FIPS 186-4 for further clarification**
@@ -44,8 +44,8 @@ func init() {
 	RegisterLint(&Lint{
 		Name:        "e_dsa_improper_modulus_or_divisor_size",
 		Description: "The minimum DSA modulus and divisor size is either L=2048, N=224 or L=2048, N=256 (extras come from FIPS 186-4)",
-		Provenance:  "CAB: 6.1.5",
-		// Refer to CAB: 6.1.5, taking the statement "Before 31 Dec 2010" literally
+		Provenance:  "BRs: 6.1.5",
+		// Refer to BRs: 6.1.5, taking the statement "Before 31 Dec 2010" literally
 		EffectiveDate: util.ZeroDate,
 		Test:          &dsaImproperSize{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EDsaImproperModulusOrDivisorSize = result },

--- a/lints/lint_dsa_shorter_than_2048_bits.go
+++ b/lints/lint_dsa_shorter_than_2048_bits.go
@@ -1,6 +1,6 @@
 // lint_dsa_shorter_than_2048_bits.go
 /************************************************
-CAB: 6.1.5
+BRs: 6.1.5
 Certificates MUST meet the following requirements for algorithm type and key size.
 Minimum DSA modulus and divisor size (bits)***: L=2048,	N=224 or L=2048, N=256
 ************************************************/
@@ -38,8 +38,8 @@ func init() {
 	RegisterLint(&Lint{
 		Name:        "e_dsa_shorter_than_2048_bits",
 		Description: "DSA modulus size must be at least 2048 bits",
-		Provenance:  "CAB: 6.1.5",
-		// Refer to CAB: 6.1.5, taking the statement "Before 31 Dec 2010" literally
+		Provenance:  "BRs: 6.1.5",
+		// Refer to BRs: 6.1.5, taking the statement "Before 31 Dec 2010" literally
 		EffectiveDate: util.ZeroDate,
 		Test:          &dsaTooShort{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EDsaShorterThan_2048Bits = result },

--- a/lints/lint_ec_improper_curves.go
+++ b/lints/lint_ec_improper_curves.go
@@ -1,6 +1,6 @@
 // lint_ec_improper_curves.go
 /************************************************
-CAB: 6.1.5
+BRs: 6.1.5
 Certificates MUST meet the following requirements for algorithm type and key size.
 ECC Curve: NIST P-256, P-384, or P-521
 ************************************************/
@@ -51,8 +51,8 @@ func init() {
 	RegisterLint(&Lint{
 		Name:        "e_ec_improper_curves",
 		Description: "Only one of NIST P‐256, P‐384, or P‐521 can be used",
-		Provenance:  "CAB: 6.1.5",
-		// Refer to CAB: 6.1.5, taking the statement "Before 31 Dec 2010" literally
+		Provenance:  "BRs: 6.1.5",
+		// Refer to BRs: 6.1.5, taking the statement "Before 31 Dec 2010" literally
 		EffectiveDate: util.ZeroDate,
 		Test:          &ecImproperCurves{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EEcImproperCurves = result },

--- a/lints/lint_ext_aia_marked_critical.go
+++ b/lints/lint_ext_aia_marked_critical.go
@@ -3,7 +3,7 @@
 Authority Information Access
    The authority information access extension indicates how to access information and services for the issuer of the certificate in which the extension appears. Information and services may include on-line validation services and CA policy data. (The location of CRLs is not specified in this extension; that information is provided by the cRLDistributionPoints extension.) This extension may be included in end entity or CA certificates. Conforming CAs MUST mark this extension as non-critical.
 ************************************************/
-//See also: CAB: 7.1.2.3 & CAB: 7.1.2.2
+//See also: BRs: 7.1.2.3 & CAB: 7.1.2.2
 
 package lints
 

--- a/lints/lint_ext_san_contains_reserved_ip.go
+++ b/lints/lint_ext_san_contains_reserved_ip.go
@@ -1,6 +1,6 @@
 // lint_ext_san_contains_reserved_ip.go
 /************************************************
-CAB: 7.1.4.2.1
+BRs: 7.1.4.2.1
 Also as of the Effective Date, the CA SHALL NOT
 issue a certificate with an Expiry Date later than
 1 November 2015 with a subjectAlternativeName extension
@@ -41,7 +41,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_contains_reserved_ip",
 		Description:   "Certificates expiring after 1 Nov 2015 MUST NOT contain a reserved IP address in the subjectAlternativeName extension",
-		Provenance:    "CAB: 7.1.4.2.1",
+		Provenance:    "BRs: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANReservedIP{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanContainsReservedIp = result },

--- a/lints/lint_ext_san_directory_name_present.go
+++ b/lints/lint_ext_san_directory_name_present.go
@@ -40,7 +40,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_directory_name_present",
 		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
-		Provenance:    "CAB: 7.1.4.2.1",
+		Provenance:    "BRs: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANDirName{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanDirectoryNamePresent = result },

--- a/lints/lint_ext_san_dnsname_not_fqdn.go
+++ b/lints/lint_ext_san_dnsname_not_fqdn.go
@@ -42,7 +42,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_dnsname_not_fqdn",
 		Description:   "SAN dnsnames MUST be Fully-Qualified Domain Names",
-		Provenance:    "CAB: 7.1.4.2.1",
+		Provenance:    "BRs: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &DNSFQDN{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanDnsnameNotFqdn = result },

--- a/lints/lint_ext_san_edi_party_name_present.go
+++ b/lints/lint_ext_san_edi_party_name_present.go
@@ -40,7 +40,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_edi_party_name_present",
 		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
-		Provenance:    "CAB: 7.1.4.2.1",
+		Provenance:    "BRs: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANEDI{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanEdiPartyNamePresent = result },

--- a/lints/lint_ext_san_missing.go
+++ b/lints/lint_ext_san_missing.go
@@ -1,6 +1,6 @@
 // lint_ext_san_missing.go
 /************************************************
-CAB: 7.1.4.2.1
+BRs: 7.1.4.2.1
 Subject Alternative Name Extension
 Certificate Field: extensions:subjectAltName
 Required/Optional: Required
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_missing",
 		Description:   "Subscriber certificates MUST contain the Subject Alternate Name extension",
-		Provenance:    "CAB: 7.1.4.2.1",
+		Provenance:    "BRs: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANMissing{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanMissing = result },

--- a/lints/lint_ext_san_other_name_present.go
+++ b/lints/lint_ext_san_other_name_present.go
@@ -40,7 +40,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_other_name_present",
 		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
-		Provenance:    "CAB: 7.1.4.2.1",
+		Provenance:    "BRs: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANOtherName{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanOtherNamePresent = result },

--- a/lints/lint_ext_san_registered_id_present.go
+++ b/lints/lint_ext_san_registered_id_present.go
@@ -40,7 +40,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_registered_id_present",
 		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
-		Provenance:    "CAB: 7.1.4.2.1",
+		Provenance:    "BRs: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANRegId{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanRegisteredIdPresent = result },

--- a/lints/lint_ext_san_rfc822_name_present.go
+++ b/lints/lint_ext_san_rfc822_name_present.go
@@ -40,7 +40,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_rfc822_name_present",
 		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
-		Provenance:    "CAB: 7.1.4.2.1",
+		Provenance:    "BRs: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANRfc822{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EExtSanRfc822NamePresent = result },

--- a/lints/lint_ext_san_uniform_resource_identifier_present.go
+++ b/lints/lint_ext_san_uniform_resource_identifier_present.go
@@ -40,7 +40,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_ext_san_uniform_resource_identifier_present",
 		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
-		Provenance:    "CAB: 7.1.4.2.1",
+		Provenance:    "BRs: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &SANURI{},
 		updateReport: func(report *LintReport, result ResultStruct) {

--- a/lints/lint_gtld_under_consideration.go
+++ b/lints/lint_gtld_under_consideration.go
@@ -48,7 +48,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_gtld_under_consideration",
 		Description:   "CAs SHOULD NOT issue certificates containing a new gTLD under consideration by ICANN",
-		Provenance:    "CAB: 4.2.2",
+		Provenance:    "BRs: 4.2.2",
 		EffectiveDate: util.CABV113Date,
 		Test:          &gtldUnderConsideration{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.WGtldUnderConsideration = result },

--- a/lints/lint_invalid_certificate_version.go
+++ b/lints/lint_invalid_certificate_version.go
@@ -34,7 +34,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_invalid_certificate_version",
 		Description:   "Certificate MUST be version 3 (encoded as 2)",
-		Provenance:    "CAB: 7.1.1",
+		Provenance:    "BRs: 7.1.1",
 		EffectiveDate: util.CABV130Date,
 		Test:          &InvalidCertificateVersion{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EInvalidCertificateVersion = result },

--- a/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
+++ b/lints/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_old_root_ca_rsa_mod_less_than_2048_bits",
 		Description:   "In a validity period beginning on or before 31 Dec 2010, root CA certificates using RSA public key algorithm MUST use a 2048 bit modulus",
-		Provenance:    "CAB: 6.1.5",
+		Provenance:    "BRs: 6.1.5",
 		EffectiveDate: util.ZeroDate,
 		Test:          &rootCaModSize{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EOldRootCaRsaModLessThan_2048Bits = result },

--- a/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
+++ b/lints/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:        "e_old_sub_ca_rsa_mod_less_than_1024_bits",
 		Description: "In a validity period beginning on or before 31 Dec 2010 and ending on or before 31 Dec 2013, subordinate CA certificates using RSA public key algorithm MUST use a 1024 bit modulus",
-		Provenance:  "CAB: 6.1.5",
+		Provenance:  "BRs: 6.1.5",
 		// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test
 		EffectiveDate: util.ZeroDate,
 		Test:          &subCaModSize{},

--- a/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
+++ b/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
@@ -36,7 +36,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:        "e_old_sub_cert_rsa_mod_less_than_1024_bits",
 		Description: "In a validity period ending on or before 31 Dec 2013, subscriber certificates using RSA public key algorithm MUST use a 1024 bit modulus",
-		Provenance:  "CAB: 6.1.5",
+		Provenance:  "BRs: 6.1.5",
 		// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test
 		EffectiveDate: util.ZeroDate,
 		Test:          &subModSize{},

--- a/lints/lint_public_key_type_not_allowed.go
+++ b/lints/lint_public_key_type_not_allowed.go
@@ -32,7 +32,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_public_key_type_not_allowed",
 		Description:   "Certificates MUST have RSA, DSA, or ECDSA public key type",
-		Provenance:    "CAB: 6.1.5",
+		Provenance:    "BRs: 6.1.5",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &publicKeyAllowed{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.EPublicKeyTypeNotAllowed = result },

--- a/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
+++ b/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
@@ -50,7 +50,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_root_ca_basic_constraints_path_len_constraint_field_present",
 		Description:   "Root CA certificate basicConstraint extension pathLenConstraint field SHOULD NOT be present",
-		Provenance:    "CAB: 7.1.2.1",
+		Provenance:    "BRs: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &rootCaPathLenPresent{},
 		updateReport: func(report *LintReport, result ResultStruct) {

--- a/lints/lint_root_ca_contains_cert_policy.go
+++ b/lints/lint_root_ca_contains_cert_policy.go
@@ -1,6 +1,6 @@
 // lint_root_ca_contains_cert_policy.go
 /************************************************
-CAB: 7.1.2.1c certificatePolicies
+BRs: 7.1.2.1c certificatePolicies
 This extension SHOULD NOT be present.
 ************************************************/
 
@@ -36,7 +36,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_root_ca_contains_cert_policy",
 		Description:   "Root CA certs SHOULD NOT contain the certificate policies extension",
-		Provenance:    "CAB: 7.1.2.1",
+		Provenance:    "BRs: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &rootCAContainsCertPolicy{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.WRootCaContainsCertPolicy = result },

--- a/lints/lint_root_ca_extended_key_usage_present.go
+++ b/lints/lint_root_ca_extended_key_usage_present.go
@@ -1,6 +1,6 @@
 // lint_root_ca_extended_key_usage_present.go
 /************************************************
-CAB: 7.1.2.1d extendedKeyUsage
+BRs: 7.1.2.1d extendedKeyUsage
 This extension MUST NOT be present.
 ************************************************/
 
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_root_ca_extended_key_usage_present",
 		Description:   "Root CA certificates MUST NOT have the extendedKeyUsage extension present",
-		Provenance:    "CAB: 7.1.2.1",
+		Provenance:    "BRs: 7.1.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &rootCAContainsEKU{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ERootCaExtendedKeyUsagePresent = result },

--- a/lints/lint_rsa_mod_factors_smaller_than_752_bits.go
+++ b/lints/lint_rsa_mod_factors_smaller_than_752_bits.go
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_rsa_mod_factors_smaller_than_752",
 		Description:   "The modulus of a RSA public key SHOULD NOT have factors smaller than 752",
-		Provenance:    "CAB: 6.1.6",
+		Provenance:    "BRs: 6.1.6",
 		EffectiveDate: util.CABV113Date,
 		Test:          &rsaModSmallFactor{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.WRsaModFactorsSmallerThan_752 = result },

--- a/lints/lint_rsa_mod_less_than_2048_bits.go
+++ b/lints/lint_rsa_mod_less_than_2048_bits.go
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_rsa_mod_less_than_2048_bits",
 		Description:   "In the validity period beginning after 31 Dec 2010, all certificates using RSA public key algorithm MUST have 2048 bits of modulus",
-		Provenance:    "CAB: 6.1.5",
+		Provenance:    "BRs: 6.1.5",
 		EffectiveDate: util.RsaDate, // CA/B BR is retroactive here
 		Test:          &rsaParsedTestsKeySize{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ERsaModLessThan_2048Bits = result },

--- a/lints/lint_rsa_mod_not_odd.go
+++ b/lints/lint_rsa_mod_not_odd.go
@@ -1,6 +1,6 @@
 // lint_rsa_mod_not_odd.go
 /*******************************************************************************************************
-"CAB: 6.1.6"
+"BRs: 6.1.6"
 RSA: The CA SHALL confirm that the value of the public exponent is an odd number equal to 3 or	more. Additionally,	the public exponent SHOULD be in the range between 2^16+1 and 2^256-1. The modulus SHOULD also have the following characteristics: an odd number, not the power of a prime, and have no factors smaller than 752. [Source: Section 5.3.3, NIST SP 800-89].
 *******************************************************************************************************/
 
@@ -40,7 +40,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_rsa_mod_not_odd",
 		Description:   "The modulus of a RSA public key should be an odd number",
-		Provenance:    "CAB: 6.1.6",
+		Provenance:    "BRs: 6.1.6",
 		EffectiveDate: util.CABV113Date,
 		Test:          &rsaParsedTestsKeyModOdd{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.WRsaModNotOdd = result },

--- a/lints/lint_rsa_public_exponent_not_in_range.go
+++ b/lints/lint_rsa_public_exponent_not_in_range.go
@@ -1,6 +1,6 @@
 // lint_rsa_public_exponent_not_in_range.go
 /*******************************************************************************************************
-"CAB: 6.1.6"
+"BRs: 6.1.6"
 RSA: The CA SHALL confirm that the value of the public exponent is an odd number equal to 3 or more. Additionally, the public exponent SHOULD be in the range between 2^16+1 and 2^256-1. The modulus SHOULD also have the following characteristics: an odd number, not the power of a prime, and have no factors smaller than 752. [Source: Section 5.3.3, NIST SP 800-89].
 *******************************************************************************************************/
 
@@ -46,7 +46,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_rsa_public_exponent_not_in_range",
 		Description:   "The RSA public exponent SHOULD be between 2^16 + 1 and 2^256 - 1",
-		Provenance:    "CAB: 6.1.6",
+		Provenance:    "BRs: 6.1.6",
 		EffectiveDate: util.CABV113Date,
 		Test:          &rsaParsedTestsExpInRange{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.WRsaPublicExponentNotInRange = result },

--- a/lints/lint_rsa_public_exponent_not_odd.go
+++ b/lints/lint_rsa_public_exponent_not_odd.go
@@ -1,6 +1,6 @@
 // lint_rsa_public_exponent_not_odd.go
 /*******************************************************************************************************
-"CAB: 6.1.6"
+"BRs: 6.1.6"
 RSA: The CA SHALL confirm that the value of the public exponent is an odd number equal to 3 or more. Additionally, the public exponent SHOULD be in the range between 2^16+1 and 2^256-1. The modulus SHOULD also have the following characteristics: an odd number, not the power of a prime, and have no factors smaller than 752. [Source: Section 5.3.3, NIST SP 800-89].
 *******************************************************************************************************/
 
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_rsa_public_exponent_not_odd",
 		Description:   "RSA public key has to be an odd number",
-		Provenance:    "CAB: 6.1.6",
+		Provenance:    "BRs: 6.1.6",
 		EffectiveDate: util.CABV113Date,
 		Test:          &rsaParsedTestsKeyExpOdd{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ERsaPublicExponentNotOdd = result },

--- a/lints/lint_rsa_public_exponent_too_small.go
+++ b/lints/lint_rsa_public_exponent_too_small.go
@@ -1,6 +1,6 @@
 // lint_rsa_public_exponent_too_small.go
 /*******************************************************************************************************
-"CAB: 6.1.6"
+"BRs: 6.1.6"
 RSA: The CA SHALL confirm that the value of the public exponent is an odd number equal to 3 or more. Additionally, the public exponent SHOULD be in the range between 2^16+1 and 2^256-1. The modulus SHOULD also have the following characteristics: an odd number, not the power of a prime, and have no factors smaller than 752. [Source: Section 5.3.3, NIST SP 800-89].
 *******************************************************************************************************/
 
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_rsa_public_exponent_too_small",
 		Description:   "RSA public key MUST be greater or equal to 3",
-		Provenance:    "CAB: 6.1.6",
+		Provenance:    "BRs: 6.1.6",
 		EffectiveDate: util.CABV113Date,
 		Test:          &rsaParsedTestsExpBounds{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ERsaPublicExponentTooSmall = result },

--- a/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
@@ -39,7 +39,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_ca_aia_does_not_contain_issuing_ca_url",
 		Description:   "Subordinate CA certificates authorityInformationAccess extension should contain the HTTP URL of the issuing CA’s certificate",
-		Provenance:    "CAB: 7.1.2.2",
+		Provenance:    "BRs: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCaIssuerUrl{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.WSubCaAiaDoesNotContainIssuingCaUrl = result },

--- a/lints/lint_sub_ca_aia_does_not_contain_ocsp_url.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_ocsp_url.go
@@ -39,7 +39,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_aia_does_not_contain_ocsp_url",
 		Description:   "Subordinate CA certificates authorityInformationAccess extension must contain the HTTP URL of the issuing CA’s OCSP responder",
-		Provenance:    "CAB: 7.1.2.2",
+		Provenance:    "BRs: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCaOcspUrl{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaAiaDoesNotContainOcspUrl = result },

--- a/lints/lint_sub_ca_aia_missing.go
+++ b/lints/lint_sub_ca_aia_missing.go
@@ -39,7 +39,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_aia_missing",
 		Description:   "Subordinate CA certificates must have a authorityInformationAccess extension",
-		Provenance:    "CAB: 7.1.2.2",
+		Provenance:    "BRs: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &caAiaMissing{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaAiaMissing = result },

--- a/lints/lint_sub_ca_certificate_policies_marked_critical.go
+++ b/lints/lint_sub_ca_certificate_policies_marked_critical.go
@@ -1,6 +1,6 @@
 // lint_sub_ca_certificate_policies_marked_critical.go
 /************************************************
-CAB: 7.1.2.2a certificatePolicies
+BRs: 7.1.2.2a certificatePolicies
 This extension MUST be present and SHOULD NOT be marked critical.
 ************************************************/
 
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_ca_certificate_policies_marked_critical",
 		Description:   "Subordinate CA certificates certificatePolicies extension should not be marked as critical",
-		Provenance:    "CAB: 7.1.2.2",
+		Provenance:    "BRs: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCACertPolicyCrit{},
 		updateReport: func(report *LintReport, result ResultStruct) {

--- a/lints/lint_sub_ca_certificate_policies_missing.go
+++ b/lints/lint_sub_ca_certificate_policies_missing.go
@@ -1,6 +1,6 @@
 // lint_sub_ca_certificate_policies_missing.go
 /************************************************
-CAB: 7.1.2.2a certificatePolicies
+BRs: 7.1.2.2a certificatePolicies
 This extension MUST be present and SHOULD NOT be marked critical.
 ************************************************/
 
@@ -36,7 +36,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_certificate_policies_missing",
 		Description:   "Subordinate CA certificates must have a certificatePolicies extension",
-		Provenance:    "CAB: 7.1.2.2",
+		Provenance:    "BRs: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCACertPolicyMissing{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaCertificatePoliciesMissing = result },

--- a/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
@@ -1,6 +1,6 @@
 // lint_sub_ca_crl_distribution_points_does_not_contain_url.go
 /************************************************
-CAB: 7.1.2.2b cRLDistributionPoints
+BRs: 7.1.2.2b cRLDistributionPoints
 This extension MUST be present and MUST NOT be marked critical.
 It MUST contain the HTTP URL of the CA’s CRL service.
 ************************************************/
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_crl_distribution_points_does_not_contain_url",
 		Description:   "Subordinate CA certificates cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service",
-		Provenance:    "CAB: 7.1.2.2",
+		Provenance:    "BRs: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCACRLDistNoUrl{},
 		updateReport: func(report *LintReport, result ResultStruct) {

--- a/lints/lint_sub_ca_crl_distribution_points_marked_critical.go
+++ b/lints/lint_sub_ca_crl_distribution_points_marked_critical.go
@@ -1,6 +1,6 @@
 // lint_sub_ca_crl_distribution_points_marked_critical.go
 /************************************************
-CAB: 7.1.2.2b cRLDistributionPoints
+BRs: 7.1.2.2b cRLDistributionPoints
 This extension MUST be present and MUST NOT be marked critical.
 It MUST contain the HTTP URL of the CA’s CRL service.
 ************************************************/
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_crl_distribution_points_marked_critical",
 		Description:   "Subordinate CA certificates must not mark the cRLDistributionPoints extension as critical",
-		Provenance:    "CAB: 7.1.2.2",
+		Provenance:    "BRs: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCACRLDistCrit{},
 		updateReport: func(report *LintReport, result ResultStruct) {

--- a/lints/lint_sub_ca_crl_distribution_points_missing.go
+++ b/lints/lint_sub_ca_crl_distribution_points_missing.go
@@ -1,6 +1,6 @@
 // lint_sub_ca_crl_distribution_points_missing.go
 /************************************************
-CAB: 7.1.2.2b cRLDistributionPoints
+BRs: 7.1.2.2b cRLDistributionPoints
 This extension MUST be present and MUST NOT be marked critical.
 It MUST contain the HTTP URL of the CA’s CRL service.
 ************************************************/
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_crl_distribution_points_missing",
 		Description:   "Subordinate CA certificates must have a cRLDistributionPoints extension",
-		Provenance:    "CAB: 7.1.2.2",
+		Provenance:    "BRs: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCACRLDistMissing{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaCrlDistributionPointsMissing = result },

--- a/lints/lint_sub_ca_eku_critical.go
+++ b/lints/lint_sub_ca_eku_critical.go
@@ -1,6 +1,6 @@
 // lint_sub_ca_eku_critical.go
 /************************************************
-CAB: 7.1.2.2g extkeyUsage (optional)
+BRs: 7.1.2.2g extkeyUsage (optional)
 For Subordinate CA Certificates to be Technically constrained in line with section 7.1.5, then either the value
 id‐kp‐serverAuth [RFC5280] or id‐kp‐clientAuth [RFC5280] or both values MUST be present**.
 Other values MAY be present.
@@ -39,7 +39,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_ca_eku_critical",
 		Description:   "Subordinate CA certificate extkeyUsage extension should be marked non-critical if present",
-		Provenance:    "CAB: 7.1.2.2",
+		Provenance:    "BRs: 7.1.2.2",
 		EffectiveDate: util.CABV116Date,
 		Test:          &subCAEKUCrit{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.WSubCaEkuCritical = result },

--- a/lints/lint_sub_ca_name_constraints_not_critical.go
+++ b/lints/lint_sub_ca_name_constraints_not_critical.go
@@ -34,7 +34,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_ca_name_constraints_not_critical",
 		Description:   "Subordinate CA certificate nameConstraints extension should be marked critical if present",
-		Provenance:    "CAB: 7.1.2.2",
+		Provenance:    "BRs: 7.1.2.2",
 		EffectiveDate: util.CABV102Date,
 		Test:          &SubCANameConstraintsNotCritical{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.WSubCaNameConstraintsNotCritical = result },

--- a/lints/lint_sub_ca_no_dns_name_contstraints.go
+++ b/lints/lint_sub_ca_no_dns_name_contstraints.go
@@ -41,7 +41,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_no_dns_name_constraints",
 		Description:   "Subordinate CA certificates MUST be accompanied by other data to it's right must include in the name contraints extension either permitted DNS names or prohibit the empty DNS name",
-		Provenance:    "CAB: 7.1.5",
+		Provenance:    "BRs: 7.1.5",
 		EffectiveDate: util.CABV116Date,
 		Test:          &subCaBadDNSConstraint{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaNoDnsNameConstraints = result },

--- a/lints/lint_sub_ca_no_ip_name_contstraints.go
+++ b/lints/lint_sub_ca_no_ip_name_contstraints.go
@@ -57,7 +57,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_ca_no_ip_name_constraints",
 		Description:   "Subordinate CA certs must include in the name contraints extension either permitted IP ranges or prohibit all IP addresses",
-		Provenance:    "CAB: 7.1.5",
+		Provenance:    "BRs: 7.1.5",
 		EffectiveDate: util.CABV116Date,
 		Test:          &subCaBadIPConstraint{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCaNoIpNameConstraints = result },

--- a/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
 /************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 cRLDistributionPoints
 This extension MAY be present. If present, it MUST NOT be marked critical, and it MUST contain the
 HTTP URL of the CA’s CRL service. See Section 13.2.1 for details.
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_aia_does_not_contain_issuing_ca_url",
 		Description:   "Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the issuing CA’s certificate",
-		Provenance:    "CAB: 7.1.2.3",
+		Provenance:    "BRs: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertIssuerUrl{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertAiaDoesNotContainIssuingCaUrl = result },

--- a/lints/lint_sub_cert_aia_does_not_contain_ocsp_url.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_ocsp_url.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_aia_does_not_contain_ocsp_url.go
 /**************************************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 authorityInformationAccess
 With the exception of stapling, which is noted below, this extension MUST be present. It MUST NOT be
 marked critical, and it MUST contain the HTTP URL of the Issuing CA’s OCSP responder (accessMethod
@@ -40,7 +40,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_aia_does_not_contain_ocsp_url",
 		Description:   "Subscriber certificates authorityInformationAccess extension must contain the HTTP URL of the issuing CA’s OCSP responder",
-		Provenance:    "CAB: 7.1.2.3",
+		Provenance:    "BRs: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertOcspUrl{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertAiaDoesNotContainOcspUrl = result },

--- a/lints/lint_sub_cert_aia_missing.go
+++ b/lints/lint_sub_cert_aia_missing.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_aia_missing.go
 /**************************************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 authorityInformationAccess
 With the exception of stapling, which is noted below, this extension MUST be present. It MUST NOT be
 marked critical, and it MUST contain the HTTP URL of the Issuing CA’s OCSP responder (accessMethod
@@ -40,7 +40,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_aia_missing",
 		Description:   "Subscriber certificates must have an authorityInformationAccess extension",
-		Provenance:    "CAB: 7.1.2.3",
+		Provenance:    "BRs: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertAiaMissing{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertAiaMissing = result },

--- a/lints/lint_sub_cert_cert_policy_empty.go
+++ b/lints/lint_sub_cert_cert_policy_empty.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_cert_policy_empty.go
 /********************************************************************************************************************
-CAB: 7.1.6.4
+BRs: 7.1.6.4
 Subscriber Certificates
 A Certificate issued to a Subscriber MUST contain one or more policy identifier(s), defined by the Issuing CA, in
 the Certificate’s certificatePolicies extension that indicates adherence to and complIANce with these Requirements.
@@ -39,7 +39,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_cert_policy_empty",
 		Description:   "Subscriber certificates must contain at least one policy identifier that indicates adherence to CAB standards",
-		Provenance:    "CAB: 7.1.6.4",
+		Provenance:    "BRs: 7.1.6.4",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertPolicyEmpty{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertCertPolicyEmpty = result },

--- a/lints/lint_sub_cert_certificate_policies_marked_critical.go
+++ b/lints/lint_sub_cert_certificate_policies_marked_critical.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_certificate_policies_marked_critical.go
 /******************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 certificatePolicies
 This extension MUST be present and SHOULD NOT be marked critical.
 ******************************************************************************/
@@ -36,7 +36,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_cert_certificate_policies_marked_critical",
 		Description:   "Subscriber certificates should have the policies extension marked non-critical",
-		Provenance:    "CAB: 7.1.2.3",
+		Provenance:    "BRs: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertPolicyCrit{},
 		updateReport: func(report *LintReport, result ResultStruct) {

--- a/lints/lint_sub_cert_certificate_policies_missing.go
+++ b/lints/lint_sub_cert_certificate_policies_missing.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_certificate_policies_missing.go
 /******************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 certificatePolicies
 This extension MUST be present and SHOULD NOT be marked critical.
 ******************************************************************************/
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_certificate_policies_missing",
 		Description:   "Subscriber certificates should have the certificates policies extension present",
-		Provenance:    "CAB: 7.1.2.2",
+		Provenance:    "BRs: 7.1.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertPolicy{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertCertificatePoliciesMissing = result },

--- a/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_crl_distribution_points_does_not_contain_url.go
 /*******************************************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 cRLDistributionPoints
 This extension MAY be present. If present, it MUST NOT be marked critical, and it MUST contain the HTTP
 URL of the CA’s CRL service.
@@ -41,7 +41,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_crl_distribution_points_does_not_contain_url",
 		Description:   "Subscriber certificate cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service",
-		Provenance:    "CAB: 7.1.2.3",
+		Provenance:    "BRs: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCRLDistNoURL{},
 		updateReport: func(report *LintReport, result ResultStruct) {

--- a/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
+++ b/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_crl_distribution_points_marked_critical.go
 /*******************************************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 cRLDistributionPoints
 This extension MAY be present. If present, it MUST NOT be marked critical, and it MUST contain the HTTP
 URL of the CA’s CRL service.
@@ -40,7 +40,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_crl_distribution_points_marked_critical",
 		Description:   "Subscriber certificate cRLDistributionPoints extension MUST NOT be marked critical if present",
-		Provenance:    "CAB: 7.1.2.3",
+		Provenance:    "BRs: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCrlDistCrit{},
 		updateReport: func(report *LintReport, result ResultStruct) {

--- a/lints/lint_sub_cert_eku_extra_values.go
+++ b/lints/lint_sub_cert_eku_extra_values.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_eku_extra_values.go
 /*******************************************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 extKeyUsage (required)
 Either the value id-kp-serverAuth [RFC5280] or id-kp-clientAuth [RFC5280] or both values MUST be present. id-kp-emailProtection [RFC5280] MAY be present. Other values SHOULD NOT be present.
 *******************************************************************************************************/
@@ -46,7 +46,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_cert_eku_extra_values",
 		Description:   "Subscriber certificates SHOULD have only id-kp-serverAuth, id-kp-clientAuth, or id-kp-emailProtection in extKeyUsage",
-		Provenance:    "CAB: 7.1.2.3",
+		Provenance:    "BRs: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subExtKeyUsageLegalUsage{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.WSubCertEkuExtraValues = result },

--- a/lints/lint_sub_cert_eku_missing.go
+++ b/lints/lint_sub_cert_eku_missing.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_eku_missing.go
 /*******************************************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 extKeyUsage (required)
 Either the value id-kp-serverAuth [RFC5280] or id-kp-clientAuth [RFC5280] or both values MUST be present. id-kp-emailProtection [RFC5280] MAY be present. Other values SHOULD NOT be present.
 *******************************************************************************************************/
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_eku_missing",
 		Description:   "Subscriber certificates MUST have the extended key usage extension present",
-		Provenance:    "CAB: 7.1.2.3",
+		Provenance:    "BRs: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subExtKeyUsage{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertEkuMissing = result },

--- a/lints/lint_sub_cert_eku_server_auth_client_auth_missing.go
+++ b/lints/lint_sub_cert_eku_server_auth_client_auth_missing.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_eku_server_auth_client_auth_missing.go
 /*******************************************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 extKeyUsage (required)
 Either the value id-kp-serverAuth [RFC5280] or id-kp-clientAuth [RFC5280] or both values MUST be present. id-kp-emailProtection [RFC5280] MAY be present. Other values SHOULD NOT be present.
 *******************************************************************************************************/
@@ -41,7 +41,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_eku_server_auth_client_auth_missing",
 		Description:   "Subscriber certificates MUST have have either id-kp-serverAuth or id-kp-clientAuth or both present in extKeyUsage",
-		Provenance:    "CAB: 7.1.2.3",
+		Provenance:    "BRs: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subExtKeyUsageClientOrServer{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertEkuServerAuthClientAuthMissing = result },

--- a/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_cert_sign_bit_set.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_key_usage_cert_sign_bit_set.go
 /**************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 keyUsage (optional)
 If present, bit positions for keyCertSign and cRLSign MUST NOT be set.
 ***************************************************************************/
@@ -37,7 +37,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_key_usage_cert_sign_bit_set",
 		Description:   "Subscriber certificates keyUsage extension keyCertSign bit MUST NOT be set",
-		Provenance:    "CAB: 7.1.2.3",
+		Provenance:    "BRs: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCertKeyUsageBitSet{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertKeyUsageCertSignBitSet = result },

--- a/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
+++ b/lints/lint_sub_cert_key_usage_crl_sign_bit_set.go
@@ -1,6 +1,6 @@
 // lint_sub_key_usage_crl_sign_bit_set.go
 /**************************************************************************
-CAB: 7.1.2.3
+BRs: 7.1.2.3
 keyUsage (optional)
 If present, bit positions for keyCertSign and cRLSign MUST NOT be set.
 ***************************************************************************/
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_key_usage_crl_sign_bit_set",
 		Description:   "Subscriber certificates keyUsage extension cRLSign bit MUST NOT be set",
-		Provenance:    "CAB: 7.1.2.3",
+		Provenance:    "BRs: 7.1.2.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subCrlSignAllowed{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertKeyUsageCrlSignBitSet = result },

--- a/lints/lint_sub_cert_or_sub_ca_using_sha1.go
+++ b/lints/lint_sub_cert_or_sub_ca_using_sha1.go
@@ -1,6 +1,6 @@
 // lint_sub_cert_or_sub_ca_using_sha1.go
 /**************************************************************************************************
-CAB: 7.1.3
+BRs: 7.1.3
 SHA‐1	MAY	be	used	with	RSA	keys	in	accordance	with	the	criteria	defined	in	Section	7.1.3.
 **************************************************************************************************/
 package lints
@@ -41,7 +41,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_or_sub_ca_using_sha1",
 		Description:   "Subscriber certificates and subordinate CA certificates MUST NOT use the SHA-1 hash algorithm on a certificate with a NotBefore date later than 1 Jan 2016",
-		Provenance:    "CAB: 7.1.3",
+		Provenance:    "BRs: 7.1.3",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &sigAlgTestsSHA1{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubCertOrSubCaUsingSha1 = result },

--- a/lints/lint_sub_cert_sha1_expiration_too_long.go
+++ b/lints/lint_sub_cert_sha1_expiration_too_long.go
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_cert_sha1_expiration_too_long",
 		Description:   "Subscriber certificates using the SHA-1 algorithm SHOULD NOT have an expiration date later than 1 Jan 2017",
-		Provenance:    "CAB: 7.1.3",
+		Provenance:    "BRs: 7.1.3",
 		EffectiveDate: time.Date(2015, time.January, 16, 0, 0, 0, 0, time.UTC),
 		Test:          &sha1ExpireLong{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.WSubCertSha1ExpirationTooLong = result },

--- a/lints/lint_subject_common_name_disallowed.go
+++ b/lints/lint_subject_common_name_disallowed.go
@@ -45,7 +45,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_common_name_disallowed",
 		Description:   "If present in a subscriber certificate, commonName MUST contain a single IP address or Fully‐Qualified Domain Name that is one of the values contained in the certificate’s subjectAltName extension",
-		Provenance:    "CAB: 7.1.4.2.2",
+		Provenance:    "BRs: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &BadCommonName{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectCommonNameDisallowed = result },

--- a/lints/lint_subject_common_name_included.go
+++ b/lints/lint_subject_common_name_included.go
@@ -1,6 +1,6 @@
 // lint_subject_common_name_included.go
 /***************************************************************
-CAB: 7.1.4.2.2
+BRs: 7.1.4.2.2
 Required/Optional: Deprecated (Discouraged, but not prohibited)
 ***************************************************************/
 package lints
@@ -35,7 +35,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "n_subject_common_name_included",
 		Description:   "Use of the commonName field is discouraged",
-		Provenance:    "CAB: 7.1.4.2.2",
+		Provenance:    "BRs: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &commonNames{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.NSubjectCommonNameIncluded = result },

--- a/lints/lint_subject_common_name_not_from_san.go
+++ b/lints/lint_subject_common_name_not_from_san.go
@@ -1,6 +1,6 @@
 // lint_subject_common_name_not_from_san.go
 /************************************************
-CAB: 7.1.4.2.2
+BRs: 7.1.4.2.2
 If present, this field MUST contain a single IP address
 or Fully‐Qualified Domain Name that is one of the values
 contained in the Certificate’s subjectAltName extension (see Section 7.1.4.2.1).
@@ -47,7 +47,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_common_name_not_from_san",
 		Description:   "The common name field in subscriber certificates must include only names from the SAN extension",
-		Provenance:    "CAB: 7.1.4.2.2",
+		Provenance:    "BRs: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subjectCommonNameNotFromSAN{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectCommonNameNotFromSan = result },

--- a/lints/lint_subject_contains_noninformational_value.go
+++ b/lints/lint_subject_contains_noninformational_value.go
@@ -1,6 +1,6 @@
 // lint_subject_contains_noninformational_value.go
 /**********************************************************************************************************************
-CAB: 7.1.4.2.2
+BRs: 7.1.4.2.2
 Other Subject Attributes
 With the exception of the subject:organizationalUnitName (OU) attribute, optional attributes, when present within
 the subject field, MUST contain information that has been verified by the CA. Metadata such as ‘.’, ‘-‘, and ‘ ‘ (i.e.
@@ -58,7 +58,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_contains_noninformational_value",
 		Description:   "Subject name fields must not contain '.','-',' ' or any other indication that the field has been omitted",
-		Provenance:    "CAB: 7.1.4.2.2",
+		Provenance:    "BRs: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &illegalChar{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectContainsNoninformationalValue = result },

--- a/lints/lint_subject_contains_reserved_ip.go
+++ b/lints/lint_subject_contains_reserved_ip.go
@@ -1,6 +1,6 @@
 // lint_subject_contains_reserved_ip.go
 /************************************************
-CAB: 7.1.4.2.1
+BRs: 7.1.4.2.1
 Also as of the Effective Date, the CA SHALL NOT
 issue a certificate with an Expiry Date later than
 1 November 2015 with a subjectAlternativeName extension
@@ -44,7 +44,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_contains_reserved_ip",
 		Description:   "Certificates expiring later than 11 Jan 2015 MUST NOT contain a reserved IP address in the common name field",
-		Provenance:    "CAB: 7.1.4.2.1",
+		Provenance:    "BRs: 7.1.4.2.1",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &subjectReservedIP{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectContainsReservedIp = result },

--- a/lints/lint_subject_country_not_iso.go
+++ b/lints/lint_subject_country_not_iso.go
@@ -1,6 +1,6 @@
 // lint_subject_country_not_iso.go
 /**************************************************************************************************************
-CAB: 7.1.4.2.2
+BRs: 7.1.4.2.2
 Certificate Field: issuer:countryName (OID 2.5.4.6)
 Required/Optional: Required
 Contents: This field MUST contain the two-letter ISO 3166-1 country code for the country in which the issuer’s
@@ -41,7 +41,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_country_not_iso",
 		Description:   "The country name field MUST contain the two-letter ISO code for the country or XX",
-		Provenance:    "CAB: 7.1.4.2.2",
+		Provenance:    "BRs: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &countryNotIso{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectCountryNotIso = result },

--- a/lints/lint_subject_locality_without_org.go
+++ b/lints/lint_subject_locality_without_org.go
@@ -39,7 +39,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_locality_without_org",
 		Description:   "The Locality field MUST NOT be included without an organization name",
-		Provenance:    "CAB: 7.1.4.2.2",
+		Provenance:    "BRs: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &localNoOrg{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectLocalityWithoutOrg = result },

--- a/lints/lint_subject_org_without_country.go
+++ b/lints/lint_subject_org_without_country.go
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_org_without_country",
 		Description:   "The organization name field MUST not be included without a country name",
-		Provenance:    "CAB: 7.1.4.2.2 (d&e)",
+		Provenance:    "BRs: 7.1.4.2.2 (d&e)",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &orgNoCountry{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectOrgWithoutCountry = result },

--- a/lints/lint_subject_org_without_locality_or_province.go
+++ b/lints/lint_subject_org_without_locality_or_province.go
@@ -34,7 +34,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_org_without_locality_or_province",
 		Description:   "If organization is included in a subscriber certificate, either stateOrProvince or locality MUST be included",
-		Provenance:    "CAB: 7.1.4.2.2 (d&e)",
+		Provenance:    "BRs: 7.1.4.2.2 (d&e)",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &orgNoLocalOrProvince{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectOrgWithoutLocalityOrProvince = result },

--- a/lints/lint_subject_postal_without_org.go
+++ b/lints/lint_subject_postal_without_org.go
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_postal_without_org",
 		Description:   "The postal code MUST NOT be included without an organization name",
-		Provenance:    "CAB: 7.1.4.2.2",
+		Provenance:    "BRs: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &postalNoOrg{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectPostalWithoutOrg = result },

--- a/lints/lint_subject_province_without_org.go
+++ b/lints/lint_subject_province_without_org.go
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_province_without_org",
 		Description:   "The stateOrProvince name MUST NOT be included without an organization name",
-		Provenance:    "CAB: 7.1.4.2.2",
+		Provenance:    "BRs: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &provinceNoOrg{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectProvinceWithoutOrg = result },

--- a/lints/lint_subject_street_without_org.go
+++ b/lints/lint_subject_street_without_org.go
@@ -38,7 +38,7 @@ func init() {
 	RegisterLint(&Lint{
 		Name:          "e_subject_street_without_org",
 		Description:   "The 'Street Address' field MUST NOT be included without an organization name",
-		Provenance:    "CAB: 7.1.4.2.2",
+		Provenance:    "BRs: 7.1.4.2.2",
 		EffectiveDate: util.CABEffectiveDate,
 		Test:          &streetNoOrg{},
 		updateReport:  func(report *LintReport, result ResultStruct) { report.ESubjectStreetWithoutOrg = result },


### PR DESCRIPTION
"[the] BRs" is a (soon to be) official short reference to our favorite document, The Baseline Requirements for the Issuance and Management of Publicly-Trusted Certificates.

https://cabforum.org/pipermail/public/2017-August/011856.html