### PR TITLE
Speed up the linters

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,159 @@
+package zlint
+
+import (
+	"encoding/pem"
+	"testing"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/lints"
+)
+
+var globalLintResult *ResultSet
+var globalSingleLintResult *lints.LintResult
+var globalLintResultList = []*lints.LintResult{}
+
+const bigCertificatePem = `-----BEGIN CERTIFICATE-----
+MIILajCCClKgAwIBAgIMOp/m5bdkZ2+oPevRMA0GCSqGSIb3DQEBCwUAMGIxCzAJ
+BgNVBAYTAkJFMRkwFwYDVQQKExBHbG9iYWxTaWduIG52LXNhMTgwNgYDVQQDEy9H
+bG9iYWxTaWduIEV4dGVuZGVkIFZhbGlkYXRpb24gQ0EgLSBTSEEyNTYgLSBHMzAe
+Fw0xNzA2MjIwNjU2MDNaFw0xOTA2MjMwNjU2MDNaMIH9MR0wGwYDVQQPDBRQcml2
+YXRlIE9yZ2FuaXphdGlvbjEPMA0GA1UEBRMGNTc4NjExMRMwEQYLKwYBBAGCNzwC
+AQMTAlVTMR4wHAYLKwYBBAGCNzwCAQITDU5ldyBIYW1wc2hpcmUxCzAJBgNVBAYT
+AlVTMRYwFAYDVQQIEw1OZXcgSGFtcHNoaXJlMRMwEQYDVQQHEwpQb3J0c21vdXRo
+MSAwHgYDVQQJExdUd28gSW50ZXJuYXRpb25hbCBEcml2ZTEdMBsGA1UEChMUR01P
+IEdsb2JhbFNpZ24sIEluYy4xGzAZBgNVBAMTEnd3dy5nbG9iYWxzaWduLmNvbTCC
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKaVk8nelrMqQmTSBju68D8B
+MO7GGHtuQU8bfvuGNTUe6HiAxHYRB+LfCVAoTMXRtKgiI2YnTQ7xedKCaGTo2ZLH
+y58Ya4ASpFgGLS3sPLjIHCP68ck126efksscXl2vBVWGGS7a0oTGLaaonFkz4FFy
+0SkSwCL9UPPKkpVoQQ48kOF+tKZx1RimoZbZC9BwXtZYjdIbL9EzineymyJGsMi4
+5utV7zQfcbZj3V9j4TAcx6UwqdwlmF7FVQ3Q1YmFtOZy6/U44us/Oz4SJ2+FIWS3
+fZ6oGXBh3qq3L4n7ixiNpuj+CZmAJP8VM7w1dSquJ9ndw6Lid0jKIpY6nlDfflkC
+AwEAAaOCB4Iwggd+MA4GA1UdDwEB/wQEAwIFoDCBlgYIKwYBBQUHAQEEgYkwgYYw
+RwYIKwYBBQUHMAKGO2h0dHA6Ly9zZWN1cmUuZ2xvYmFsc2lnbi5jb20vY2FjZXJ0
+L2dzZXh0ZW5kdmFsc2hhMmczcjMuY3J0MDsGCCsGAQUFBzABhi9odHRwOi8vb2Nz
+cDIuZ2xvYmFsc2lnbi5jb20vZ3NleHRlbmR2YWxzaGEyZzNyMzBVBgNVHSAETjBM
+MEEGCSsGAQQBoDIBATA0MDIGCCsGAQUFBwIBFiZodHRwczovL3d3dy5nbG9iYWxz
+aWduLmNvbS9yZXBvc2l0b3J5LzAHBgVngQwBATAJBgNVHRMEAjAAMEUGA1UdHwQ+
+MDwwOqA4oDaGNGh0dHA6Ly9jcmwuZ2xvYmFsc2lnbi5jb20vZ3MvZ3NleHRlbmR2
+YWxzaGEyZzNyMy5jcmwwggPRBgNVHREEggPIMIIDxIISd3d3Lmdsb2JhbHNpZ24u
+Y29tghVzeXN0ZW0uZ2xvYmFsc2lnbi5jb22CF3N5c3RlbWV1Lmdsb2JhbHNpZ24u
+Y29tghdzeXN0ZW11cy5nbG9iYWxzaWduLmNvbYISZ2NjLmdsb2JhbHNpZ24uY29t
+ghpjdGwxLnN5c3RlbS5nbG9iYWxzaWduLmNvbYIaY3RsMi5zeXN0ZW0uZ2xvYmFs
+c2lnbi5jb22CEmhjcy5nbG9iYWxzaWduLmNvbYIXY3RsMS5oY3MuZ2xvYmFsc2ln
+bi5jb22CF2N0bDIuaGNzLmdsb2JhbHNpZ24uY29tghVjbGllbnQuZ2xvYmFsc2ln
+bi5jb22CFmVwa2lwcm8uZ2xvYmFsc2lnbi5jb22CG2N0bDEuZXBraXByby5nbG9i
+YWxzaWduLmNvbYIYb3BlcmF0aW9uLmdsb2JhbHNpZ24uY29tghVyZWdpc3QuZ2xv
+YmFsc2lnbi5jb22CE3NlYWwuZ2xvYmFsc2lnbi5jb22CFHNzaWYxLmdsb2JhbHNp
+Z24uY29tghZwcm9maWxlLmdsb2JhbHNpZ24uY29tgiByZmMzMTYxLXRpbWVzdGFt
+cC5nbG9iYWxzaWduLmNvbYIfcmZjMzE2MXRpbWVzdGFtcC5nbG9iYWxzaWduLmNv
+bYIiY2VydGlmaWVkLXRpbWVzdGFtcC5nbG9iYWxzaWduLmNvbYIRY24uZ2xvYmFs
+c2lnbi5jb22CEWhrLmdsb2JhbHNpZ24uY29tghF0aC5nbG9iYWxzaWduLmNvbYIT
+YXBhYy5nbG9iYWxzaWduLmNvbYISZWRpLmdsb2JhbHNpZ24uY29tghRvY25ncy5n
+bG9iYWxzaWduLmNvbYIRZXYuZ2xvYmFsc2lnbi5jb22CEWpwLmdsb2JhbHNpZ24u
+Y29tghVlLXNpZ24uZ2xvYmFsc2lnbi5jb22CF3NzbGNoZWNrLmdsb2JhbHNpZ24u
+Y29tghZjc3JoZWxwLmdsb2JhbHNpZ24uY29tghZzdGF0aWMxLmdsb2JhbHNpZ24u
+Y29tghZzdGF0aWMyLmdsb2JhbHNpZ24uY29tghNibG9nLmdsb2JhbHNpZ24uY29t
+ghNpbmZvLmdsb2JhbHNpZ24uY29tghVzZWN1cmUuZ2xvYmFsc2lnbi5jb22CFmFy
+Y2hpdmUuZ2xvYmFsc2lnbi5jb22CFXN0YXR1cy5nbG9iYWxzaWduLmNvbYIWc3Vw
+cG9ydC5nbG9iYWxzaWduLmNvbYIOZ2xvYmFsc2lnbi5jb20wHQYDVR0lBBYwFAYI
+KwYBBQUHAwEGCCsGAQUFBwMCMB0GA1UdDgQWBBRUTciSxFJzJeFvq8WcPxoBQUKf
+GzAfBgNVHSMEGDAWgBTds+dtqC7oxU5uz3TmdTyUFc7oHTCCAfQGCisGAQQB1nkC
+BAIEggHkBIIB4AHeAHUA3esdK3oNT6Ygi4GtgWhwfi6OnQHVXIiNPRHEzbbsvswA
+AAFczpYhfgAABAMARjBEAiAhJrXOLs31S6LkFx6xPmf3F2wckkQZK4cCygJXvOJ8
+QwIgapfp6Kal4+/un4yLjQJee1swP+LTYIhXK0vBHARXhfoAdgBWFAaaL9fC7NP1
+4b1Esj7HRna5vJkRXMDvlJhV1onQ3QAAAVzOliGfAAAEAwBHMEUCIQDCI99WIuKT
++kVmLBvMlxQi9fHtjUJuKTmRUEic2YYtdAIgT81iWIFUFTDZzH365JnoUMgkoUm0
+W9ORqqTKYgb3/iwAdgCkuQmQtBhYFIe7E6LMZ3AKPDWYBPkb37jjd80OyA3cEAAA
+AVzOliRsAAAEAwBHMEUCIQDiruypdLDxo/3TisqFXxxXxDbwR8VSjrfmQJ1aqvy0
+OwIgaeeWftYP2eNNnwEkgJEhfCfbZZxthhUJ/Xxtqx+WleEAdQDuS723dc5guuFC
+aR+r4Z5mow9+X7By2IMAxHuJeqj9ywAAAVzOlid6AAAEAwBGMEQCIFTgSc6vU/n3
+Xf29uuatcVDxaiy37JX6XubsnowOU8PrAiBiTgjJ6LelCJq7xCv02fYdoMNOQqFy
+a/zh9QwsFs7mmzANBgkqhkiG9w0BAQsFAAOCAQEAliaxkGO3qX15z6WN1RkwwTnH
+ngJ5nDTrMscQ3rMGnfEYFW9uudfUVRnNLS49IR/V01nVML5Ex+Bz8CENw6ms7pHa
+eVcCW12pFbLQxLns+dhExFvZBfy2iewouKo8Q41tolmEv4A3ADNuv+3r1bYhTnzE
+55e0GMvnRIz5zQ7JWBTuamWNFI4OccJVh7vt0dnrSgiXs+XJ89qmgDyc/DikdM4q
+psw2SW2R/SwSnkgvaLM/o0tw77aapxlaAs29Y4SE/RvRR2CJ0V/gvq9GUorY4OF2
+2HEky394KiGDZDYUUDArx2+9w+yPikV5llF7lm2o84kZifnBO6SE9+4zdBExzg==
+-----END CERTIFICATE-----
+`
+
+func BenchmarkZlint(b *testing.B) {
+	var certDerBlock, _ = pem.Decode([]byte(bigCertificatePem))
+	var x509Cert, err = x509.ParseCertificate(certDerBlock.Bytes)
+	if err != nil {
+		b.Fatalf("Error parsing certificate: %s", err.Error())
+	}
+
+	b.ResetTimer()
+	b.Run("All lints", func(b *testing.B) {
+		var lintResult *ResultSet
+		for i := 0; i < b.N; i++ {
+			lintResult = LintCertificate(x509Cert)
+		}
+
+		globalLintResult = lintResult
+	})
+
+	b.Run("Fast lints", func(b *testing.B) {
+		globalLintResult = &ResultSet{}
+		globalLintResult.Results = make(map[string]*lints.LintResult, len(lints.Lints))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for key, value := range lints.Lints {
+				switch key {
+				case "w_dnsname_underscore_in_trd", "e_dnsname_underscore_in_sld", "e_dnsname_hyphen_in_sld",
+					"w_dnsname_wildcard_left_of_public_suffix", "w_san_iana_pub_suffix_empty":
+					continue
+				}
+
+				if !value.Lint.CheckApplies(x509Cert) {
+					continue
+				}
+				globalLintResult.Results[key] = value.Lint.Execute(x509Cert)
+			}
+		}
+	})
+
+	b.Run("Fastest lints", func(b *testing.B) {
+		globalLintResult = &ResultSet{}
+		globalLintResult.Results = make(map[string]*lints.LintResult, len(lints.Lints))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for key, value := range lints.Lints {
+				switch key {
+				case "w_dnsname_underscore_in_trd", "e_dnsname_underscore_in_sld", "e_dnsname_hyphen_in_sld",
+					"w_dnsname_wildcard_left_of_public_suffix", "w_san_iana_pub_suffix_empty",
+					"w_rsa_mod_factors_smaller_than_752", "e_dnsname_bad_character_in_label", "w_subject_dn_leading_whitespace",
+					"w_subject_dn_trailing_whitespace", "w_multiple_subject_rdn", "e_ext_san_dns_not_ia5_string",
+					"e_ext_san_empty_name", "e_dnsname_not_valid_tld", "e_dnsname_contains_bare_iana_suffix",
+					"e_dnsname_wildcard_only_in_left_label", "e_international_dns_name_not_nfkc", "e_dnsname_left_label_wildcard_correct",
+					"e_international_dns_name_not_unicode", "w_issuer_dn_trailing_whitespace", "w_issuer_dn_leading_whitespace",
+					"w_multiple_issuer_rdn", "e_dnsname_empty_label", "e_dnsname_label_too_long", "e_distribution_point_incomplete",
+					"e_wrong_time_format_pre2050", "e_utc_time_does_not_include_seconds", "e_sub_cert_not_is_ca", "w_rsa_mod_not_odd",
+					"e_path_len_constraint_zero_or_less", "e_san_dns_name_includes_null_char":
+					continue
+				}
+
+				if !value.Lint.CheckApplies(x509Cert) {
+					continue
+				}
+				globalLintResult.Results[key] = value.Lint.Execute(x509Cert)
+			}
+		}
+	})
+
+	for key, value := range lints.Lints {
+		b.Run(key, func(b *testing.B) {
+			if !value.Lint.CheckApplies(x509Cert) {
+				b.Skip("Check doesn't apply")
+			}
+
+			var result *lints.LintResult
+			for i := 0; i < b.N; i++ {
+				result = value.Lint.Execute(x509Cert)
+			}
+
+			globalSingleLintResult = result
+		})
+	}
+}

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/zmap/zlint/lints"
 )
 
