### PR TITLE
fix effective date for SubCert825Days

### DIFF
--- a/util/time.go
+++ b/util/time.go
@@ -47,7 +47,7 @@ var (
 	GeneralizedDate            = time.Date(2050, time.January, 1, 0, 0, 0, 0, time.UTC)
 	NoReservedIP               = time.Date(2015, time.November, 1, 0, 0, 0, 0, time.UTC)
 	SubCert39Month             = time.Date(2016, time.June, 30, 0, 0, 0, 0, time.UTC)
-	SubCert825Days             = time.Date(2018, time.February, 28, 0, 0, 0, 0, time.UTC)
+	SubCert825Days             = time.Date(2018, time.March, 2, 0, 0, 0, 0, time.UTC)
 	CABV148Date                = time.Date(2017, time.June, 8, 0, 0, 0, 0, time.UTC)
 )
 


### PR DESCRIPTION
Interpreting "issued after 1 March 2018" to mean "issued when it is no longer 1 March 2018"