### PR TITLE
Fix san bare suffix, ca CN effective time, subCA EKU 

### DIFF
--- a/lints/lint_ca_common_name_missing.go
+++ b/lints/lint_ca_common_name_missing.go
@@ -43,7 +43,7 @@ func init() {
 		Description:   "CA Certificates common name MUST be included.",
 		Citation:      "BRs: 7.1.4.3.1",
 		Source:        CABFBaselineRequirements,
-		EffectiveDate: util.RFC2459Date,
+		EffectiveDate: util.CABV148Date,
 		Lint:          &caCommonNameMissing{},
 	})
 }

--- a/lints/lint_san_iana_pub_suffix_empty.go
+++ b/lints/lint_san_iana_pub_suffix_empty.go
@@ -5,7 +5,7 @@ package lints
 import (
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"golang.org/x/net/publicsuffix"
+	"strings"
 )
 
 type pubSuffix struct{}
@@ -20,9 +20,13 @@ func (l *pubSuffix) CheckApplies(c *x509.Certificate) bool {
 
 func (l *pubSuffix) Execute(c *x509.Certificate) *LintResult {
 	for _, dns := range c.DNSNames {
-		suffix, _ := publicsuffix.PublicSuffix(dns)
-		if suffix == dns {
-			return &LintResult{Status: Warn}
+		_, err := util.ICANNPublicSuffixParse(dns)
+		if err != nil {
+			if strings.HasSuffix(err.Error(), "is a suffix") {
+				return &LintResult{Status: Warn}
+			} else {
+				return &LintResult{Status: NA}
+			}
 		}
 	}
 	return &LintResult{Status: Pass}

--- a/lints/lint_san_iana_pub_suffix_empty_test.go
+++ b/lints/lint_san_iana_pub_suffix_empty_test.go
@@ -14,6 +14,15 @@ func TestSANBarePubSuffix(t *testing.T) {
 	}
 }
 
+func TestSANBarePrivatePubSuffix(t *testing.T) {
+	inputPath := "../testlint/testCerts/sanPrivatePublicSuffix.pem"
+	expected := Pass
+	out := Lints["w_san_iana_pub_suffix_empty"].Execute(ReadCertificate(inputPath))
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
 func TestSANGoodPubSuffix(t *testing.T) {
 	inputPath := "../testlint/testCerts/SANGoodSuffix.pem"
 	expected := Pass

--- a/lints/lint_sub_ca_eku_missing.go
+++ b/lints/lint_sub_ca_eku_missing.go
@@ -19,14 +19,14 @@ func (l *subCAEKUMissing) Execute(c *x509.Certificate) *LintResult {
 	if util.IsExtInCert(c, util.EkuSynOid) {
 		return &LintResult{Status: Pass}
 	} else {
-		return &LintResult{Status: Error}
+		return &LintResult{Status: Notice}
 	}
 }
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "e_sub_ca_eku_missing",
-		Description:   "Subordinate CA certificate MUST have extkeyUsage extension",
+		Name:          "n_sub_ca_eku_missing",
+		Description:   "To be considered Technically Constrained, the Subordinate CA certificate MUST have extkeyUsage extension",
 		Citation:      "BRs: 7.1.5",
 		Source:        CABFBaselineRequirements,
 		EffectiveDate: util.CABEffectiveDate,

--- a/lints/lint_sub_ca_eku_missing_test.go
+++ b/lints/lint_sub_ca_eku_missing_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestSubCaEkuMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAEKUMissing.pem"
-	expected := Error
-	out := Lints["e_sub_ca_eku_missing"].Execute(ReadCertificate(inputPath))
+	expected := Notice
+	out := Lints["n_sub_ca_eku_missing"].Execute(ReadCertificate(inputPath))
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
@@ -17,7 +17,7 @@ func TestSubCaEkuMissing(t *testing.T) {
 func TestSubCaEkuNotMissing(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCAWEkuCrit.pem"
 	expected := Pass
-	out := Lints["e_sub_ca_eku_missing"].Execute(ReadCertificate(inputPath))
+	out := Lints["n_sub_ca_eku_missing"].Execute(ReadCertificate(inputPath))
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}

--- a/testlint/testCerts/sanPrivatePublicSuffix.pem
+++ b/testlint/testCerts/sanPrivatePublicSuffix.pem
@@ -1,0 +1,105 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            03:2a:b9:e3:72:7c:a4:cb:16:8e:23:24:96:0b:5c:00:af:e9
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, O=Let's Encrypt, CN=Let's Encrypt Authority X3
+        Validity
+            Not Before: Sep 15 02:00:00 2017 GMT
+            Not After : Dec 14 02:00:00 2017 GMT
+        Subject: CN=ryujjin.alwaysdata.net
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:e1:87:fe:d2:f1:8e:3a:f6:dc:7a:09:90:3a:b4:
+                    c7:a5:1a:46:a7:49:37:aa:ed:4e:ed:fb:15:18:29:
+                    c4:86:86:b6:41:82:35:33:69:ce:bd:21:3c:e2:c9:
+                    16:88:4f:89:c7:43:14:ac:a2:23:41:95:6f:92:90:
+                    39:cf:89:55:2b:a2:6b:df:92:ea:c4:dd:a2:3f:e2:
+                    3e:86:9c:f3:85:a7:d4:b5:f8:11:03:65:6f:39:10:
+                    00:f4:d9:aa:cc:d4:69:48:16:3b:07:85:1f:92:9f:
+                    24:45:22:27:83:bb:77:ed:bf:ec:dc:f4:c6:2b:a5:
+                    20:0a:7a:2a:c3:08:60:89:f1:5a:8a:35:eb:79:4d:
+                    11:ed:f6:17:4b:0a:3c:42:d2:1d:34:e1:90:79:a1:
+                    a4:d6:b1:c2:27:02:95:2c:00:e1:96:f8:db:42:90:
+                    81:46:34:68:1e:d0:31:19:a1:51:e6:39:40:48:62:
+                    08:0d:3f:59:09:be:4a:28:ba:cf:4d:76:3f:a4:ff:
+                    03:0b:61:cf:30:cc:5c:b4:00:62:26:65:34:90:fd:
+                    a2:22:c0:48:d2:8c:f7:45:55:50:c4:b1:98:5c:51:
+                    da:b5:95:12:a4:59:03:a7:1b:66:f5:b3:d6:bb:da:
+                    16:37:cf:85:fe:bd:ca:08:0b:21:d8:a2:cf:23:2e:
+                    56:43
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                CA:95:77:90:A8:D7:4D:52:80:02:9A:17:AB:5A:25:1F:82:48:A1:BF
+            X509v3 Authority Key Identifier: 
+                keyid:A8:4A:6A:63:04:7D:DD:BA:E6:D1:39:B7:A6:45:65:EF:F3:A8:EC:A1
+
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.int-x3.letsencrypt.org
+                CA Issuers - URI:http://cert.int-x3.letsencrypt.org/
+
+            X509v3 Subject Alternative Name: 
+                DNS:ryujjin.alwaysdata.net
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+                Policy: 1.3.6.1.4.1.44947.1.1.1
+                  CPS: http://cps.letsencrypt.org
+                  User Notice:
+                    Explicit Text: This Certificate may only be relied upon by Relying Parties and only in accordance with the Certificate Policy found at https://letsencrypt.org/repository/
+
+    Signature Algorithm: sha256WithRSAEncryption
+         14:c5:e0:26:60:13:67:5b:79:22:e4:46:ad:4b:79:42:2b:0d:
+         61:c9:15:10:e6:5f:fc:4e:a9:51:fa:6c:ff:f2:28:ff:66:1c:
+         74:4f:f6:b6:a1:46:4d:79:c2:c5:eb:8c:2b:90:5e:9c:fd:0f:
+         2a:71:91:bc:b6:a4:08:ea:87:ff:b1:28:14:15:a9:3f:b5:a6:
+         4b:e1:19:91:3e:48:23:5f:9c:5a:1e:c6:f5:b3:0e:4a:eb:0b:
+         44:4e:3d:30:6c:80:a3:a8:05:ad:37:ee:be:d0:e0:3a:d0:a8:
+         55:2f:78:45:0c:aa:7d:12:3a:c1:bd:ed:27:1a:1d:ae:7a:04:
+         86:5c:89:06:91:8f:7d:d6:7e:84:7f:7c:b8:89:30:07:9d:ef:
+         20:e8:60:cf:46:e1:e1:94:09:ee:e1:b0:0a:65:16:7e:52:be:
+         36:f0:b7:13:4f:17:be:96:7f:eb:a0:d8:e7:99:ff:99:02:bc:
+         2d:06:31:d5:02:15:ed:e6:65:32:47:84:89:a8:93:29:3b:a3:
+         e2:c6:9a:96:96:26:fc:3b:5d:07:4c:d9:4f:a5:0e:dc:2a:b2:
+         a7:dc:c2:ba:1e:b3:9a:37:3a:cd:1e:51:08:cc:8d:70:3e:fc:
+         59:7c:67:48:21:c8:12:54:dc:84:62:c1:8d:ba:fb:f7:32:5c:
+         d8:0b:fa:20
+-----BEGIN CERTIFICATE-----
+MIIFDzCCA/egAwIBAgISAyq543J8pMsWjiMklgtcAK/pMA0GCSqGSIb3DQEBCwUA
+MEoxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MSMwIQYDVQQD
+ExpMZXQncyBFbmNyeXB0IEF1dGhvcml0eSBYMzAeFw0xNzA5MTUwMjAwMDBaFw0x
+NzEyMTQwMjAwMDBaMCExHzAdBgNVBAMTFnJ5dWpqaW4uYWx3YXlzZGF0YS5uZXQw
+ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDhh/7S8Y469tx6CZA6tMel
+GkanSTeq7U7t+xUYKcSGhrZBgjUzac69ITziyRaIT4nHQxSsoiNBlW+SkDnPiVUr
+omvfkurE3aI/4j6GnPOFp9S1+BEDZW85EAD02arM1GlIFjsHhR+SnyRFIieDu3ft
+v+zc9MYrpSAKeirDCGCJ8VqKNet5TRHt9hdLCjxC0h004ZB5oaTWscInApUsAOGW
++NtCkIFGNGge0DEZoVHmOUBIYggNP1kJvkoous9Ndj+k/wMLYc8wzFy0AGImZTSQ
+/aIiwEjSjPdFVVDEsZhcUdq1lRKkWQOnG2b1s9a72hY3z4X+vcoICyHYos8jLlZD
+AgMBAAGjggIWMIICEjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUH
+AwEGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFMqVd5Co101SgAKa
+F6taJR+CSKG/MB8GA1UdIwQYMBaAFKhKamMEfd265tE5t6ZFZe/zqOyhMG8GCCsG
+AQUFBwEBBGMwYTAuBggrBgEFBQcwAYYiaHR0cDovL29jc3AuaW50LXgzLmxldHNl
+bmNyeXB0Lm9yZzAvBggrBgEFBQcwAoYjaHR0cDovL2NlcnQuaW50LXgzLmxldHNl
+bmNyeXB0Lm9yZy8wIQYDVR0RBBowGIIWcnl1amppbi5hbHdheXNkYXRhLm5ldDCB
+/gYDVR0gBIH2MIHzMAgGBmeBDAECATCB5gYLKwYBBAGC3xMBAQEwgdYwJgYIKwYB
+BQUHAgEWGmh0dHA6Ly9jcHMubGV0c2VuY3J5cHQub3JnMIGrBggrBgEFBQcCAjCB
+ngyBm1RoaXMgQ2VydGlmaWNhdGUgbWF5IG9ubHkgYmUgcmVsaWVkIHVwb24gYnkg
+UmVseWluZyBQYXJ0aWVzIGFuZCBvbmx5IGluIGFjY29yZGFuY2Ugd2l0aCB0aGUg
+Q2VydGlmaWNhdGUgUG9saWN5IGZvdW5kIGF0IGh0dHBzOi8vbGV0c2VuY3J5cHQu
+b3JnL3JlcG9zaXRvcnkvMA0GCSqGSIb3DQEBCwUAA4IBAQAUxeAmYBNnW3ki5Eat
+S3lCKw1hyRUQ5l/8TqlR+mz/8ij/Zhx0T/a2oUZNecLF64wrkF6c/Q8qcZG8tqQI
+6of/sSgUFak/taZL4RmRPkgjX5xaHsb1sw5K6wtETj0wbICjqAWtN+6+0OA60KhV
+L3hFDKp9EjrBve0nGh2uegSGXIkGkY991n6Ef3y4iTAHne8g6GDPRuHhlAnu4bAK
+ZRZ+Ur428LcTTxe+ln/roNjnmf+ZArwtBjHVAhXt5mUyR4SJqJMpO6PixpqWlib8
+O10HTNlPpQ7cKrKn3MK6HrOaNzrNHlEIzI1wPvxZfGdIIcgSVNyEYsGNuvv3MlzY
+C/og
+-----END CERTIFICATE-----

--- a/util/time.go
+++ b/util/time.go
@@ -33,6 +33,7 @@ var (
 	GeneralizedDate            = time.Date(2050, time.January, 1, 0, 0, 0, 0, time.UTC)
 	NoReservedIP               = time.Date(2015, time.November, 1, 0, 0, 0, 0, time.UTC)
 	SubCert39Month             = time.Date(2016, time.June, 30, 0, 0, 0, 0, time.UTC)
+	CABV148Date		   = time.Date(2017, time.June, 8, 0, 0, 0, 0, time.UTC)
 )
 
 func FindTimeType(firstDate, secondDate asn1.RawValue) (int, int) {

--- a/util/time.go
+++ b/util/time.go
@@ -33,7 +33,7 @@ var (
 	GeneralizedDate            = time.Date(2050, time.January, 1, 0, 0, 0, 0, time.UTC)
 	NoReservedIP               = time.Date(2015, time.November, 1, 0, 0, 0, 0, time.UTC)
 	SubCert39Month             = time.Date(2016, time.June, 30, 0, 0, 0, 0, time.UTC)
-	CABV148Date		   = time.Date(2017, time.June, 8, 0, 0, 0, 0, time.UTC)
+	CABV148Date                = time.Date(2017, time.June, 8, 0, 0, 0, 0, time.UTC)
 )
 
 func FindTimeType(firstDate, secondDate asn1.RawValue) (int, int) {


### PR DESCRIPTION
Updates three lints:

- Uses `util.ICANNPublicSuffixParse` for the SAN bare suffix test
- Uses the correct `EffectiveDate` for the commonName test for CAs
- Reduces the error to a notice if EKU is missing in subCA, required only for technically constrained CAs.