-var globalLintResult *ResultSet
-var globalSingleLintResult *lints.LintResult
-var globalLintResultList = []*lints.LintResult{}
+var (
+	globalLintResult       *ResultSet
+	globalSingleLintResult *lints.LintResult
+)
 
 const bigCertificatePem = `-----BEGIN CERTIFICATE-----
 MIILajCCClKgAwIBAgIMOp/m5bdkZ2+oPevRMA0GCSqGSIb3DQEBCwUAMGIxCzAJ
@@ -78,8 +79,8 @@ psw2SW2R/SwSnkgvaLM/o0tw77aapxlaAs29Y4SE/RvRR2CJ0V/gvq9GUorY4OF2
 `
 
 func BenchmarkZlint(b *testing.B) {
-	var certDerBlock, _ = pem.Decode([]byte(bigCertificatePem))
-	var x509Cert, err = x509.ParseCertificate(certDerBlock.Bytes)
+	certDerBlock, _ := pem.Decode([]byte(bigCertificatePem))
+	x509Cert, err := x509.ParseCertificate(certDerBlock.Bytes)
 	if err != nil {
 		b.Fatalf("Error parsing certificate: %s", err.Error())
 	}

--- a/lints/lint_ca_is_ca.go
+++ b/lints/lint_ca_is_ca.go
@@ -2,6 +2,7 @@ package lints
 
 import (
 	"encoding/asn1"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_distribution_point_incomplete.go
+++ b/lints/lint_distribution_point_incomplete.go
@@ -16,6 +16,7 @@ package lints
 
 import (
 	"encoding/asn1"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zcrypto/x509/pkix"
 	"github.com/zmap/zlint/util"

--- a/lints/lint_distribution_point_missing_ldap_or_uri.go
+++ b/lints/lint_distribution_point_missing_ldap_or_uri.go
@@ -7,9 +7,10 @@ When present, DistributionPointName SHOULD include at least one LDAP or HTTP URI
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type distribNoLDAPorURI struct{}

--- a/lints/lint_dnsname_bad_character_in_label.go
+++ b/lints/lint_dnsname_bad_character_in_label.go
@@ -12,7 +12,7 @@ type DNSNameProperCharacters struct {
 }
 
 func (l *DNSNameProperCharacters) Initialize() error {
-	const dnsNameRegexp = `^(\*\.)?(\?\.)?(A-Za-z0-9*_-]+\.)*[A-Za-z0-9*_-]*$`
+	const dnsNameRegexp = `^(\*\.)?(\?\.)*(A-Za-z0-9*_-]+\.)*[A-Za-z0-9*_-]*$`
 	var err error
 	l.CompiledExpression, err = regexp.Compile(dnsNameRegexp)
 

--- a/lints/lint_dnsname_bad_character_in_label.go
+++ b/lints/lint_dnsname_bad_character_in_label.go
@@ -1,10 +1,10 @@
 package lints
 
 import (
+	"regexp"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"regexp"
-	"strings"
 )
 
 type DNSNameProperCharacters struct {
@@ -12,39 +12,25 @@ type DNSNameProperCharacters struct {
 }
 
 func (l *DNSNameProperCharacters) Initialize() error {
-	const dnsLabelRegex = "^[A-Za-z0-9*_-]+$"
-	l.CompiledExpression = regexp.MustCompile(dnsLabelRegex)
-	return nil
+	const dnsNameRegexp = `^(\*\.)?(\?\.)?(A-Za-z0-9*_-]+\.)*[A-Za-z0-9*_-]*$`
+	var err error
+	l.CompiledExpression, err = regexp.Compile(dnsNameRegexp)
+
+	return err
 }
 
 func (l *DNSNameProperCharacters) CheckApplies(c *x509.Certificate) bool {
 	return util.IsSubscriberCert(c) && util.DNSNamesExist(c)
 }
 
-func (l *DNSNameProperCharacters) labelContainsBadCharacters(domain string) bool {
-	labels := strings.Split(domain, ".")
-	for _, label := range labels {
-		if !l.CompiledExpression.MatchString(label) {
-			return true
-		}
-	}
-	return false
-}
-
 func (l *DNSNameProperCharacters) Execute(c *x509.Certificate) *LintResult {
 	if c.Subject.CommonName != "" {
-		commonNameWithoutWildcard := util.RemovePrependedWildcard(c.Subject.CommonName)
-		commonNameWithoutQuestionMarks := util.RemovePrependedQuestionMarks(commonNameWithoutWildcard)
-		badCharacterFound := l.labelContainsBadCharacters(commonNameWithoutQuestionMarks)
-		if badCharacterFound {
+		if !l.CompiledExpression.MatchString(c.Subject.CommonName) {
 			return &LintResult{Status: Error}
 		}
 	}
 	for _, dns := range c.DNSNames {
-		domainWithoutWildcard := util.RemovePrependedWildcard(dns)
-		domainWithoutQuestionMarks := util.RemovePrependedQuestionMarks(domainWithoutWildcard)
-		badCharacterFound := l.labelContainsBadCharacters(domainWithoutQuestionMarks)
-		if badCharacterFound {
+		if !l.CompiledExpression.MatchString(dns) {
 			return &LintResult{Status: Error}
 		}
 	}

--- a/lints/lint_dnsname_check_left_label_wildcard.go
+++ b/lints/lint_dnsname_check_left_label_wildcard.go
@@ -1,9 +1,10 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type DNSNameLeftLabelWildcardCheck struct{}

--- a/lints/lint_dnsname_contains_empty_label.go
+++ b/lints/lint_dnsname_contains_empty_label.go
@@ -1,9 +1,10 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type DNSNameEmptyLabel struct{}

--- a/lints/lint_dnsname_hyphen_in_sld.go
+++ b/lints/lint_dnsname_hyphen_in_sld.go
@@ -17,34 +17,23 @@ func (l *DNSNameHyphenInSLD) CheckApplies(c *x509.Certificate) bool {
 	return util.IsSubscriberCert(c) && util.DNSNamesExist(c)
 }
 
-func hyphenAtStartOrEndOfSLD(domain string) (bool, error) {
-	domainName, err := util.ICANNPublicSuffixParse(domain)
-	if err != nil {
-		return true, err
-	}
-	if strings.HasPrefix(domainName.SLD, "-") || strings.HasSuffix(domainName.SLD, "-") {
-		return true, nil
-	} else {
-		return false, nil
-	}
-}
-
 func (l *DNSNameHyphenInSLD) Execute(c *x509.Certificate) *LintResult {
 	if c.Subject.CommonName != "" {
-		hyphenFound, err := hyphenAtStartOrEndOfSLD(c.Subject.CommonName)
-		if err != nil {
+		var domainInfo = c.GetParsedSubjectCommonName(false)
+		if domainInfo.ParseError != nil {
 			return &LintResult{Status: NA}
 		}
-		if hyphenFound {
+		if strings.HasPrefix(domainInfo.ParsedDomain.SLD, "-") || strings.HasSuffix(domainInfo.ParsedDomain.SLD, "-") {
 			return &LintResult{Status: Error}
 		}
 	}
-	for _, dns := range c.DNSNames {
-		hyphenFound, err := hyphenAtStartOrEndOfSLD(dns)
-		if err != nil {
+	var parsedSANDNSNames = c.GetParsedDNSNames(false)
+	for i := range c.GetParsedDNSNames(false) {
+		if parsedSANDNSNames[i].ParseError != nil {
 			return &LintResult{Status: NA}
 		}
-		if hyphenFound {
+		if strings.HasPrefix(parsedSANDNSNames[i].ParsedDomain.SLD, "-") ||
+			strings.HasSuffix(parsedSANDNSNames[i].ParsedDomain.SLD, "-") {
 			return &LintResult{Status: Error}
 		}
 	}

--- a/lints/lint_dnsname_hyphen_in_sld.go
+++ b/lints/lint_dnsname_hyphen_in_sld.go
@@ -19,7 +19,7 @@ func (l *DNSNameHyphenInSLD) CheckApplies(c *x509.Certificate) bool {
 
 func (l *DNSNameHyphenInSLD) Execute(c *x509.Certificate) *LintResult {
 	if c.Subject.CommonName != "" {
-		var domainInfo = c.GetParsedSubjectCommonName(false)
+		domainInfo := c.GetParsedSubjectCommonName(false)
 		if domainInfo.ParseError != nil {
 			return &LintResult{Status: NA}
 		}
@@ -27,7 +27,7 @@ func (l *DNSNameHyphenInSLD) Execute(c *x509.Certificate) *LintResult {
 			return &LintResult{Status: Error}
 		}
 	}
-	var parsedSANDNSNames = c.GetParsedDNSNames(false)
+	parsedSANDNSNames := c.GetParsedDNSNames(false)
 	for i := range c.GetParsedDNSNames(false) {
 		if parsedSANDNSNames[i].ParseError != nil {
 			return &LintResult{Status: NA}

--- a/lints/lint_dnsname_label_too_long.go
+++ b/lints/lint_dnsname_label_too_long.go
@@ -1,9 +1,10 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type DNSNameLabelLengthTooLong struct{}

--- a/lints/lint_dnsname_underscore_in_sld.go
+++ b/lints/lint_dnsname_underscore_in_sld.go
@@ -19,7 +19,7 @@ func (l *DNSNameUnderscoreInSLD) CheckApplies(c *x509.Certificate) bool {
 
 func (l *DNSNameUnderscoreInSLD) Execute(c *x509.Certificate) *LintResult {
 	if c.Subject.CommonName != "" {
-		var domainInfo = c.GetParsedSubjectCommonName(false)
+		domainInfo := c.GetParsedSubjectCommonName(false)
 		if domainInfo.ParseError != nil {
 			return &LintResult{Status: NA}
 		}
@@ -28,7 +28,7 @@ func (l *DNSNameUnderscoreInSLD) Execute(c *x509.Certificate) *LintResult {
 		}
 	}
 
-	var parsedSANDNSNames = c.GetParsedDNSNames(false)
+	parsedSANDNSNames := c.GetParsedDNSNames(false)
 	for i := range c.GetParsedDNSNames(false) {
 		if parsedSANDNSNames[i].ParseError != nil {
 			return &LintResult{Status: NA}

--- a/lints/lint_dnsname_underscore_in_sld.go
+++ b/lints/lint_dnsname_underscore_in_sld.go
@@ -17,34 +17,23 @@ func (l *DNSNameUnderscoreInSLD) CheckApplies(c *x509.Certificate) bool {
 	return util.IsSubscriberCert(c) && util.DNSNamesExist(c)
 }
 
-func underscoreInSLD(domain string) (bool, error) {
-	domainName, err := util.ICANNPublicSuffixParse(domain)
-	if err != nil {
-		return true, err
-	}
-	if strings.Contains(domainName.SLD, "_") {
-		return true, nil
-	} else {
-		return false, nil
-	}
-}
-
 func (l *DNSNameUnderscoreInSLD) Execute(c *x509.Certificate) *LintResult {
 	if c.Subject.CommonName != "" {
-		underscoreFound, err := underscoreInSLD(c.Subject.CommonName)
-		if err != nil {
+		var domainInfo = c.GetParsedSubjectCommonName(false)
+		if domainInfo.ParseError != nil {
 			return &LintResult{Status: NA}
 		}
-		if underscoreFound {
+		if strings.Contains(domainInfo.ParsedDomain.SLD, "_") {
 			return &LintResult{Status: Error}
 		}
 	}
-	for _, dns := range c.DNSNames {
-		underscoreFound, err := underscoreInSLD(dns)
-		if err != nil {
+
+	var parsedSANDNSNames = c.GetParsedDNSNames(false)
+	for i := range c.GetParsedDNSNames(false) {
+		if parsedSANDNSNames[i].ParseError != nil {
 			return &LintResult{Status: NA}
 		}
-		if underscoreFound {
+		if strings.Contains(parsedSANDNSNames[i].ParsedDomain.SLD, "_") {
 			return &LintResult{Status: Error}
 		}
 	}

--- a/lints/lint_dnsname_underscore_in_trd.go
+++ b/lints/lint_dnsname_underscore_in_trd.go
@@ -19,7 +19,7 @@ func (l *DNSNameUnderscoreInTRD) CheckApplies(c *x509.Certificate) bool {
 
 func (l *DNSNameUnderscoreInTRD) Execute(c *x509.Certificate) *LintResult {
 	if c.Subject.CommonName != "" {
-		var domainInfo = c.GetParsedSubjectCommonName(false)
+		domainInfo := c.GetParsedSubjectCommonName(false)
 		if domainInfo.ParseError != nil {
 			return &LintResult{Status: NA}
 		}
@@ -28,7 +28,7 @@ func (l *DNSNameUnderscoreInTRD) Execute(c *x509.Certificate) *LintResult {
 		}
 	}
 
-	var parsedSANDNSNames = c.GetParsedDNSNames(false)
+	parsedSANDNSNames := c.GetParsedDNSNames(false)
 	for i := range c.GetParsedDNSNames(false) {
 		if parsedSANDNSNames[i].ParseError != nil {
 			return &LintResult{Status: NA}

--- a/lints/lint_dnsname_underscore_in_trd.go
+++ b/lints/lint_dnsname_underscore_in_trd.go
@@ -17,37 +17,27 @@ func (l *DNSNameUnderscoreInTRD) CheckApplies(c *x509.Certificate) bool {
 	return util.IsSubscriberCert(c) && util.DNSNamesExist(c)
 }
 
-func underscoreInTRD(domain string) (bool, error) {
-	domainName, err := util.ICANNPublicSuffixParse(domain)
-	if err != nil {
-		return true, err
-	}
-	if strings.Contains(domainName.TRD, "_") {
-		return true, nil
-	} else {
-		return false, nil
-	}
-}
-
 func (l *DNSNameUnderscoreInTRD) Execute(c *x509.Certificate) *LintResult {
 	if c.Subject.CommonName != "" {
-		underscoreFound, err := underscoreInTRD(c.Subject.CommonName)
-		if err != nil {
+		var domainInfo = c.GetParsedSubjectCommonName(false)
+		if domainInfo.ParseError != nil {
 			return &LintResult{Status: NA}
 		}
-		if underscoreFound {
+		if strings.Contains(domainInfo.ParsedDomain.TRD, "_") {
 			return &LintResult{Status: Warn}
 		}
 	}
-	for _, dns := range c.DNSNames {
-		underscoreFound, err := underscoreInTRD(dns)
-		if err != nil {
+
+	var parsedSANDNSNames = c.GetParsedDNSNames(false)
+	for i := range c.GetParsedDNSNames(false) {
+		if parsedSANDNSNames[i].ParseError != nil {
 			return &LintResult{Status: NA}
 		}
-		if underscoreFound {
+		if strings.Contains(parsedSANDNSNames[i].ParsedDomain.TRD, "_") {
 			return &LintResult{Status: Warn}
 		}
 	}
+
 	return &LintResult{Status: Pass}
 }
 

--- a/lints/lint_dnsname_wildcard_left_of_public_suffix.go
+++ b/lints/lint_dnsname_wildcard_left_of_public_suffix.go
@@ -17,7 +17,7 @@ func (l *DNSNameWildcardLeftofPublicSuffix) CheckApplies(c *x509.Certificate) bo
 
 func (l *DNSNameWildcardLeftofPublicSuffix) Execute(c *x509.Certificate) *LintResult {
 	if c.Subject.CommonName != "" {
-		var domainInfo = c.GetParsedSubjectCommonName(false)
+		domainInfo := c.GetParsedSubjectCommonName(false)
 		if domainInfo.ParseError != nil {
 			return &LintResult{Status: NA}
 		}
@@ -27,7 +27,7 @@ func (l *DNSNameWildcardLeftofPublicSuffix) Execute(c *x509.Certificate) *LintRe
 		}
 	}
 
-	var parsedSANDNSNames = c.GetParsedDNSNames(false)
+	parsedSANDNSNames := c.GetParsedDNSNames(false)
 	for i := range c.GetParsedDNSNames(false) {
 		if parsedSANDNSNames[i].ParseError != nil {
 			return &LintResult{Status: NA}

--- a/lints/lint_dnsname_wildcard_left_of_public_suffix.go
+++ b/lints/lint_dnsname_wildcard_left_of_public_suffix.go
@@ -15,33 +15,25 @@ func (l *DNSNameWildcardLeftofPublicSuffix) CheckApplies(c *x509.Certificate) bo
 	return util.IsSubscriberCert(c) && util.DNSNamesExist(c)
 }
 
-func wildcardLeftOfPublicSuffix(domain string) (bool, error) {
-	parsedDomain, err := util.ICANNPublicSuffixParse(domain)
-	if err != nil {
-		return true, err
-	}
-	if parsedDomain.SLD == "*" {
-		return true, nil
-	}
-	return false, nil
-}
-
 func (l *DNSNameWildcardLeftofPublicSuffix) Execute(c *x509.Certificate) *LintResult {
 	if c.Subject.CommonName != "" {
-		wildcardFound, err := wildcardLeftOfPublicSuffix(c.Subject.CommonName)
-		if err != nil {
+		var domainInfo = c.GetParsedSubjectCommonName(false)
+		if domainInfo.ParseError != nil {
 			return &LintResult{Status: NA}
 		}
-		if wildcardFound {
+
+		if domainInfo.ParsedDomain.SLD == "*" {
 			return &LintResult{Status: Warn}
 		}
 	}
-	for _, dns := range c.DNSNames {
-		wildcardFound, err := wildcardLeftOfPublicSuffix(dns)
-		if err != nil {
+
+	var parsedSANDNSNames = c.GetParsedDNSNames(false)
+	for i := range c.GetParsedDNSNames(false) {
+		if parsedSANDNSNames[i].ParseError != nil {
 			return &LintResult{Status: NA}
 		}
-		if wildcardFound {
+
+		if parsedSANDNSNames[i].ParsedDomain.SLD == "*" {
 			return &LintResult{Status: Warn}
 		}
 	}

--- a/lints/lint_dnsname_wildcard_only_in_left_label.go
+++ b/lints/lint_dnsname_wildcard_only_in_left_label.go
@@ -1,9 +1,10 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type DNSNameWildcardOnlyInLeftlabel struct{}

--- a/lints/lint_ec_improper_curves.go
+++ b/lints/lint_ec_improper_curves.go
@@ -9,6 +9,7 @@ package lints
 
 import (
 	"crypto/ecdsa"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_ext_aia_access_location_missing.go
+++ b/lints/lint_ext_aia_access_location_missing.go
@@ -13,9 +13,10 @@ An authorityInfoAccess extension may include multiple instances of
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type aiaNoHTTPorLDAP struct{}

--- a/lints/lint_ext_ian_rfc822_format_invalid.go
+++ b/lints/lint_ext_ian_rfc822_format_invalid.go
@@ -14,9 +14,10 @@ RFC 5280: 4.2.1.6
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type IANEmail struct{}

--- a/lints/lint_ext_ian_uri_format_invalid.go
+++ b/lints/lint_ext_ian_uri_format_invalid.go
@@ -7,9 +7,10 @@ scheme (e.g., "http" or "ftp") and a scheme-specific-part.
 package lints
 
 import (
+	"net/url"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"net/url"
 )
 
 type IANURIFormat struct{}

--- a/lints/lint_ext_ian_uri_host_not_fqdn_or_ip.go
+++ b/lints/lint_ext_ian_uri_host_not_fqdn_or_ip.go
@@ -14,9 +14,10 @@ Section 7.4.
 package lints
 
 import (
+	"net/url"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"net/url"
 )
 
 type IANURIFQDNOrIP struct{}

--- a/lints/lint_ext_ian_uri_not_ia5.go
+++ b/lints/lint_ext_ian_uri_not_ia5.go
@@ -7,9 +7,10 @@ stored in the uniformResourceIdentifier (an IA5String).
 package lints
 
 import (
+	"unicode"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"unicode"
 )
 
 type IANURIIA5String struct{}

--- a/lints/lint_ext_ian_uri_relative.go
+++ b/lints/lint_ext_ian_uri_relative.go
@@ -14,9 +14,10 @@ Section 7.4.
 package lints
 
 import (
+	"net/url"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"net/url"
 )
 
 type uriRelative struct{}

--- a/lints/lint_ext_policy_constraints_empty.go
+++ b/lints/lint_ext_policy_constraints_empty.go
@@ -12,6 +12,7 @@ package lints
 
 import (
 	"encoding/asn1"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_ext_san_rfc822_format_invalid.go
+++ b/lints/lint_ext_san_rfc822_format_invalid.go
@@ -14,9 +14,10 @@ RFC 5280: 4.2.1.6
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type invalidEmail struct{}

--- a/lints/lint_ext_san_uri_format_invalid.go
+++ b/lints/lint_ext_san_uri_format_invalid.go
@@ -7,9 +7,10 @@ scheme (e.g., "http" or "ftp") and a scheme-specific-part.
 package lints
 
 import (
+	"net/url"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"net/url"
 )
 
 type extSANURIFormatInvalid struct{}

--- a/lints/lint_ext_san_uri_not_ia5.go
+++ b/lints/lint_ext_san_uri_not_ia5.go
@@ -7,9 +7,10 @@ stored in the uniformResourceIdentifier (an IA5String).
 package lints
 
 import (
+	"unicode"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"unicode"
 )
 
 type extSANURINotIA5 struct{}

--- a/lints/lint_ext_san_uri_relative.go
+++ b/lints/lint_ext_san_uri_relative.go
@@ -14,9 +14,10 @@ Section 7.4.
 package lints
 
 import (
+	"net/url"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"net/url"
 )
 
 type extSANURIRelative struct{}

--- a/lints/lint_generalized_time_includes_fraction_seconds.go
+++ b/lints/lint_generalized_time_includes_fraction_seconds.go
@@ -16,6 +16,7 @@ package lints
 
 import (
 	"encoding/asn1"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_ian_bare_wildcard.go
+++ b/lints/lint_ian_bare_wildcard.go
@@ -3,9 +3,10 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type brIANBareWildcard struct{}

--- a/lints/lint_ian_dns_name_starts_with_period.go
+++ b/lints/lint_ian_dns_name_starts_with_period.go
@@ -3,9 +3,10 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type IANDNSPeriod struct{}

--- a/lints/lint_ian_iana_pub_suffix_empty.go
+++ b/lints/lint_ian_iana_pub_suffix_empty.go
@@ -3,9 +3,10 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type IANPubSuffix struct{}

--- a/lints/lint_idn_dnsname_malformed_unicode.go
+++ b/lints/lint_idn_dnsname_malformed_unicode.go
@@ -1,10 +1,11 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 	"golang.org/x/net/idna"
-	"strings"
 )
 
 type IDNMalformedUnicode struct{}

--- a/lints/lint_idn_dnsname_must_be_nfkc.go
+++ b/lints/lint_idn_dnsname_must_be_nfkc.go
@@ -1,11 +1,12 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 	"golang.org/x/net/idna"
 	"golang.org/x/text/unicode/norm"
-	"strings"
 )
 
 type IDNNotNFKC struct{}

--- a/lints/lint_is_redacted_cert.go
+++ b/lints/lint_is_redacted_cert.go
@@ -1,9 +1,10 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type DNSNameRedacted struct{}

--- a/lints/lint_name_constraint_empty.go
+++ b/lints/lint_name_constraint_empty.go
@@ -15,6 +15,7 @@ package lints
 
 import (
 	"encoding/asn1"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
+++ b/lints/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
@@ -5,6 +5,7 @@ package lints
 
 import (
 	"crypto/rsa"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
+++ b/lints/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
@@ -9,6 +9,7 @@ package lints
 
 import (
 	"encoding/asn1"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_rsa_exp_negative.go
+++ b/lints/lint_rsa_exp_negative.go
@@ -4,6 +4,7 @@ package lints
 
 import (
 	"crypto/rsa"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_rsa_mod_factors_smaller_than_752_bits.go
+++ b/lints/lint_rsa_mod_factors_smaller_than_752_bits.go
@@ -8,6 +8,7 @@ package lints
 
 import (
 	"crypto/rsa"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )
@@ -29,6 +30,7 @@ func (l *rsaModSmallFactor) Execute(c *x509.Certificate) *LintResult {
 		return &LintResult{Status: Pass}
 	}
 	return &LintResult{Status: Warn}
+
 }
 
 func init() {

--- a/lints/lint_rsa_mod_not_odd.go
+++ b/lints/lint_rsa_mod_not_odd.go
@@ -8,9 +8,10 @@ package lints
 
 import (
 	"crypto/rsa"
+	"math/big"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"math/big"
 )
 
 type rsaParsedTestsKeyModOdd struct{}

--- a/lints/lint_rsa_no_public_key.go
+++ b/lints/lint_rsa_no_public_key.go
@@ -3,6 +3,7 @@ package lints
 
 import (
 	"crypto/rsa"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_rsa_public_exponent_not_odd.go
+++ b/lints/lint_rsa_public_exponent_not_odd.go
@@ -8,6 +8,7 @@ package lints
 
 import (
 	"crypto/rsa"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_rsa_public_exponent_too_small.go
+++ b/lints/lint_rsa_public_exponent_too_small.go
@@ -8,6 +8,7 @@ package lints
 
 import (
 	"crypto/rsa"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_san_bare_wildcard.go
+++ b/lints/lint_san_bare_wildcard.go
@@ -3,9 +3,10 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type brSANBareWildcard struct{}

--- a/lints/lint_san_dns_name_starts_with_period.go
+++ b/lints/lint_san_dns_name_starts_with_period.go
@@ -3,9 +3,10 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type SANDNSPeriod struct{}

--- a/lints/lint_san_iana_pub_suffix_empty.go
+++ b/lints/lint_san_iana_pub_suffix_empty.go
@@ -3,9 +3,10 @@
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type pubSuffix struct{}
@@ -19,10 +20,10 @@ func (l *pubSuffix) CheckApplies(c *x509.Certificate) bool {
 }
 
 func (l *pubSuffix) Execute(c *x509.Certificate) *LintResult {
-	for _, dns := range c.DNSNames {
-		_, err := util.ICANNPublicSuffixParse(dns)
-		if err != nil {
-			if strings.HasSuffix(err.Error(), "is a suffix") {
+	var parsedSANDNSNames = c.GetParsedDNSNames(false)
+	for i := range c.GetParsedDNSNames(false) {
+		if parsedSANDNSNames[i].ParseError != nil {
+			if strings.HasSuffix(parsedSANDNSNames[i].ParseError.Error(), "is a suffix") {
 				return &LintResult{Status: Warn}
 			} else {
 				return &LintResult{Status: NA}

--- a/lints/lint_san_iana_pub_suffix_empty.go
+++ b/lints/lint_san_iana_pub_suffix_empty.go
@@ -20,7 +20,7 @@ func (l *pubSuffix) CheckApplies(c *x509.Certificate) bool {
 }
 
 func (l *pubSuffix) Execute(c *x509.Certificate) *LintResult {
-	var parsedSANDNSNames = c.GetParsedDNSNames(false)
+	parsedSANDNSNames := c.GetParsedDNSNames(false)
 	for i := range c.GetParsedDNSNames(false) {
 		if parsedSANDNSNames[i].ParseError != nil {
 			if strings.HasSuffix(parsedSANDNSNames[i].ParseError.Error(), "is a suffix") {

--- a/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
@@ -10,9 +10,10 @@ marked critical, and it MUST contain the HTTP URL of the Issuing CA’s OCSP res
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type subCaIssuerUrl struct{}

--- a/lints/lint_sub_ca_aia_does_not_contain_ocsp_url.go
+++ b/lints/lint_sub_ca_aia_does_not_contain_ocsp_url.go
@@ -10,9 +10,10 @@ marked critical, and it MUST contain the HTTP URL of the Issuing CA’s OCSP res
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type subCaOcspUrl struct{}

--- a/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
@@ -8,9 +8,10 @@ It MUST contain the HTTP URL of the CA’s CRL service.
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type subCACRLDistNoUrl struct{}

--- a/lints/lint_sub_cert_aia_does_not_contain_ocsp_url.go
+++ b/lints/lint_sub_cert_aia_does_not_contain_ocsp_url.go
@@ -11,9 +11,10 @@ marked critical, and it MUST contain the HTTP URL of the Issuing CA’s OCSP res
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type subCertOcspUrl struct{}

--- a/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
+++ b/lints/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
@@ -9,9 +9,10 @@ URL of the CA’s CRL service.
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type subCRLDistNoURL struct{}

--- a/lints/lint_sub_cert_is_ca.go
+++ b/lints/lint_sub_cert_is_ca.go
@@ -2,6 +2,7 @@ package lints
 
 import (
 	"encoding/asn1"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_sub_cert_sha1_expiration_too_long.go
+++ b/lints/lint_sub_cert_sha1_expiration_too_long.go
@@ -9,9 +9,10 @@ CAs and Subscribers using such certificates do so at their own risk.
 package lints
 
 import (
+	"time"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"time"
 )
 
 type sha1ExpireLong struct{}

--- a/lints/lint_subject_common_name_max_length.go
+++ b/lints/lint_subject_common_name_max_length.go
@@ -9,9 +9,10 @@ RFC 5280: A.1
 package lints
 
 import (
+	"unicode/utf8"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"unicode/utf8"
 )
 
 type subjectCommonNameMaxLength struct{}

--- a/lints/lint_subject_contains_noninformational_value.go
+++ b/lints/lint_subject_contains_noninformational_value.go
@@ -10,9 +10,10 @@ be used.
 package lints
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type illegalChar struct{}

--- a/lints/lint_subject_contains_reserved_ip.go
+++ b/lints/lint_subject_contains_reserved_ip.go
@@ -11,9 +11,10 @@ Address or Internal Name.
 package lints
 
 import (
+	"net"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"net"
 )
 
 type subjectReservedIP struct{}

--- a/lints/lint_subject_locality_name_max_length.go
+++ b/lints/lint_subject_locality_name_max_length.go
@@ -9,9 +9,10 @@ RFC 5280: A.1
 package lints
 
 import (
+	"unicode/utf8"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"unicode/utf8"
 )
 
 type subjectLocalityNameMaxLength struct{}

--- a/lints/lint_subject_not_dn.go
+++ b/lints/lint_subject_not_dn.go
@@ -11,10 +11,11 @@
 package lints
 
 import (
+	"reflect"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zcrypto/x509/pkix"
 	"github.com/zmap/zlint/util"
-	"reflect"
 )
 
 type subjectDN struct{}

--- a/lints/lint_subject_organization_name_max_length.go
+++ b/lints/lint_subject_organization_name_max_length.go
@@ -9,9 +9,10 @@ RFC 5280: A.1
 package lints
 
 import (
+	"unicode/utf8"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"unicode/utf8"
 )
 
 type subjectOrganizationNameMaxLength struct{}

--- a/lints/lint_subject_organizational_unit_name_max_length.go
+++ b/lints/lint_subject_organizational_unit_name_max_length.go
@@ -9,9 +9,10 @@ RFC 5280: A.1
 package lints
 
 import (
+	"unicode/utf8"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"unicode/utf8"
 )
 
 type subjectOrganizationalUnitNameMaxLength struct{}

--- a/lints/lint_subject_state_name_max_length.go
+++ b/lints/lint_subject_state_name_max_length.go
@@ -9,9 +9,10 @@ RFC 5280: A.1
 package lints
 
 import (
+	"unicode/utf8"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"unicode/utf8"
 )
 
 type subjectStateNameMaxLength struct{}

--- a/lints/lint_utc_time_not_in_zulu.go
+++ b/lints/lint_utc_time_not_in_zulu.go
@@ -20,9 +20,10 @@
 package lints
 
 import (
+	"time"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"time"
 )
 
 type utcTimeGMT struct {

--- a/lints/lint_wrong_time_format_pre2050.go
+++ b/lints/lint_wrong_time_format_pre2050.go
@@ -11,9 +11,10 @@ package lints
 
 import (
 	"encoding/asn1"
+	"time"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"time"
 )
 
 type generalizedPre2050 struct{}

--- a/lints/testingUtil.go
+++ b/lints/testingUtil.go
@@ -6,9 +6,10 @@ package lints
 import (
 	"encoding/pem"
 	"fmt"
-	"github.com/zmap/zcrypto/x509"
 	"io/ioutil"
 	"strings"
+
+	"github.com/zmap/zcrypto/x509"
 )
 
 func ReadCertificate(inPath string) *x509.Certificate {

--- a/util/primes.go
+++ b/util/primes.go
@@ -2,30 +2,39 @@ package util
 
 import "math/big"
 
-var primes = []int{
-	2, 3, 5, 7, 11, 13, 17, 19, 23,
-	29, 31, 37, 41, 43, 47, 53, 59, 61, 67,
-	71, 73, 79, 83, 89, 97, 101, 103, 107, 109,
-	113, 127, 131, 137, 139, 149, 151, 157, 163, 167,
-	173, 179, 181, 191, 193, 197, 199, 211, 223, 227,
-	229, 233, 239, 241, 251, 257, 263, 269, 271, 277,
-	281, 283, 293, 307, 311, 313, 317, 331, 337, 347,
-	349, 353, 359, 367, 373, 379, 383, 389, 397, 401,
-	409, 419, 421, 431, 433, 439, 443, 449, 457, 461,
-	463, 467, 479, 487, 491, 499, 503, 509, 521, 523,
-	541, 547, 557, 563, 569, 571, 577, 587, 593, 599,
-	601, 607, 613, 617, 619, 631, 641, 643, 647, 653,
-	659, 661, 673, 677, 683, 691, 701, 709, 719, 727,
-	733, 739, 743, 751,
+var bigIntPrimes = []*big.Int{
+	big.NewInt(2), big.NewInt(3), big.NewInt(5), big.NewInt(7), big.NewInt(11), big.NewInt(13),
+	big.NewInt(17), big.NewInt(19), big.NewInt(23), big.NewInt(29), big.NewInt(31), big.NewInt(37),
+	big.NewInt(41), big.NewInt(43), big.NewInt(47), big.NewInt(53), big.NewInt(59), big.NewInt(61),
+	big.NewInt(67), big.NewInt(71), big.NewInt(73), big.NewInt(79), big.NewInt(83), big.NewInt(89),
+	big.NewInt(97), big.NewInt(101), big.NewInt(103), big.NewInt(107), big.NewInt(109), big.NewInt(113),
+	big.NewInt(127), big.NewInt(131), big.NewInt(137), big.NewInt(139), big.NewInt(149), big.NewInt(151),
+	big.NewInt(157), big.NewInt(163), big.NewInt(167), big.NewInt(173), big.NewInt(179), big.NewInt(181),
+	big.NewInt(191), big.NewInt(193), big.NewInt(197), big.NewInt(199), big.NewInt(211), big.NewInt(223),
+	big.NewInt(227), big.NewInt(229), big.NewInt(233), big.NewInt(239), big.NewInt(241), big.NewInt(251),
+	big.NewInt(257), big.NewInt(263), big.NewInt(269), big.NewInt(271), big.NewInt(277), big.NewInt(281),
+	big.NewInt(283), big.NewInt(293), big.NewInt(307), big.NewInt(311), big.NewInt(353), big.NewInt(359),
+	big.NewInt(367), big.NewInt(373), big.NewInt(379), big.NewInt(383), big.NewInt(313), big.NewInt(317),
+	big.NewInt(331), big.NewInt(337), big.NewInt(347), big.NewInt(349), big.NewInt(389), big.NewInt(397),
+	big.NewInt(401), big.NewInt(409), big.NewInt(419), big.NewInt(421), big.NewInt(431), big.NewInt(433),
+	big.NewInt(439), big.NewInt(443), big.NewInt(449), big.NewInt(457), big.NewInt(461), big.NewInt(463),
+	big.NewInt(467), big.NewInt(479), big.NewInt(487), big.NewInt(491), big.NewInt(499), big.NewInt(503),
+	big.NewInt(509), big.NewInt(521), big.NewInt(523), big.NewInt(541), big.NewInt(547), big.NewInt(557),
+	big.NewInt(563), big.NewInt(569), big.NewInt(571), big.NewInt(577), big.NewInt(587), big.NewInt(593),
+	big.NewInt(599), big.NewInt(601), big.NewInt(607), big.NewInt(613), big.NewInt(617), big.NewInt(619),
+	big.NewInt(631), big.NewInt(641), big.NewInt(643), big.NewInt(647), big.NewInt(653), big.NewInt(659),
+	big.NewInt(661), big.NewInt(673), big.NewInt(677), big.NewInt(683), big.NewInt(691), big.NewInt(701),
+	big.NewInt(709), big.NewInt(719), big.NewInt(727), big.NewInt(733), big.NewInt(739), big.NewInt(743),
+	big.NewInt(751),
 }
 
+var zero = big.NewInt(0)
+
 func PrimeNoSmallerThan752(dividend *big.Int) bool {
-	zero := big.NewInt(0)
 	quotient := big.NewInt(0)
 	mod := big.NewInt(0)
-	for _, divisor := range primes {
-		bigDivisor := big.NewInt(int64(divisor))
-		quotient.DivMod(dividend, bigDivisor, mod)
+	for _, divisor := range bigIntPrimes {
+		quotient.DivMod(dividend, divisor, mod)
 		if mod.Cmp(zero) == 0 {
 			return false
 		}

--- a/zlint.go
+++ b/zlint.go
@@ -1,4 +1,4 @@
-/* z.go
+/* zlint.go
  * Used to check parsed info from certificate for compliance
  */
 


### PR DESCRIPTION
This pull request will speed up the slowest linters. 

* w_dnsname_underscore_in_trd
* e_dnsname_underscore_in_sld
* e_dnsname_hyphen_in_sld
* w_dnsname_wildcard_left_of_public_suffix
* w_san_iana_pub_suffix_empty
* w_rsa_mod_factors_smaller_than_752
* e_dnsname_bad_character_in_label

Plus some linting done by my IDE. 

Benchmark results
```
benchcmp old.benchmarks.txt new.benchmarks.txt
benchmark                      old ns/op     new ns/op     delta
BenchmarkZlint/All_lints-8     33228743      407902        -98.77%

benchmark                      old allocs     new allocs     delta
BenchmarkZlint/All_lints-8     30006          2115           -92.95%

benchmark                      old bytes     new bytes     delta
BenchmarkZlint/All_lints-8     18835646      90210         -99.52%
```

Overall, the benchmarks are ~80x faster. 
If you guys are happy with the changes, I might have a look at some other slow benchmarks. 

* w_subject_dn_leading_whitespace
* w_subject_dn_trailing_whitespace
* w_multiple_subject_rdn
* e_ext_san_dns_not_ia5_string
* e_ext_san_empty_name
* e_dnsname_not_valid_tld
* e_dnsname_contains_bare_iana_suffix
* e_dnsname_wildcard_only_in_left_label
* e_international_dns_name_not_nfkc

Again, speeding them up might require some changes to the zcrypto/x509 to cache some values (tentatively)

I would appreciate any remarks. 