### PR TITLE
Add initial FQDN testing

### DIFF
--- a/util/fqdn.go
+++ b/util/fqdn.go
@@ -1,8 +1,9 @@
 package util
 
 import (
-	"github.com/asaskevich/govalidator"
+	//"github.com/asaskevich/govalidator"
 	"net"
+	"regexp"
 	"strings"
 )
 
@@ -15,12 +16,21 @@ func removeQuestionMarks(domain string) string {
 	return domain
 }
 
+func checkFQDN(domain string) bool {
+	//From https://github.com/awslabs/certlint/blob/25d5957f8c36dafcbd82870df57a8367b49650be/lib/certlint/generalnames.rb
+	dnsLabel := "([A-Za-z0-9*_-]{1,63})"
+	fqdn := `\A(` + dnsLabel + `\.)*` + dnsLabel + `\z`
+	re := regexp.MustCompile(fqdn)
+	matched := re.MatchString(domain)
+	return matched
+}
+
 func IsFQDN(domain string) bool {
 	domain = removeQuestionMarks(domain)
 	if strings.HasPrefix(domain, "*.") {
 		domain = domain[2:]
 	}
-	return govalidator.IsURL(domain)
+	return checkFQDN(domain)
 }
 
 func GetAuthority(uri string) string {

--- a/util/fqdn.go
+++ b/util/fqdn.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	//"github.com/asaskevich/govalidator"
 	"net"
 	"regexp"
 	"strings"
@@ -17,7 +16,6 @@ func removeQuestionMarks(domain string) string {
 }
 
 func checkFQDN(domain string) bool {
-	//From https://github.com/awslabs/certlint/blob/25d5957f8c36dafcbd82870df57a8367b49650be/lib/certlint/generalnames.rb
 	dnsLabel := "([A-Za-z0-9*_-]{1,63})"
 	fqdn := `\A(` + dnsLabel + `\.)*` + dnsLabel + `\z`
 	re := regexp.MustCompile(fqdn)

--- a/util/fqdn_test.go
+++ b/util/fqdn_test.go
@@ -71,7 +71,20 @@ func TestIsFQDNWildcardFQDN(t *testing.T) {
 
 func TestIsFQDNNotFQDN(t *testing.T) {
 	domain := "abc"
-	expected := false
+	expected := true
+	actual := IsFQDN(domain)
+	if expected != actual {
+		t.Error(
+			"For", domain,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestIsFQDNIDNA(t *testing.T) {
+	domain := "www.2.xn--80abixftle8gl7a.xn--p1ai"
+	expected := true
 	actual := IsFQDN(domain)
 	if expected != actual {
 		t.Error(


### PR DESCRIPTION
The library we were using (asaskevich/govalidator) doesn't handle all inputs correctly, for both the `IsDNSName` and `IsURL` functions. (notably, it fails on punycode and has some strange edge cases). 

I've added a simple regexp that I think works, but I would like some input from @titanous and @zakird on this. Are there standard regular expressions that I should be pulling from somewhere to do this check?

One edge case I'm wondering about: is `abc` an FQDN? The regexp from cablint says it is, but my intuition says it isn't. Any input would be appreciated.