### PR TITLE
Address issue 198 (SAN format)

### DIFF
--- a/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
+++ b/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
@@ -29,6 +29,7 @@ package lints
 import (
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
+	"net/url"
 )
 
 type SANURIHost struct{}
@@ -44,12 +45,20 @@ func (l *SANURIHost) CheckApplies(c *x509.Certificate) bool {
 func (l *SANURIHost) Execute(c *x509.Certificate) *LintResult {
 	for _, uri := range c.URIs {
 		if uri != "" {
-			host := util.GetHost(uri)
-			if !util.AuthIsFQDNOrIP(host) {
+			parsed, err := url.Parse(uri)
+			if err != nil {
+				return &LintResult{Status: Error}
+			}
+
+			if parsed.Host == "" {
+				return &LintResult{Status: Error}
+			}
+			if !util.IsFQDNOrIP(parsed.Host) {
 				return &LintResult{Status: Error}
 			}
 		}
 	}
+
 	return &LintResult{Status: Pass}
 }
 

--- a/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
+++ b/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
@@ -49,12 +49,14 @@ func (l *SANURIHost) Execute(c *x509.Certificate) *LintResult {
 			if err != nil {
 				return &LintResult{Status: Error}
 			}
-
-			if parsed.Host == "" {
-				return &LintResult{Status: Error}
-			}
-			if !util.IsFQDNOrIP(parsed.Host) {
-				return &LintResult{Status: Error}
+			if parsed.Opaque == "" {
+				// if Opaque is not empty, that means there is no authority, which means that the URI is vacuously OK
+				if parsed.Host == "" {
+					return &LintResult{Status: Error}
+				}
+				if !util.IsFQDNOrIP(parsed.Host) {
+					return &LintResult{Status: Error}
+				}
 			}
 		}
 	}

--- a/lints/lint_ext_san_uri_host_not_fqdn_or_ip_test.go
+++ b/lints/lint_ext_san_uri_host_not_fqdn_or_ip_test.go
@@ -62,3 +62,14 @@ func TestSANURIHostFQDN(t *testing.T) {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
+
+func TestSANURINoAuthority(t *testing.T) {
+	// This certificate has a SAN with URI=sip:alice@sip.uri.com
+	// Since this has no authority section, it should be accepted.
+	inputPath := "../testlint/testCerts/SANURINoAuthority.pem"
+	expected := Pass
+	out := Lints["e_ext_san_uri_host_not_fqdn_or_ip"].Execute(ReadCertificate(inputPath))
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/testlint/testCerts/SANURIHostFQDN.pem
+++ b/testlint/testCerts/SANURIHostFQDN.pem
@@ -1,97 +1,71 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 18008675309 (0x4316693ed)
-    Signature Algorithm: sha256WithRSAEncryption
-        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Serial Number:
+            e8:f8:ad:9e:a1:86:8b:d9
+        Signature Algorithm: sha1WithRSAEncryption
+        Issuer: CN=Testroot
         Validity
-            Not Before: Mar 17 22:37:38 2017 GMT
-            Not After : May 29 22:37:38 2017 GMT
-        Subject: C = US, O = Extreme Discord, OU = Chaos, L = Tallahassee, ST = FL, street = 3210 Holly Mill Run, postalCode = 30062, CN = gov.us
+            Not Before: Jan 12 19:21:11 2018 GMT
+            Not After : Jan 10 19:21:11 2028 GMT
+        Subject: CN=SANURIHostFQDN
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (2048 bit)
                 Modulus:
-                    00:e2:53:26:0a:56:31:da:f2:f3:8e:27:22:36:3b:
-                    a3:df:bf:af:3f:af:84:13:f4:6b:ba:df:87:c2:2c:
-                    50:97:b7:b1:be:67:20:48:f2:ed:32:ef:33:f4:8e:
-                    f2:69:89:bd:dd:f2:96:47:0e:8b:c7:b2:bf:59:85:
-                    28:40:48:12:7a:3f:e3:8f:7a:0e:89:b0:10:4e:94:
-                    e3:55:21:ef:71:ae:cd:11:2b:d9:40:7c:4f:ae:99:
-                    a8:e9:d5:8c:59:39:de:b7:94:3f:ac:a1:fa:53:f1:
-                    b2:b1:0c:d0:e7:4d:f7:7d:eb:9a:bf:a4:c0:ea:2f:
-                    56:22:0e:0b:26:7a:b7:82:f9:ea:ce:07:56:48:82:
-                    7f:70:ff:f6:cd:c5:73:a7:52:57:7a:a2:ec:26:af:
-                    6b:cc:db:69:d5:3a:e8:28:4a:0a:39:c2:af:80:35:
-                    ee:6f:ed:4e:22:0c:c5:e8:72:f5:45:75:18:29:b1:
-                    c4:89:40:83:87:b9:c1:d3:59:f2:ca:2d:df:62:0f:
-                    16:b6:d5:1c:58:f4:e2:71:56:08:75:96:70:fd:2c:
-                    80:70:82:db:72:86:a1:dc:65:5f:c2:0e:b2:a5:ec:
-                    71:2e:45:d8:21:ad:e7:ee:d9:55:43:1e:78:10:a4:
-                    b1:05:66:8f:42:f4:60:48:4d:05:6b:20:44:00:d8:
-                    70:53
+                    00:f7:13:f3:34:fc:14:cc:c9:cd:50:68:e7:9d:58:
+                    2d:35:9b:b4:0f:12:4d:ae:22:41:a3:c7:c6:6f:1a:
+                    05:08:6c:80:0c:1c:cf:c5:df:0a:20:55:7b:9b:f6:
+                    f7:25:f5:63:f8:89:92:d1:3a:e2:98:81:75:d6:1e:
+                    49:5d:b0:2c:37:50:5e:50:35:f0:ca:83:77:d0:e3:
+                    bf:d1:18:1b:c7:19:62:0a:52:66:d8:74:e6:a7:ee:
+                    fd:27:57:ea:df:61:96:44:81:6a:fc:dd:7f:f7:15:
+                    e6:66:0c:74:cb:66:12:1e:9c:34:dc:29:55:fc:e8:
+                    b4:d2:f8:5c:e5:e1:8b:3e:06:4c:0b:c7:0c:14:73:
+                    44:b6:40:20:37:0e:39:de:8e:04:7a:55:9f:5b:ef:
+                    13:34:cd:81:1a:54:5b:bd:a2:af:c7:25:ed:a0:bd:
+                    f2:6b:7b:f9:78:8d:0f:bb:9a:6e:be:64:2f:aa:44:
+                    19:b6:b0:7d:4e:1e:d0:b0:3c:cd:95:6c:11:f3:3b:
+                    92:93:e7:cf:22:c8:77:7b:ef:35:9e:cc:96:28:fb:
+                    67:bb:a9:0c:e7:97:5d:de:25:8f:0b:eb:45:0b:07:
+                    a5:0b:62:b5:76:5c:8b:0d:f5:43:57:2d:44:0e:c3:
+                    66:ba:5b:f7:ad:ef:b0:ea:76:63:da:fb:af:23:ad:
+                    1c:d5
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
-            X509v3 Key Usage: critical
-                Digital Signature, Key Encipherment
-            X509v3 Extended Key Usage: 
-                TLS Web Client Authentication, TLS Web Server Authentication
-            X509v3 Basic Constraints: critical
-                CA:FALSE
-            X509v3 Authority Key Identifier: 
-                keyid:01:02:03
-
-            Authority Information Access: 
-                OCSP - URI:http://theca.net/ocsp
-                CA Issuers - URI:http://theca.net/totallythecert.crt
-
             X509v3 Subject Alternative Name: 
-                DNS:*.example.com, URI:test//user@www.example.com:1337/test
-            X509v3 Issuer Alternative Name: 
-                URI:test//user@*.example.com:1337/test
-            X509v3 Certificate Policies: 
-                Policy: 2.23.140.1.2.2
-
-    Signature Algorithm: sha256WithRSAEncryption
-         44:36:b5:4d:e9:e6:ec:0c:af:e9:4f:c2:10:ee:60:87:e9:f5:
-         b6:96:bd:78:23:8a:79:34:dd:30:ae:a2:c3:a7:32:29:65:3c:
-         ca:38:1d:ec:2f:0b:fa:1a:26:88:92:85:a2:20:92:10:88:13:
-         ef:31:11:68:42:ba:7d:6d:bb:ac:3d:58:47:94:74:23:17:8f:
-         5b:ba:71:c6:32:7f:8b:ad:53:5b:37:90:20:84:74:c1:df:5a:
-         48:15:49:6d:31:33:99:64:f5:de:ec:58:41:76:2b:b2:9c:e9:
-         57:7c:5e:4b:b0:b5:d6:cd:49:7f:75:0b:8c:45:9b:15:65:89:
-         f5:de:b3:d9:5a:97:51:a5:9d:43:69:2c:37:bb:4a:26:2e:1d:
-         42:50:ae:a7:62:60:21:b9:bb:a0:99:84:9e:71:4b:cc:1b:9a:
-         ca:95:3c:21:0a:d7:0c:92:71:2c:99:b6:91:db:b4:74:45:60:
-         97:70:c4:64:cb:9c:b5:b8:e7:a5:9f:f7:d3:7f:ea:73:bc:69:
-         87:4f:6a:7f:e8:28:08:4a:2f:4b:73:ed:5d:88:8f:8b:9c:fc:
-         ae:65:1c:8a:19:0f:61:81:f9:33:58:30:4e:73:38:fd:1d:92:
-         9a:d4:84:b9:f0:b4:bf:74:47:af:89:b3:da:ca:ff:35:75:74:
-         e8:ca:a3:03
+                DNS:*.example.com, URI:test://user@www.example.com:1337/test
+    Signature Algorithm: sha1WithRSAEncryption
+        77:35:1e:a4:19:49:b3:e7:ec:24:92:db:e4:8a:7d:e7:a8:28:
+        c5:e9:4d:9b:86:b3:a4:39:33:ca:3d:46:ce:24:52:b9:8d:0a:
+        c3:8e:ff:97:29:5f:1f:b0:d4:97:1d:ab:bb:a0:02:83:53:6f:
+        28:2e:96:b7:c8:c7:df:3e:10:9a:da:03:5b:fa:2d:b5:9e:b7:
+        9c:76:47:27:fe:e6:77:0c:ca:3b:f5:91:59:03:14:0f:62:7a:
+        d0:4c:9d:a3:10:2c:37:2a:1c:99:d6:bb:b1:e2:30:97:fe:45:
+        f4:34:b3:dc:16:50:d1:f3:17:e9:28:a5:50:89:d5:f1:d7:fc:
+        30:ca:74:82:ff:d0:39:61:6b:9d:c9:89:51:74:36:55:dc:ee:
+        3b:9d:65:fd:62:78:8f:4d:a0:0a:1f:04:83:57:91:7b:d9:30:
+        97:c0:1b:fc:b0:71:82:26:81:c8:c1:3d:29:a9:82:c3:31:c9:
+        63:f5:f1:d9:c0:a1:b3:18:9f:e5:56:30:fe:32:9e:e5:2f:4e:
+        e9:f5:2e:50:a4:91:61:00:99:4f:09:11:ab:74:1f:6d:19:ce:
+        ea:43:4c:a5:b8:cb:08:93:7c:bf:fc:bc:72:91:3b:b4:ba:dd:
+        98:0b:dc:16:c5:f8:dd:ed:71:9b:03:4b:ab:93:e0:98:e7:57:
+        77:ea:de:9b
 -----BEGIN CERTIFICATE-----
-MIIEpjCCA5CgAwIBAgIFBDFmk+0wCwYJKoZIhvcNAQELMFQxCzAJBgNVBAYTAlVT
-MRYwFAYDVQQKEw1Nb3RoZXIgTmF0dXJlMRMwEQYDVQQLEwpFdmVyeXRoaW5nMRYw
-FAYDVQQDEw1Nb3RoZXIgTmF0dXJlMQAwHhcNMTcwMzE3MjIzNzM4WhcNMTcwNTI5
-MjIzNzM4WjCBmzELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD0V4dHJlbWUgRGlzY29y
-ZDEOMAwGA1UECxMFQ2hhb3MxFDASBgNVBAcTC1RhbGxhaGFzc2VlMQswCQYDVQQI
-EwJGTDEcMBoGA1UECRMTMzIxMCBIb2xseSBNaWxsIFJ1bjEOMAwGA1UEERMFMzAw
-NjIxDzANBgNVBAMTBmdvdi51czEAMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
-CgKCAQEA4lMmClYx2vLzjiciNjuj37+vP6+EE/Rrut+HwixQl7exvmcgSPLtMu8z
-9I7yaYm93fKWRw6Lx7K/WYUoQEgSej/jj3oOibAQTpTjVSHvca7NESvZQHxPrpmo
-6dWMWTnet5Q/rKH6U/GysQzQ5033feuav6TA6i9WIg4LJnq3gvnqzgdWSIJ/cP/2
-zcVzp1JXeqLsJq9rzNtp1TroKEoKOcKvgDXub+1OIgzF6HL1RXUYKbHEiUCDh7nB
-01nyyi3fYg8WttUcWPTicVYIdZZw/SyAcILbcoah3GVfwg6ypexxLkXYIa3n7tlV
-Qx54EKSxBWaPQvRgSE0FayBEANhwUwIDAQABo4IBOTCCATUwDgYDVR0PAQH/BAQD
-AgCgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAMBgNVHRMBAf8EAjAA
-MA4GA1UdIwQHMAWAAwECAzBiBggrBgEFBQcBAQRWMFQwIQYIKwYBBQUHMAGGFWh0
-dHA6Ly90aGVjYS5uZXQvb2NzcDAvBggrBgEFBQcwAoYjaHR0cDovL3RoZWNhLm5l
-dC90b3RhbGx5dGhlY2VydC5jcnQwPgYDVR0RBDcwNYINKi5leGFtcGxlLmNvbYYk
-dGVzdC8vdXNlckB3d3cuZXhhbXBsZS5jb206MTMzNy90ZXN0MC0GA1UdEgQmMCSG
-InRlc3QvL3VzZXJAKi5leGFtcGxlLmNvbToxMzM3L3Rlc3QwEwYDVR0gBAwwCjAI
-BgZngQwBAgIwCwYJKoZIhvcNAQELA4IBAQBENrVN6ebsDK/pT8IQ7mCH6fW2lr14
-I4p5NN0wrqLDpzIpZTzKOB3sLwv6GiaIkoWiIJIQiBPvMRFoQrp9bbusPVhHlHQj
-F49bunHGMn+LrVNbN5AghHTB31pIFUltMTOZZPXe7FhBdiuynOlXfF5LsLXWzUl/
-dQuMRZsVZYn13rPZWpdRpZ1DaSw3u0omLh1CUK6nYmAhubugmYSecUvMG5rKlTwh
-CtcMknEsmbaR27R0RWCXcMRky5y1uOeln/fTf+pzvGmHT2p/6CgISi9Lc+1diI+L
-nPyuZRyKGQ9hgfkzWDBOczj9HZKa1IS58LS/dEevibPayv81dXToyqMD
+MIIC8jCCAdqgAwIBAgIJAOj4rZ6hhovZMA0GCSqGSIb3DQEBBQUAMBMxETAPBgNV
+BAMTCFRlc3Ryb290MB4XDTE4MDExMjE5MjExMVoXDTI4MDExMDE5MjExMVowGTEX
+MBUGA1UEAxMOU0FOVVJJSG9zdEZRRE4wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
+ggEKAoIBAQD3E/M0/BTMyc1QaOedWC01m7QPEk2uIkGjx8ZvGgUIbIAMHM/F3wog
+VXub9vcl9WP4iZLROuKYgXXWHkldsCw3UF5QNfDKg3fQ47/RGBvHGWIKUmbYdOan
+7v0nV+rfYZZEgWr83X/3FeZmDHTLZhIenDTcKVX86LTS+Fzl4Ys+BkwLxwwUc0S2
+QCA3DjnejgR6VZ9b7xM0zYEaVFu9oq/HJe2gvfJre/l4jQ+7mm6+ZC+qRBm2sH1O
+HtCwPM2VbBHzO5KT588iyHd77zWezJYo+2e7qQznl13eJY8L60ULB6ULYrV2XIsN
+9UNXLUQOw2a6W/et77DqdmPa+68jrRzVAgMBAAGjQzBBMD8GA1UdEQQ4MDaCDSou
+ZXhhbXBsZS5jb22GJXRlc3Q6Ly91c2VyQHd3dy5leGFtcGxlLmNvbToxMzM3L3Rl
+c3QwDQYJKoZIhvcNAQEFBQADggEBAHc1HqQZSbPn7CSS2+SKfeeoKMXpTZuGs6Q5
+M8o9Rs4kUrmNCsOO/5cpXx+w1Jcdq7ugAoNTbygulrfIx98+EJraA1v6LbWet5x2
+Ryf+5ncMyjv1kVkDFA9ietBMnaMQLDcqHJnWu7HiMJf+RfQ0s9wWUNHzF+kopVCJ
+1fHX/DDKdIL/0Dlha53JiVF0NlXc7judZf1ieI9NoAofBINXkXvZMJfAG/ywcYIm
+gcjBPSmpgsMxyWP18dnAobMYn+VWMP4ynuUvTun1LlCkkWEAmU8JEat0H20ZzupD
+TKW4ywiTfL/8vHKRO7S63ZgL3BbF+N3tcZsDS6uT4JjnV3fq3ps=
 -----END CERTIFICATE-----

--- a/testlint/testCerts/SANURIHostWildcardFQDN.pem
+++ b/testlint/testCerts/SANURIHostWildcardFQDN.pem
@@ -1,97 +1,71 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 18008675309 (0x4316693ed)
-    Signature Algorithm: sha256WithRSAEncryption
-        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Serial Number:
+            e8:f8:ad:9e:a1:86:8b:da
+        Signature Algorithm: sha1WithRSAEncryption
+        Issuer: CN=Testroot
         Validity
-            Not Before: Mar 17 22:29:18 2017 GMT
-            Not After : May 29 22:29:18 2017 GMT
-        Subject: C = US, O = Extreme Discord, OU = Chaos, L = Tallahassee, ST = FL, street = 3210 Holly Mill Run, postalCode = 30062, CN = gov.us
+            Not Before: Jan 12 19:21:12 2018 GMT
+            Not After : Jan 10 19:21:12 2028 GMT
+        Subject: CN=SANURIHostWildcardFQDN
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (2048 bit)
                 Modulus:
-                    00:c5:f2:c0:c7:62:e1:d5:0c:a5:10:4a:6c:48:da:
-                    da:2f:15:18:fe:38:1b:8c:37:9e:29:c6:46:ea:b8:
-                    50:fd:dc:22:29:61:88:61:7f:02:f7:a4:14:0e:06:
-                    cd:ba:5b:46:27:35:7f:a6:2e:eb:11:6e:de:c3:28:
-                    cd:a1:16:a2:8a:f3:35:5e:58:48:2e:d7:95:9e:23:
-                    b7:5e:6a:4f:f9:56:1a:d7:8b:51:88:19:71:c8:82:
-                    1c:26:9f:b7:63:ae:9b:73:21:36:6a:4e:a5:a7:81:
-                    52:3e:f2:f1:24:76:89:82:82:66:1d:25:47:b3:63:
-                    f6:7e:9e:e4:75:3c:29:08:2a:24:af:e9:89:be:00:
-                    22:31:59:1b:ff:db:91:06:f0:99:64:86:d7:9d:59:
-                    0c:de:a7:66:bd:a7:5f:e4:1b:32:e1:b7:93:2d:3e:
-                    1e:70:5e:1f:85:1c:95:8f:25:da:8d:e3:a6:97:7f:
-                    90:eb:48:e6:1b:1e:c3:d9:a6:ee:31:5e:cf:65:38:
-                    99:0a:db:09:10:15:37:71:3b:63:86:52:45:2f:8b:
-                    d7:8e:f0:4a:c2:ad:f8:8a:f3:95:5b:79:53:25:6c:
-                    f5:92:12:67:13:6a:1c:2f:f1:35:06:75:d2:f8:0e:
-                    a0:39:2b:9e:b8:ea:e9:86:de:44:9d:b4:a9:68:65:
-                    4d:a7
+                    00:b9:17:fd:f8:03:5d:41:52:27:c6:7c:df:59:68:
+                    1a:a7:e2:f2:22:db:1c:88:20:3e:9a:73:ed:0f:ea:
+                    8d:28:29:7b:ef:c3:f6:2c:11:87:b6:86:ab:da:e4:
+                    9d:f9:dd:78:6e:d1:fa:90:fa:1b:be:c7:34:2d:3e:
+                    15:5f:a3:42:0b:ea:2f:3b:47:09:2e:b1:b9:3f:fb:
+                    44:b5:14:e7:c4:68:c7:d4:c0:36:b5:ea:2b:91:81:
+                    9f:42:32:b9:88:25:1a:e7:c8:f3:3a:03:2b:e5:e7:
+                    cd:34:4e:75:57:1f:83:42:0b:4d:ae:99:79:53:50:
+                    b2:bb:c0:a6:30:5e:e4:a8:e8:60:ff:2c:66:bf:dc:
+                    4a:fd:33:55:62:6c:ad:d0:b1:74:0a:65:66:5d:3b:
+                    ad:b0:cd:92:b5:16:7e:7e:ca:01:a8:5e:86:e7:05:
+                    e6:58:87:58:81:a8:fb:c4:b9:87:75:3c:66:72:16:
+                    00:d6:78:dc:51:43:ef:b8:a9:f7:7e:a5:70:5f:ee:
+                    0c:00:c9:db:4e:0e:11:4f:24:e5:64:37:06:77:1f:
+                    56:86:6f:f8:d4:b7:5a:81:1a:c0:85:2e:20:9c:38:
+                    d6:50:27:4b:15:86:92:e5:de:f3:dd:da:1a:d2:7d:
+                    7f:de:0b:a3:8f:83:90:14:cc:de:f4:13:d8:4a:b3:
+                    90:63
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
-            X509v3 Key Usage: critical
-                Digital Signature, Key Encipherment
-            X509v3 Extended Key Usage: 
-                TLS Web Client Authentication, TLS Web Server Authentication
-            X509v3 Basic Constraints: critical
-                CA:FALSE
-            X509v3 Authority Key Identifier: 
-                keyid:01:02:03
-
-            Authority Information Access: 
-                OCSP - URI:http://theca.net/ocsp
-                CA Issuers - URI:http://theca.net/totallythecert.crt
-
             X509v3 Subject Alternative Name: 
-                DNS:*.example.com, URI:test//user@*.example.com:1337/test
-            X509v3 Issuer Alternative Name: 
-                URI:test//user@*.example.com:1337/test
-            X509v3 Certificate Policies: 
-                Policy: 2.23.140.1.2.2
-
-    Signature Algorithm: sha256WithRSAEncryption
-         1e:0e:b4:90:c6:ee:31:39:11:b7:24:38:2d:af:68:d8:28:be:
-         01:6a:40:a7:95:c9:3b:32:cd:c1:dd:3d:d9:63:4b:a0:d8:bb:
-         87:cc:37:02:51:83:4e:29:07:1f:b8:e1:7b:8f:4f:f5:cc:39:
-         f3:32:7d:c8:4c:ff:0f:f5:b3:cd:3b:9c:04:f2:8a:3f:18:44:
-         88:9b:3a:12:14:70:cd:ab:f9:21:f7:f3:20:79:65:35:5f:42:
-         42:3c:83:7d:12:e0:c1:bc:ff:b0:23:68:e9:c8:4f:95:c4:83:
-         90:38:2c:5b:c2:cb:99:c5:d8:62:c9:6d:14:12:79:7e:9d:ed:
-         f5:c1:a2:01:95:95:48:c6:c8:c0:81:0d:0e:85:6a:03:e4:ed:
-         51:34:3c:91:22:29:56:16:70:6b:3c:09:c6:4b:31:31:70:8b:
-         06:fb:83:77:fe:ea:c9:08:56:69:f3:0e:c6:3c:22:f6:f0:24:
-         bc:c7:c4:58:27:56:53:89:5c:5c:9a:7c:4c:9d:f8:9a:9c:7b:
-         c5:77:f6:ad:50:cb:12:6a:4c:4a:f1:6a:fa:a8:dc:c0:f0:23:
-         23:31:9d:fd:01:bc:24:2c:be:6a:bd:a8:a9:57:53:b5:cf:5e:
-         13:30:b1:0d:32:f9:ec:4c:5f:c5:a1:fd:20:6d:13:1d:75:08:
-         1c:c2:72:5e
+                DNS:*.example.com, URI:test://user@*.example.com:1337/test
+    Signature Algorithm: sha1WithRSAEncryption
+        7c:ea:e7:ea:7e:c1:ab:30:bc:5d:8a:d4:76:77:c2:7d:6e:2e:
+        94:d7:d9:22:0d:a7:91:fa:7a:97:6b:0b:0f:f8:18:d5:93:21:
+        42:dd:69:3d:92:f9:78:76:55:8e:71:c1:ea:26:f0:c3:a3:1d:
+        88:b7:3b:bc:e2:54:c2:e4:c9:31:9b:0b:05:63:05:27:9a:a6:
+        e6:50:d2:4f:0f:85:27:b0:88:19:4f:4d:d8:10:65:bc:81:f1:
+        8a:fe:90:36:d8:66:87:16:c5:c8:16:13:b6:90:96:ca:bf:29:
+        87:8f:5c:12:b5:13:bb:57:b5:27:cd:bb:a8:cb:49:40:8b:76:
+        99:75:2a:f1:c4:10:40:44:cc:ad:d6:e8:e5:c3:aa:db:02:1a:
+        ac:26:c6:68:ee:09:a4:fd:e8:fb:8e:7a:46:00:5b:4d:33:c8:
+        1b:1e:f8:9d:d7:cd:10:09:d2:18:06:b4:29:08:80:cc:79:b2:
+        86:d0:29:ab:0d:a4:a5:b2:ef:d4:89:1b:ae:49:a6:28:79:fa:
+        fa:58:24:b6:8c:02:5a:cb:64:69:57:69:88:4e:44:2b:06:2e:
+        2a:a4:97:00:d4:f6:2a:4b:67:dd:3d:4f:d4:0a:82:e2:51:1b:
+        30:f6:1c:39:1e:be:ed:b7:33:55:a9:52:82:97:93:5e:eb:5a:
+        8d:d0:fc:c2
 -----BEGIN CERTIFICATE-----
-MIIEpDCCA46gAwIBAgIFBDFmk+0wCwYJKoZIhvcNAQELMFQxCzAJBgNVBAYTAlVT
-MRYwFAYDVQQKEw1Nb3RoZXIgTmF0dXJlMRMwEQYDVQQLEwpFdmVyeXRoaW5nMRYw
-FAYDVQQDEw1Nb3RoZXIgTmF0dXJlMQAwHhcNMTcwMzE3MjIyOTE4WhcNMTcwNTI5
-MjIyOTE4WjCBmzELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD0V4dHJlbWUgRGlzY29y
-ZDEOMAwGA1UECxMFQ2hhb3MxFDASBgNVBAcTC1RhbGxhaGFzc2VlMQswCQYDVQQI
-EwJGTDEcMBoGA1UECRMTMzIxMCBIb2xseSBNaWxsIFJ1bjEOMAwGA1UEERMFMzAw
-NjIxDzANBgNVBAMTBmdvdi51czEAMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
-CgKCAQEAxfLAx2Lh1QylEEpsSNraLxUY/jgbjDeeKcZG6rhQ/dwiKWGIYX8C96QU
-DgbNultGJzV/pi7rEW7ewyjNoRaiivM1XlhILteVniO3XmpP+VYa14tRiBlxyIIc
-Jp+3Y66bcyE2ak6lp4FSPvLxJHaJgoJmHSVHs2P2fp7kdTwpCCokr+mJvgAiMVkb
-/9uRBvCZZIbXnVkM3qdmvadf5Bsy4beTLT4ecF4fhRyVjyXajeOml3+Q60jmGx7D
-2abuMV7PZTiZCtsJEBU3cTtjhlJFL4vXjvBKwq34ivOVW3lTJWz1khJnE2ocL/E1
-BnXS+A6gOSueuOrpht5EnbSpaGVNpwIDAQABo4IBNzCCATMwDgYDVR0PAQH/BAQD
-AgCgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAMBgNVHRMBAf8EAjAA
-MA4GA1UdIwQHMAWAAwECAzBiBggrBgEFBQcBAQRWMFQwIQYIKwYBBQUHMAGGFWh0
-dHA6Ly90aGVjYS5uZXQvb2NzcDAvBggrBgEFBQcwAoYjaHR0cDovL3RoZWNhLm5l
-dC90b3RhbGx5dGhlY2VydC5jcnQwPAYDVR0RBDUwM4INKi5leGFtcGxlLmNvbYYi
-dGVzdC8vdXNlckAqLmV4YW1wbGUuY29tOjEzMzcvdGVzdDAtBgNVHRIEJjAkhiJ0
-ZXN0Ly91c2VyQCouZXhhbXBsZS5jb206MTMzNy90ZXN0MBMGA1UdIAQMMAowCAYG
-Z4EMAQICMAsGCSqGSIb3DQEBCwOCAQEAHg60kMbuMTkRtyQ4La9o2Ci+AWpAp5XJ
-OzLNwd092WNLoNi7h8w3AlGDTikHH7jhe49P9cw58zJ9yEz/D/WzzTucBPKKPxhE
-iJs6EhRwzav5IffzIHllNV9CQjyDfRLgwbz/sCNo6chPlcSDkDgsW8LLmcXYYslt
-FBJ5fp3t9cGiAZWVSMbIwIENDoVqA+TtUTQ8kSIpVhZwazwJxksxMXCLBvuDd/7q
-yQhWafMOxjwi9vAkvMfEWCdWU4lcXJp8TJ34mpx7xXf2rVDLEmpMSvFq+qjcwPAj
-IzGd/QG8JCy+ar2oqVdTtc9eEzCxDTL57ExfxaH9IG0THXUIHMJyXg==
+MIIC+DCCAeCgAwIBAgIJAOj4rZ6hhovaMA0GCSqGSIb3DQEBBQUAMBMxETAPBgNV
+BAMTCFRlc3Ryb290MB4XDTE4MDExMjE5MjExMloXDTI4MDExMDE5MjExMlowITEf
+MB0GA1UEAxMWU0FOVVJJSG9zdFdpbGRjYXJkRlFETjCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBALkX/fgDXUFSJ8Z831loGqfi8iLbHIggPppz7Q/qjSgp
+e+/D9iwRh7aGq9rknfndeG7R+pD6G77HNC0+FV+jQgvqLztHCS6xuT/7RLUU58Ro
+x9TANrXqK5GBn0IyuYglGufI8zoDK+XnzTROdVcfg0ILTa6ZeVNQsrvApjBe5Kjo
+YP8sZr/cSv0zVWJsrdCxdAplZl07rbDNkrUWfn7KAahehucF5liHWIGo+8S5h3U8
+ZnIWANZ43FFD77ip936lcF/uDADJ204OEU8k5WQ3BncfVoZv+NS3WoEawIUuIJw4
+1lAnSxWGkuXe893aGtJ9f94Lo4+DkBTM3vQT2EqzkGMCAwEAAaNBMD8wPQYDVR0R
+BDYwNIINKi5leGFtcGxlLmNvbYYjdGVzdDovL3VzZXJAKi5leGFtcGxlLmNvbTox
+MzM3L3Rlc3QwDQYJKoZIhvcNAQEFBQADggEBAHzq5+p+waswvF2K1HZ3wn1uLpTX
+2SINp5H6epdrCw/4GNWTIULdaT2S+Xh2VY5xweom8MOjHYi3O7ziVMLkyTGbCwVj
+BSeapuZQ0k8PhSewiBlPTdgQZbyB8Yr+kDbYZocWxcgWE7aQlsq/KYePXBK1E7tX
+tSfNu6jLSUCLdpl1KvHEEEBEzK3W6OXDqtsCGqwmxmjuCaT96PuOekYAW00zyBse
++J3XzRAJ0hgGtCkIgMx5sobQKasNpKWy79SJG65Jpih5+vpYJLaMAlrLZGlXaYhO
+RCsGLiqklwDU9ipLZ909T9QKguJRGzD2HDkevu23M1WpUoKXk17rWo3Q/MI=
 -----END CERTIFICATE-----

--- a/testlint/testCerts/SANURINoAuthority.pem
+++ b/testlint/testCerts/SANURINoAuthority.pem
@@ -1,0 +1,71 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            e8:f8:ad:9e:a1:86:8b:db
+        Signature Algorithm: sha1WithRSAEncryption
+        Issuer: CN=Testroot
+        Validity
+            Not Before: Jan 15 15:51:14 2018 GMT
+            Not After : Jan 13 15:51:14 2028 GMT
+        Subject: CN=SANURINoAuthority
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:bb:39:15:f8:cf:f3:e2:72:4a:a3:77:66:c4:2f:
+                    47:d3:ad:7f:62:11:67:fa:87:f6:16:38:8b:62:c5:
+                    a4:a0:e8:8a:2e:09:f1:03:d8:9f:74:d5:45:66:92:
+                    0c:c0:e5:e9:36:5d:10:ad:8d:6d:00:90:9b:7c:7f:
+                    6f:c8:97:74:af:5f:a3:30:c5:d6:58:e4:0a:db:96:
+                    f9:90:49:64:91:a2:07:63:5f:43:2f:f3:4e:58:9b:
+                    ba:56:2b:59:22:60:bc:94:55:66:25:20:16:8b:4a:
+                    e8:69:4b:87:f3:cf:73:f1:1d:0c:a1:55:37:95:7c:
+                    aa:1e:94:cb:61:4e:37:6c:c0:82:4b:a7:de:5d:f5:
+                    3f:c8:f7:f0:6d:02:2d:aa:3d:06:71:5c:12:a1:18:
+                    cc:c1:81:43:05:dd:81:7c:e4:a9:fe:7f:90:c4:e4:
+                    51:40:9c:42:d2:cf:b8:93:b5:47:5a:58:08:76:dd:
+                    1e:43:aa:87:ce:06:3e:bb:80:c7:c5:3e:36:16:e6:
+                    a3:8a:8b:d3:70:f7:d0:71:2e:d1:c6:19:aa:43:90:
+                    59:7f:29:f0:13:31:d0:46:97:2c:6e:37:65:73:03:
+                    4e:a6:07:e8:34:2f:2b:47:dc:70:db:95:45:37:9a:
+                    ba:18:57:92:b7:da:e0:b5:d7:ea:f7:a7:81:56:42:
+                    88:59
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Alternative Name: 
+                DNS:*.example.com, URI:sip:alice@sip.uri.com
+    Signature Algorithm: sha1WithRSAEncryption
+        a5:5e:79:a7:ca:e9:2b:61:87:a8:ed:93:fb:4b:4f:21:bd:e1:
+        c0:1c:f7:38:90:e1:fc:e7:74:d7:70:7a:47:c7:07:7f:5c:20:
+        48:a5:2c:73:0d:a9:c5:b9:60:c1:a3:86:35:18:55:ad:ad:94:
+        d2:64:12:8e:34:40:fc:f1:e3:84:87:e6:59:2f:f9:3c:64:18:
+        8f:95:90:a4:b1:27:3e:ce:32:6c:2d:34:2e:de:4b:9b:96:0a:
+        9c:1b:77:c4:ec:58:8e:6a:a2:52:3d:b9:04:28:3e:33:d4:52:
+        40:75:88:b5:e0:f0:1b:24:2c:8c:52:8e:bb:0f:7c:3d:78:8e:
+        c8:5d:b2:27:51:7d:e8:8c:32:ae:e4:8c:ea:0f:65:67:aa:39:
+        e7:cf:ac:01:62:3a:56:48:45:c4:4f:8b:76:19:42:5a:c6:b2:
+        70:f8:77:a7:b5:79:69:43:16:d0:27:53:80:5a:54:b9:e4:70:
+        8b:76:7d:a0:4f:15:1c:13:12:1c:a4:20:cd:b6:17:70:4f:b5:
+        13:88:ac:78:be:55:26:f6:d2:e1:f1:f6:d8:69:c2:ef:e7:df:
+        86:eb:e2:2e:38:4f:9a:b3:df:79:dd:35:83:d1:b1:7c:8d:37:
+        e4:b2:99:df:fe:f1:91:1a:59:f9:db:a9:70:f6:f5:2c:45:7b:
+        d0:68:73:ec
+-----BEGIN CERTIFICATE-----
+MIIC5TCCAc2gAwIBAgIJAOj4rZ6hhovbMA0GCSqGSIb3DQEBBQUAMBMxETAPBgNV
+BAMTCFRlc3Ryb290MB4XDTE4MDExNTE1NTExNFoXDTI4MDExMzE1NTExNFowHDEa
+MBgGA1UEAxMRU0FOVVJJTm9BdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQC7ORX4z/Pickqjd2bEL0fTrX9iEWf6h/YWOItixaSg6IouCfED
+2J901UVmkgzA5ek2XRCtjW0AkJt8f2/Il3SvX6MwxdZY5ArblvmQSWSRogdjX0Mv
+805Ym7pWK1kiYLyUVWYlIBaLSuhpS4fzz3PxHQyhVTeVfKoelMthTjdswIJLp95d
+9T/I9/BtAi2qPQZxXBKhGMzBgUMF3YF85Kn+f5DE5FFAnELSz7iTtUdaWAh23R5D
+qofOBj67gMfFPjYW5qOKi9Nw99BxLtHGGapDkFl/KfATMdBGlyxuN2VzA06mB+g0
+LytH3HDblUU3mroYV5K32uC11+r3p4FWQohZAgMBAAGjMzAxMC8GA1UdEQQoMCaC
+DSouZXhhbXBsZS5jb22GFXNpcDphbGljZUBzaXAudXJpLmNvbTANBgkqhkiG9w0B
+AQUFAAOCAQEApV55p8rpK2GHqO2T+0tPIb3hwBz3OJDh/Od013B6R8cHf1wgSKUs
+cw2pxblgwaOGNRhVra2U0mQSjjRA/PHjhIfmWS/5PGQYj5WQpLEnPs4ybC00Lt5L
+m5YKnBt3xOxYjmqiUj25BCg+M9RSQHWIteDwGyQsjFKOuw98PXiOyF2yJ1F96Iwy
+ruSM6g9lZ6o558+sAWI6VkhFxE+LdhlCWsaycPh3p7V5aUMW0CdTgFpUueRwi3Z9
+oE8VHBMSHKQgzbYXcE+1E4iseL5VJvbS4fH22GnC7+ffhuviLjhPmrPfed01g9Gx
+fI035LKZ3/7xkRpZ+dupcPb1LEV70Ghz7A==
+-----END CERTIFICATE-----

--- a/util/fqdn.go
+++ b/util/fqdn.go
@@ -62,7 +62,7 @@ func GetAuthority(uri string) string {
 func GetHost(auth string) string {
 	begin := strings.Index(auth, "@")
 	if begin == -1 || begin == len(auth)-1 {
-		return ""
+		begin = -1
 	}
 	end := strings.Index(auth, ":")
 	if end == -1 {
@@ -75,10 +75,14 @@ func GetHost(auth string) string {
 }
 
 func AuthIsFQDNOrIP(auth string) bool {
-	if IsFQDN(auth) {
+	return IsFQDNOrIP(GetHost(auth))
+}
+
+func IsFQDNOrIP(host string) bool {
+	if IsFQDN(host) {
 		return true
 	}
-	if net.ParseIP(auth) != nil {
+	if net.ParseIP(host) != nil {
 		return true
 	}
 	return false

--- a/util/fqdn_test.go
+++ b/util/fqdn_test.go
@@ -96,6 +96,59 @@ func TestIsFQDNNotFQDN(t *testing.T) {
 	}
 }
 
+func TestGetAuthorityBadURI(t *testing.T) {
+	uri := "not//a/valid/uri"
+	expected := ""
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostBadURI(t *testing.T) {
+	uri := "not//a/valid/uri"
+	expected := ""
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityRootless(t *testing.T) {
+	uri := "sip:user@host.com"
+	expected := ""
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostRootless(t *testing.T) {
+	uri := "sip:user@host.com"
+	expected := ""
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
 func TestGetAuthorityNoUserinfoNoPortNoAbsolutePathNoQueryNoFragment(t *testing.T) {
 	uri := "scheme://host.com"
 	expected := "host.com"

--- a/util/fqdn_test.go
+++ b/util/fqdn_test.go
@@ -95,3 +95,867 @@ func TestIsFQDNNotFQDN(t *testing.T) {
 		)
 	}
 }
+
+func TestGetAuthorityNoUserinfoNoPortNoAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com"
+	expected := "host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoNoPortNoAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoNoPortNoAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com"
+	expected := "user@host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoNoPortNoAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoWithPortNoAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com:123"
+	expected := "host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoWithPortNoAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com:123"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoWithPortNoAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123"
+	expected := "user@host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoWithPortNoAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoNoPortWithAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com/path/to/something"
+	expected := "host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoNoPortWithAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com/path/to/something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoNoPortWithAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com/path/to/something"
+	expected := "user@host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoNoPortWithAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com/path/to/something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoWithPortWithAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com:123/path/to/something"
+	expected := "host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoWithPortWithAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com:123/path/to/something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoWithPortWithAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123/path/to/something"
+	expected := "user@host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoWithPortWithAbsolutePathNoQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123/path/to/something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoNoPortNoAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com?query=something"
+	expected := "host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoNoPortNoAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com?query=something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoNoPortNoAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com?query=something"
+	expected := "user@host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoNoPortNoAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com?query=something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoWithPortNoAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com:123?query=something"
+	expected := "host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoWithPortNoAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com:123?query=something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoWithPortNoAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123?query=something"
+	expected := "user@host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoWithPortNoAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123?query=something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoNoPortWithAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com/path/to/something?query=something"
+	expected := "host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoNoPortWithAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com/path/to/something?query=something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoNoPortWithAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com/path/to/something?query=something"
+	expected := "user@host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoNoPortWithAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com/path/to/something?query=something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoWithPortWithAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com:123/path/to/something?query=something"
+	expected := "host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoWithPortWithAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://host.com:123/path/to/something?query=something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoWithPortWithAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123/path/to/something?query=something"
+	expected := "user@host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoWithPortWithAbsolutePathWithQueryNoFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123/path/to/something?query=something"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoNoPortNoAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com#fragment"
+	expected := "host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoNoPortNoAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoNoPortNoAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com#fragment"
+	expected := "user@host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoNoPortNoAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoWithPortNoAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com:123#fragment"
+	expected := "host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoWithPortNoAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com:123#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoWithPortNoAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123#fragment"
+	expected := "user@host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoWithPortNoAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoNoPortWithAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com/path/to/something#fragment"
+	expected := "host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoNoPortWithAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com/path/to/something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoNoPortWithAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com/path/to/something#fragment"
+	expected := "user@host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoNoPortWithAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com/path/to/something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoWithPortWithAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com:123/path/to/something#fragment"
+	expected := "host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoWithPortWithAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com:123/path/to/something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoWithPortWithAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123/path/to/something#fragment"
+	expected := "user@host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoWithPortWithAbsolutePathNoQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123/path/to/something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoNoPortNoAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com?query=something#fragment"
+	expected := "host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoNoPortNoAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com?query=something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoNoPortNoAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com?query=something#fragment"
+	expected := "user@host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoNoPortNoAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com?query=something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoWithPortNoAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com:123?query=something#fragment"
+	expected := "host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoWithPortNoAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com:123?query=something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoWithPortNoAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123?query=something#fragment"
+	expected := "user@host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoWithPortNoAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123?query=something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoNoPortWithAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com/path/to/something?query=something#fragment"
+	expected := "host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoNoPortWithAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com/path/to/something?query=something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoNoPortWithAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com/path/to/something?query=something#fragment"
+	expected := "user@host.com"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoNoPortWithAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com/path/to/something?query=something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityNoUserinfoWithPortWithAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com:123/path/to/something?query=something#fragment"
+	expected := "host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostNoUserinfoWithPortWithAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://host.com:123/path/to/something?query=something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetAuthorityWithUserinfoWithPortWithAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123/path/to/something?query=something#fragment"
+	expected := "user@host.com:123"
+	actual := GetAuthority(uri)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestGetHostWithUserinfoWithPortWithAbsolutePathWithQueryWithFragment(t *testing.T) {
+	uri := "scheme://user@host.com:123/path/to/something?query=something#fragment"
+	expected := "host.com"
+	authority := GetAuthority(uri)
+	actual := GetHost(authority)
+	if expected != actual {
+		t.Error(
+			"For", uri,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}


### PR DESCRIPTION
Two issues were identified in https://github.com/zmap/zlint/issues/198 -- 

1. util.GetHost doesn't act as expected (returns empty string for valid URIs)
2. Two test certs had mistakenly-invalid URIs (`test//` instead of `test://`)

The problem with util.GetHost seems to be that it expected an authority (not a full URI, as was being passed to it by the lint), and further it required that authority to have a userinfo piece -- see https://tools.ietf.org/html/rfc3986#section-3.2). The lint now uses the built-in `net/url.Parse().Host` to get the host name, and `util.IsFQDNOrIP(parsed.Host)` to check its validity.

The test certs were replaced with certificates having the same SAN, but with `test://` instead of `test//`.