### PR TITLE
Fix 39 month effective date

### DIFF
--- a/util/time.go
+++ b/util/time.go
@@ -46,7 +46,7 @@ var (
 	NoRSA1024Date              = time.Date(2014, time.January, 1, 0, 0, 0, 0, time.UTC)
 	GeneralizedDate            = time.Date(2050, time.January, 1, 0, 0, 0, 0, time.UTC)
 	NoReservedIP               = time.Date(2015, time.November, 1, 0, 0, 0, 0, time.UTC)
-	SubCert39Month             = time.Date(2016, time.June, 30, 0, 0, 0, 0, time.UTC)
+	SubCert39Month             = time.Date(2016, time.July, 2, 0, 0, 0, 0, time.UTC)
 	SubCert825Days             = time.Date(2018, time.March, 2, 0, 0, 0, 0, time.UTC)
 	CABV148Date                = time.Date(2017, time.June, 8, 0, 0, 0, 0, time.UTC)
 )

--- a/util/time.go
+++ b/util/time.go
@@ -47,7 +47,7 @@ var (
 	GeneralizedDate            = time.Date(2050, time.January, 1, 0, 0, 0, 0, time.UTC)
 	NoReservedIP               = time.Date(2015, time.November, 1, 0, 0, 0, 0, time.UTC)
 	SubCert39Month             = time.Date(2016, time.June, 30, 0, 0, 0, 0, time.UTC)
-	SubCert825Days             = time.Date(2018, time.February, 28, 0, 0, 0, 0, time.UTC)
+	SubCert825Days             = time.Date(2018, time.March, 2, 0, 0, 0, 0, time.UTC)
 	CABV148Date                = time.Date(2017, time.June, 8, 0, 0, 0, 0, time.UTC)
 )
 


### PR DESCRIPTION
Interpret "issued after 1 July 2016" to mean "issued when it is no longer July 1 2016" (so, at midnight of 2 July 2016)