### PR TITLE
Issue #191: 825 day certificates

### DIFF
--- a/lints/lint_sub_cert_valid_time_longer_than_39_months.go
+++ b/lints/lint_sub_cert_valid_time_longer_than_39_months.go
@@ -1,4 +1,4 @@
-// lint_sub_cert_valid_time_too_long.go
+// lint_sub_cert_valid_time_longer_than_39_months.go
 
 package lints
 
@@ -7,17 +7,17 @@ import (
 	"github.com/zmap/zlint/util"
 )
 
-type subCertValidTimeTooLong struct{}
+type subCertValidTimeLongerThan39Months struct{}
 
-func (l *subCertValidTimeTooLong) Initialize() error {
+func (l *subCertValidTimeLongerThan39Months) Initialize() error {
 	return nil
 }
 
-func (l *subCertValidTimeTooLong) CheckApplies(c *x509.Certificate) bool {
+func (l *subCertValidTimeLongerThan39Months) CheckApplies(c *x509.Certificate) bool {
 	return util.IsSubscriberCert(c)
 }
 
-func (l *subCertValidTimeTooLong) Execute(c *x509.Certificate) *LintResult {
+func (l *subCertValidTimeLongerThan39Months) Execute(c *x509.Certificate) *LintResult {
 	if c.NotBefore.AddDate(0, 39, 0).Before(c.NotAfter) {
 		return &LintResult{Status: Error}
 	}
@@ -26,11 +26,11 @@ func (l *subCertValidTimeTooLong) Execute(c *x509.Certificate) *LintResult {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "e_sub_cert_valid_time_too_long",
+		Name:          "e_sub_cert_valid_time_longer_than_39_months",
 		Description:   "Subscriber Certificates issued after 1 March 2018 MUST have a Validity Period no greater than 825 days. Subscriber Certificates issued after 1 July 2016 but prior to 1 March 2018 MUST have a Validity Period no greater than 39 months.",
 		Citation:      "BRs: 6.3.2",
 		Source:        CABFBaselineRequirements,
 		EffectiveDate: util.SubCert39Month,
-		Lint:          &subCertValidTimeTooLong{},
+		Lint:          &subCertValidTimeLongerThan39Months{},
 	})
 }

--- a/lints/lint_sub_cert_valid_time_longer_than_39_months.go
+++ b/lints/lint_sub_cert_valid_time_longer_than_39_months.go
@@ -27,7 +27,7 @@ func (l *subCertValidTimeLongerThan39Months) Execute(c *x509.Certificate) *LintR
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_valid_time_longer_than_39_months",
-		Description:   "Subscriber Certificates issued after 1 March 2018 MUST have a Validity Period no greater than 825 days. Subscriber Certificates issued after 1 July 2016 but prior to 1 March 2018 MUST have a Validity Period no greater than 39 months.",
+		Description:   "Subscriber Certificates issued after 1 July 2016 but prior to 1 March 2018 MUST have a Validity Period no greater than 39 months.",
 		Citation:      "BRs: 6.3.2",
 		Source:        CABFBaselineRequirements,
 		EffectiveDate: util.SubCert39Month,

--- a/lints/lint_sub_cert_valid_time_longer_than_39_months_test.go
+++ b/lints/lint_sub_cert_valid_time_longer_than_39_months_test.go
@@ -1,14 +1,14 @@
-// lint_subject_common_name_included_test.go
+// lint_sub_cert_valid_time_longer_than_39_months_test.go
 package lints
 
 import (
 	"testing"
 )
 
-func TestSubCertValidTimeTooLong(t *testing.T) {
+func TestSubCertValidTimeLongerThan39Months(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertValidTimeTooLong.pem"
 	expected := Error
-	out := Lints["e_sub_cert_valid_time_too_long"].Execute(ReadCertificate(inputPath))
+	out := Lints["e_sub_cert_valid_time_longer_than_39_months"].Execute(ReadCertificate(inputPath))
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
@@ -17,7 +17,7 @@ func TestSubCertValidTimeTooLong(t *testing.T) {
 func TestSubCertValidTimeGood(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCertValidTimeGood.pem"
 	expected := Pass
-	out := Lints["e_sub_cert_valid_time_too_long"].Execute(ReadCertificate(inputPath))
+	out := Lints["e_sub_cert_valid_time_longer_than_39_months"].Execute(ReadCertificate(inputPath))
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}

--- a/lints/lint_sub_cert_valid_time_longer_than_825_days.go
+++ b/lints/lint_sub_cert_valid_time_longer_than_825_days.go
@@ -27,7 +27,7 @@ func (l *subCertValidTimeLongerThan825Days) Execute(c *x509.Certificate) *LintRe
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_valid_time_longer_than_825_days",
-		Description:   "Subscriber Certificates issued after 1 March 2018 MUST have a Validity Period no greater than 825 days. Subscriber Certificates issued after 1 July 2016 but prior to 1 March 2018 MUST have a Validity Period no greater than 39 months.",
+		Description:   "Subscriber Certificates issued after 1 March 2018 MUST have a Validity Period no greater than 825 days.",
 		Citation:      "BRs: 6.3.2",
 		Source:        CABFBaselineRequirements,
 		EffectiveDate: util.SubCert825Days,

--- a/lints/lint_sub_cert_valid_time_longer_than_825_days.go
+++ b/lints/lint_sub_cert_valid_time_longer_than_825_days.go
@@ -1,4 +1,4 @@
-// lint_sub_cert_valid_time_too_long.go
+// lint_sub_cert_valid_time_longer_than_825_days.go
 
 package lints
 
@@ -7,18 +7,18 @@ import (
 	"github.com/zmap/zlint/util"
 )
 
-type subCertValidTimeTooLong struct{}
+type subCertValidTimeLongerThan825Days struct{}
 
-func (l *subCertValidTimeTooLong) Initialize() error {
+func (l *subCertValidTimeLongerThan825Days) Initialize() error {
 	return nil
 }
 
-func (l *subCertValidTimeTooLong) CheckApplies(c *x509.Certificate) bool {
+func (l *subCertValidTimeLongerThan825Days) CheckApplies(c *x509.Certificate) bool {
 	return util.IsSubscriberCert(c)
 }
 
-func (l *subCertValidTimeTooLong) Execute(c *x509.Certificate) *LintResult {
-	if c.NotBefore.AddDate(0, 39, 0).Before(c.NotAfter) {
+func (l *subCertValidTimeLongerThan825Days) Execute(c *x509.Certificate) *LintResult {
+	if c.NotBefore.AddDate(0, 0, 825).Before(c.NotAfter) {
 		return &LintResult{Status: Error}
 	}
 	return &LintResult{Status: Pass}
@@ -26,11 +26,11 @@ func (l *subCertValidTimeTooLong) Execute(c *x509.Certificate) *LintResult {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "e_sub_cert_valid_time_too_long",
+		Name:          "e_sub_cert_valid_time_longer_than_825_days",
 		Description:   "Subscriber Certificates issued after 1 March 2018 MUST have a Validity Period no greater than 825 days. Subscriber Certificates issued after 1 July 2016 but prior to 1 March 2018 MUST have a Validity Period no greater than 39 months.",
 		Citation:      "BRs: 6.3.2",
 		Source:        CABFBaselineRequirements,
-		EffectiveDate: util.SubCert39Month,
-		Lint:          &subCertValidTimeTooLong{},
+		EffectiveDate: util.SubCert825Days,
+		Lint:          &subCertValidTimeLongerThan825Days{},
 	})
 }

--- a/lints/lint_sub_cert_valid_time_longer_than_825_days_test.go
+++ b/lints/lint_sub_cert_valid_time_longer_than_825_days_test.go
@@ -23,7 +23,6 @@ func TestSubCertValidTimeLongerThan825DaysBeforeCutoff(t *testing.T) {
 	}
 }
 
-
 func TestSubCertValidTime825Days(t *testing.T) {
 	inputPath := "../testlint/testCerts/subCert825DaysOK.pem"
 	expected := Pass

--- a/lints/lint_sub_cert_valid_time_longer_than_825_days_test.go
+++ b/lints/lint_sub_cert_valid_time_longer_than_825_days_test.go
@@ -1,0 +1,34 @@
+// lint_sub_cert_valid_time_longer_than_825_days_test.go
+package lints
+
+import (
+	"testing"
+)
+
+func TestSubCertValidTimeLongerThan825Days(t *testing.T) {
+	inputPath := "../testlint/testCerts/subCertOver825DaysBad.pem"
+	expected := Error
+	out := Lints["e_sub_cert_valid_time_longer_than_825_days"].Execute(ReadCertificate(inputPath))
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestSubCertValidTimeLongerThan825DaysBeforeCutoff(t *testing.T) {
+	inputPath := "../testlint/testCerts/subCertOver825DaysOK.pem"
+	expected := NE
+	out := Lints["e_sub_cert_valid_time_longer_than_825_days"].Execute(ReadCertificate(inputPath))
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+
+func TestSubCertValidTime825Days(t *testing.T) {
+	inputPath := "../testlint/testCerts/subCert825DaysOK.pem"
+	expected := Pass
+	out := Lints["e_sub_cert_valid_time_longer_than_825_days"].Execute(ReadCertificate(inputPath))
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/lints/lint_sub_cert_valid_time_too_long.go
+++ b/lints/lint_sub_cert_valid_time_too_long.go
@@ -1,8 +1,9 @@
-// lint_ev_valid_time_too_long.go
+// lint_sub_cert_valid_time_too_long.go
 
 package lints
 
 import (
+	"time"
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )
@@ -18,16 +19,32 @@ func (l *subCertValidTimeTooLong) CheckApplies(c *x509.Certificate) bool {
 }
 
 func (l *subCertValidTimeTooLong) Execute(c *x509.Certificate) *LintResult {
-	if c.NotBefore.AddDate(0, 39, 0).Before(c.NotAfter) {
-		return &LintResult{Status: Error}
+	july_1_2016 := time.Date(2016, time.July, 1, 0, 0, 0, 0, time.UTC)
+	march_1_2018 := time.Date(2018, time.March, 1, 0, 0, 0, 0, time.UTC)
+	if c.NotBefore.Before(july_1_2016) {
+		// Vacuously passed
+		return &LintResult{Status: Pass}
 	}
-	return &LintResult{Status: Pass}
+	if c.NotBefore.After(march_1_2018) {
+		if c.NotBefore.AddDate(0, 0, 825).Before(c.NotAfter) {
+			// NotAfter - NotBefore > 825 days
+			return &LintResult{Status: Error}
+		} else {
+			return &LintResult{Status: Pass}
+		}
+	} else {
+		// Between 2016/July/01 and 2018/March/01: 39 months
+		if c.NotBefore.AddDate(0, 39, 0).Before(c.NotAfter) {
+			return &LintResult{Status: Error}
+		}
+		return &LintResult{Status: Pass}
+	}
 }
 
 func init() {
 	RegisterLint(&Lint{
 		Name:          "e_sub_cert_valid_time_too_long",
-		Description:   "CAs MUST NOT issue subscriber certificates with validity periods longer than 39 months regardless of circumstance.",
+		Description:   "Subscriber Certificates issued after 1 March 2018 MUST have a Validity Period no greater than 825 days. Subscriber Certificates issued after 1 July 2016 but prior to 1 March 2018 MUST have a Validity Period no greater than 39 months. ",
 		Citation:      "BRs: 6.3.2",
 		Source:        CABFBaselineRequirements,
 		EffectiveDate: util.SubCert39Month,

--- a/lints/lint_sub_cert_valid_time_too_long.go
+++ b/lints/lint_sub_cert_valid_time_too_long.go
@@ -3,9 +3,9 @@
 package lints
 
 import (
-	"time"
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
+	"time"
 )
 
 type subCertValidTimeTooLong struct{}

--- a/testlint/testCerts/subCert825DaysOK.pem
+++ b/testlint/testCerts/subCert825DaysOK.pem
@@ -1,0 +1,67 @@
+Certificate:
+    Data:
+        Version: 1 (0x0)
+        Serial Number:
+            e8:f8:ad:9e:a1:86:8b:d4
+        Signature Algorithm: sha1WithRSAEncryption
+        Issuer: CN=Testroot
+        Validity
+            Not Before: Mar  2 15:49:34 2018 GMT
+            Not After : Jun  4 15:49:34 2020 GMT
+        Subject: CN=825OK
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:a7:1d:7c:12:0a:6d:33:e7:5c:9f:28:f9:70:73:
+                    f4:79:11:60:a8:3f:68:7f:b2:6e:6b:2e:50:3d:52:
+                    50:80:54:3e:8d:a4:4a:e6:b3:e0:34:0c:dd:c3:7b:
+                    0c:4a:09:f5:46:20:45:41:46:3e:0e:6a:ee:ae:03:
+                    a9:b5:a8:7b:87:26:a1:69:a8:e4:ee:12:8f:07:71:
+                    fc:2f:26:39:70:ad:40:72:ab:52:f4:e4:bf:57:2a:
+                    98:ae:04:bc:2f:ff:90:2f:f3:c8:c0:e0:ee:56:c9:
+                    39:fe:fd:51:4b:84:db:1d:0c:80:d2:47:61:ac:1c:
+                    4e:ff:f8:4b:60:99:db:1d:1a:4e:d1:c0:45:99:88:
+                    a9:dd:21:cf:0e:88:a7:78:5b:9f:7b:5b:85:e7:35:
+                    df:52:8d:e2:a3:ea:cb:11:b0:06:85:99:ec:4f:79:
+                    0e:71:08:90:3b:53:b0:21:94:2c:e2:2c:25:56:d6:
+                    b2:8e:ce:8a:5c:b7:53:6e:c5:17:8a:89:24:aa:2e:
+                    c6:4c:10:7a:f7:31:1f:47:7e:26:7e:d4:a2:dd:82:
+                    a6:37:c7:3e:92:b3:de:d0:ac:a5:2f:25:1f:44:ba:
+                    71:a9:91:e5:05:a3:fb:4f:8d:cb:bc:9e:42:a8:ef:
+                    f3:c4:1e:7d:9d:46:72:f9:86:5b:29:7b:cc:b0:78:
+                    d3:ed
+                Exponent: 65537 (0x10001)
+    Signature Algorithm: sha1WithRSAEncryption
+        a2:70:7b:45:ff:e9:3a:be:4b:b4:d3:94:61:91:98:9e:a5:11:
+        bb:8a:17:b7:2a:f9:c4:04:58:7a:d3:fb:71:b4:68:17:f1:25:
+        55:91:83:56:45:78:79:27:db:4e:4c:6d:98:9f:0c:67:19:f9:
+        ae:b7:f2:06:64:c1:dc:b3:2a:39:1f:ad:57:7f:3a:da:3a:6c:
+        fc:72:60:ab:e2:e5:46:c2:e0:86:96:2d:9b:f3:a9:a8:80:c0:
+        16:ca:e7:85:20:5c:b8:81:c2:a6:b5:4b:7a:f8:3a:ad:b6:6e:
+        3f:2c:02:36:3c:31:4e:15:7c:7d:cc:0d:cc:34:c8:ac:7c:8f:
+        08:5e:3d:57:ab:a2:0b:23:52:dc:11:2c:62:74:30:9d:e5:d0:
+        f9:94:4e:3d:0a:55:de:18:72:47:db:37:86:e8:7e:72:39:24:
+        fa:8e:f6:10:46:60:50:ee:ef:10:d3:b2:4c:ab:2f:c4:65:9c:
+        f9:32:34:be:16:05:6d:7b:a9:fa:bc:06:e0:7e:57:a2:b7:33:
+        10:eb:fb:d5:cf:6a:cf:18:86:77:a2:2e:dc:68:e9:85:95:12:
+        75:8d:b9:ea:f0:98:61:e5:f8:fe:d1:83:f4:f2:b8:9f:ac:4c:
+        1a:55:a5:74:dd:55:2f:fd:70:a4:fe:5c:dc:de:80:61:ef:9e:
+        e3:19:1d:9c
+-----BEGIN CERTIFICATE-----
+MIICnzCCAYcCCQDo+K2eoYaL1DANBgkqhkiG9w0BAQUFADATMREwDwYDVQQDEwhU
+ZXN0cm9vdDAeFw0xODAzMDIxNTQ5MzRaFw0yMDA2MDQxNTQ5MzRaMBAxDjAMBgNV
+BAMTBTgyNU9LMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApx18Egpt
+M+dcnyj5cHP0eRFgqD9of7Juay5QPVJQgFQ+jaRK5rPgNAzdw3sMSgn1RiBFQUY+
+DmrurgOptah7hyahaajk7hKPB3H8LyY5cK1AcqtS9OS/VyqYrgS8L/+QL/PIwODu
+Vsk5/v1RS4TbHQyA0kdhrBxO//hLYJnbHRpO0cBFmYip3SHPDoineFufe1uF5zXf
+Uo3io+rLEbAGhZnsT3kOcQiQO1OwIZQs4iwlVtayjs6KXLdTbsUXiokkqi7GTBB6
+9zEfR34mftSi3YKmN8c+krPe0KylLyUfRLpxqZHlBaP7T43LvJ5CqO/zxB59nUZy
++YZbKXvMsHjT7QIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQCicHtF/+k6vku005Rh
+kZiepRG7ihe3KvnEBFh60/txtGgX8SVVkYNWRXh5J9tOTG2YnwxnGfmut/IGZMHc
+syo5H61XfzraOmz8cmCr4uVGwuCGli2b86mogMAWyueFIFy4gcKmtUt6+Dqttm4/
+LAI2PDFOFXx9zA3MNMisfI8IXj1Xq6ILI1LcESxidDCd5dD5lE49ClXeGHJH2zeG
+6H5yOST6jvYQRmBQ7u8Q07JMqy/EZZz5MjS+FgVte6n6vAbgfleitzMQ6/vVz2rP
+GIZ3oi7caOmFlRJ1jbnq8Jhh5fj+0YP08rifrEwaVaV03VUv/XCk/lzc3oBh757j
+GR2c
+-----END CERTIFICATE-----

--- a/testlint/testCerts/subCertOver825DaysBad.pem
+++ b/testlint/testCerts/subCertOver825DaysBad.pem
@@ -1,0 +1,67 @@
+Certificate:
+    Data:
+        Version: 1 (0x0)
+        Serial Number:
+            e8:f8:ad:9e:a1:86:8b:d3
+        Signature Algorithm: sha1WithRSAEncryption
+        Issuer: CN=Testroot
+        Validity
+            Not Before: Mar  2 15:49:33 2018 GMT
+            Not After : Jun  6 15:49:33 2020 GMT
+        Subject: CN=827Bad
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:a7:df:9b:d3:5d:de:ba:f2:8b:01:b9:e0:48:69:
+                    f7:26:71:49:92:1a:be:9e:ba:c9:f6:d9:89:74:42:
+                    49:95:32:10:62:fc:b9:19:ea:7a:ea:8b:ef:3d:dc:
+                    cc:19:f7:d9:69:0a:7d:6f:6b:39:19:d0:c7:14:f0:
+                    56:d0:3a:c7:36:5a:2d:00:e0:23:8c:e8:fb:37:4d:
+                    5d:0c:16:e3:2c:1a:df:5a:cf:da:f5:06:55:ee:17:
+                    90:23:b3:66:c6:2d:6b:14:af:0f:f5:27:9b:f9:3e:
+                    09:18:3e:e1:34:97:db:ef:fc:43:a2:9e:48:5b:c7:
+                    7f:9e:67:bc:98:c4:e7:8b:f7:8a:7c:2f:3c:7c:ad:
+                    52:f5:37:e8:24:c9:5c:93:cc:ed:94:05:f8:c9:8f:
+                    f4:b8:9f:11:77:b6:17:21:53:2f:e1:a3:19:ef:36:
+                    85:6b:7a:e8:09:b7:57:a9:0c:a3:30:dc:d4:0a:3f:
+                    3b:03:96:68:fc:12:f4:5f:07:ff:44:38:5e:3b:c1:
+                    53:92:58:e8:d9:f6:be:06:6f:2c:e4:42:2b:ee:ef:
+                    e5:d3:83:b2:31:cf:cc:c4:6f:d1:5a:14:5e:30:78:
+                    f8:2e:9e:1c:c2:16:0f:c0:f3:d5:b2:ba:19:be:28:
+                    3e:f3:7a:c6:95:73:84:36:64:6b:db:50:6d:b9:17:
+                    29:e9
+                Exponent: 65537 (0x10001)
+    Signature Algorithm: sha1WithRSAEncryption
+        b6:68:74:30:cf:70:60:5d:86:bc:aa:9a:68:0b:58:48:fb:85:
+        d2:c3:ae:01:f0:68:ad:c3:f7:76:b2:76:07:6b:05:7f:e5:12:
+        f0:3d:f6:17:d3:54:3b:5c:ec:50:af:bc:81:0a:53:44:46:9c:
+        2a:ce:8a:38:94:c7:07:96:e5:fc:dd:d0:03:ba:d0:08:52:06:
+        c9:2e:b1:e4:a4:0a:c7:fe:f1:b9:72:be:bd:9e:60:87:95:cb:
+        88:0c:56:eb:8a:42:65:56:18:ac:30:66:ca:85:27:a0:90:a1:
+        a2:16:10:b8:7e:4a:a9:11:33:74:49:b7:bd:0c:af:2e:1d:7c:
+        d4:18:2a:15:f1:2d:47:7c:46:79:6e:98:20:5a:50:e0:83:6b:
+        70:14:d8:bc:9a:1e:44:b7:63:1d:c2:19:02:a7:3b:9e:44:05:
+        32:8b:8f:12:61:08:e3:87:d0:81:60:a2:82:6c:f9:03:cf:5a:
+        c4:8a:65:50:eb:72:e3:61:55:55:7a:54:ab:87:c2:a2:43:28:
+        b0:80:d3:6a:c7:e6:76:0b:bb:97:00:ed:97:e5:9c:8d:fe:92:
+        d3:d9:21:9a:47:38:9b:41:7c:c7:68:9c:78:45:b9:30:e2:1b:
+        62:9a:14:d0:b2:8b:ca:8f:c2:07:94:07:96:e7:14:21:5d:8a:
+        51:24:1a:75
+-----BEGIN CERTIFICATE-----
+MIICoDCCAYgCCQDo+K2eoYaL0zANBgkqhkiG9w0BAQUFADATMREwDwYDVQQDEwhU
+ZXN0cm9vdDAeFw0xODAzMDIxNTQ5MzNaFw0yMDA2MDYxNTQ5MzNaMBExDzANBgNV
+BAMTBjgyN0JhZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKffm9Nd
+3rryiwG54Ehp9yZxSZIavp66yfbZiXRCSZUyEGL8uRnqeuqL7z3czBn32WkKfW9r
+ORnQxxTwVtA6xzZaLQDgI4zo+zdNXQwW4ywa31rP2vUGVe4XkCOzZsYtaxSvD/Un
+m/k+CRg+4TSX2+/8Q6KeSFvHf55nvJjE54v3inwvPHytUvU36CTJXJPM7ZQF+MmP
+9LifEXe2FyFTL+GjGe82hWt66Am3V6kMozDc1Ao/OwOWaPwS9F8H/0Q4XjvBU5JY
+6Nn2vgZvLORCK+7v5dODsjHPzMRv0VoUXjB4+C6eHMIWD8Dz1bK6Gb4oPvN6xpVz
+hDZka9tQbbkXKekCAwEAATANBgkqhkiG9w0BAQUFAAOCAQEAtmh0MM9wYF2GvKqa
+aAtYSPuF0sOuAfBorcP3drJ2B2sFf+US8D32F9NUO1zsUK+8gQpTREacKs6KOJTH
+B5bl/N3QA7rQCFIGyS6x5KQKx/7xuXK+vZ5gh5XLiAxW64pCZVYYrDBmyoUnoJCh
+ohYQuH5KqREzdEm3vQyvLh181BgqFfEtR3xGeW6YIFpQ4INrcBTYvJoeRLdjHcIZ
+Aqc7nkQFMouPEmEI44fQgWCigmz5A89axIplUOty42FVVXpUq4fCokMosIDTasfm
+dgu7lwDtl+Wcjf6S09khmkc4m0F8x2iceEW5MOIbYpoU0LKLyo/CB5QHlucUIV2K
+USQadQ==
+-----END CERTIFICATE-----

--- a/testlint/testCerts/subCertOver825DaysOK.pem
+++ b/testlint/testCerts/subCertOver825DaysOK.pem
@@ -1,0 +1,67 @@
+Certificate:
+    Data:
+        Version: 1 (0x0)
+        Serial Number:
+            e8:f8:ad:9e:a1:86:8b:d2
+        Signature Algorithm: sha1WithRSAEncryption
+        Issuer: CN=Testroot
+        Validity
+            Not Before: Feb 25 15:49:31 2018 GMT
+            Not After : Jun  1 15:49:31 2020 GMT
+        Subject: CN=827OK
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:eb:8b:37:d3:db:a0:46:09:fb:33:35:8d:2f:d2:
+                    e8:74:94:e4:ac:c9:90:dd:75:77:78:bb:1b:25:fe:
+                    57:11:19:43:0f:6b:5e:e8:60:f2:db:41:40:41:5c:
+                    46:55:ec:64:81:1c:e2:8a:65:c0:60:c4:25:39:98:
+                    0f:1f:3d:70:e1:89:54:e1:0e:ad:ec:33:ef:ff:fb:
+                    88:14:16:02:40:ec:31:d8:67:fc:09:ef:fc:48:d0:
+                    ab:8d:50:e8:cf:35:82:89:1a:6c:68:7d:be:de:82:
+                    b0:37:da:da:f6:1c:6a:96:81:87:8d:78:01:bd:d7:
+                    6c:a8:2b:51:12:d0:5d:45:46:69:d9:01:45:27:3f:
+                    52:ef:8a:4b:94:b8:3f:fd:91:f4:6f:82:82:8a:15:
+                    00:80:e6:ab:e0:6f:7f:62:47:93:42:34:e2:09:f0:
+                    63:99:24:48:29:b4:67:30:5e:3c:99:a5:80:55:71:
+                    73:cd:9e:c9:9f:03:d3:04:c6:d1:42:1c:c9:d9:fd:
+                    79:b5:02:c8:63:ee:3f:4f:bc:11:67:5d:45:af:fc:
+                    42:6e:cb:39:0f:4a:7d:4c:55:2b:19:6b:b9:ff:11:
+                    84:2b:38:df:c2:26:fc:32:67:73:25:3a:15:b2:53:
+                    80:a4:72:f3:93:68:f5:4c:29:66:6a:04:cf:a4:6d:
+                    83:9b
+                Exponent: 65537 (0x10001)
+    Signature Algorithm: sha1WithRSAEncryption
+        6a:a2:c1:9f:a0:98:99:7c:2e:bc:b9:9b:08:e0:47:35:ca:a9:
+        1e:ba:f8:e1:a2:b8:59:56:59:48:66:5c:99:6b:fe:67:58:0d:
+        24:78:50:66:e7:57:58:10:99:98:f5:e9:b3:de:ff:7b:6a:c9:
+        53:da:34:51:3c:dd:a0:20:94:7c:8a:32:db:22:f8:ca:f4:61:
+        07:dd:ea:a1:ab:05:53:0c:fc:e8:35:13:d6:ea:01:56:76:e5:
+        ee:b2:5d:26:26:e3:7f:cc:1f:aa:dc:15:9c:1d:7e:40:9c:c8:
+        9f:43:3a:c9:26:dd:5b:bf:20:65:ce:1e:ab:b3:c1:bc:7c:e7:
+        f9:59:6b:47:da:31:02:33:f6:be:68:34:7b:21:da:f9:8b:36:
+        0a:85:2b:bb:09:41:c5:e1:50:d2:a8:72:49:f5:93:19:fc:46:
+        98:65:51:26:3e:5a:6d:27:6b:68:a4:49:49:3b:5e:56:47:bb:
+        f9:b0:00:17:41:22:48:3a:62:ab:00:5a:45:84:44:ca:46:90:
+        d4:58:4d:b7:a6:7c:b9:ab:22:ef:10:22:d3:51:20:2b:40:3c:
+        0b:82:83:7a:02:43:25:33:e3:92:84:60:61:98:0a:e7:9b:0c:
+        23:aa:32:99:4f:35:0f:5a:f4:ba:5d:f1:20:ae:b8:b7:63:78:
+        7b:87:0c:ad
+-----BEGIN CERTIFICATE-----
+MIICnzCCAYcCCQDo+K2eoYaL0jANBgkqhkiG9w0BAQUFADATMREwDwYDVQQDEwhU
+ZXN0cm9vdDAeFw0xODAyMjUxNTQ5MzFaFw0yMDA2MDExNTQ5MzFaMBAxDjAMBgNV
+BAMTBTgyN09LMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA64s309ug
+Rgn7MzWNL9LodJTkrMmQ3XV3eLsbJf5XERlDD2te6GDy20FAQVxGVexkgRziimXA
+YMQlOZgPHz1w4YlU4Q6t7DPv//uIFBYCQOwx2Gf8Ce/8SNCrjVDozzWCiRpsaH2+
+3oKwN9ra9hxqloGHjXgBvddsqCtREtBdRUZp2QFFJz9S74pLlLg//ZH0b4KCihUA
+gOar4G9/YkeTQjTiCfBjmSRIKbRnMF48maWAVXFzzZ7JnwPTBMbRQhzJ2f15tQLI
+Y+4/T7wRZ11Fr/xCbss5D0p9TFUrGWu5/xGEKzjfwib8MmdzJToVslOApHLzk2j1
+TClmagTPpG2DmwIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQBqosGfoJiZfC68uZsI
+4Ec1yqkeuvjhorhZVllIZlyZa/5nWA0keFBm51dYEJmY9emz3v97aslT2jRRPN2g
+IJR8ijLbIvjK9GEH3eqhqwVTDPzoNRPW6gFWduXusl0mJuN/zB+q3BWcHX5AnMif
+QzrJJt1bvyBlzh6rs8G8fOf5WWtH2jECM/a+aDR7Idr5izYKhSu7CUHF4VDSqHJJ
+9ZMZ/EaYZVEmPlptJ2topElJO15WR7v5sAAXQSJIOmKrAFpFhETKRpDUWE23pny5
+qyLvECLTUSArQDwLgoN6AkMlM+OShGBhmArnmwwjqjKZTzUPWvS6XfEgrri3Y3h7
+hwyt
+-----END CERTIFICATE-----

--- a/util/time.go
+++ b/util/time.go
@@ -33,6 +33,7 @@ var (
 	GeneralizedDate            = time.Date(2050, time.January, 1, 0, 0, 0, 0, time.UTC)
 	NoReservedIP               = time.Date(2015, time.November, 1, 0, 0, 0, 0, time.UTC)
 	SubCert39Month             = time.Date(2016, time.June, 30, 0, 0, 0, 0, time.UTC)
+	SubCert825Days             = time.Date(2018, time.February, 28, 0, 0, 0, 0, time.UTC)
 	CABV148Date                = time.Date(2017, time.June, 8, 0, 0, 0, 0, time.UTC)
 )
 


### PR DESCRIPTION
Add new lint_sub_cert_valid_time_longer_than_825_days to implement the language of https://cabforum.org/2017/03/17/ballot-193-825-day-certificate-lifetimes/ -- namely, subscriber certificates issued after 2018/03/01 must have a validity period no longer than 825 days.

The existing lint_sub_cert_valid_time_too_long already handles the 39-month requirement (this was renamed to lint_sub_cert_valid_time_longer_than_39_months to remove the implication that it implements the whole "valid_time_too_long" requirement).
  