### PR TITLE
Fix for 7.1.6.1 tests -- only state/locality only required in subscribers

### DIFF
--- a/lints/lint_cert_policy_iv_requires_province_or_locality.go
+++ b/lints/lint_cert_policy_iv_requires_province_or_locality.go
@@ -12,7 +12,8 @@
  * permissions and limitations under the License.
  */
 
-/*If the Certificate asserts the policy identifier of 2.23.140.1.2.3, then it MUST also include (i) either organizationName or givenName and surname, (ii) localityName (to the extent such field is required under Section 7.1.4.2.2), (iii) stateOrProvinceName (to the extent required under Section 7.1.4.2.2), and (iv) countryName in the Subject field.*/
+// 7.1.6.1: If the Certificate asserts the policy identifier of 2.23.140.1.2.3, then it MUST also include (i) either organizationName or givenName and surname, (ii) localityName (to the extent such field is required under Section 7.1.4.2.2), (iii) stateOrProvinceName (to the extent required under Section 7.1.4.2.2), and (iv) countryName in the Subject field.
+// 7.1.4.2.2 applies only to subscriber certificates.
 
 package lints
 
@@ -28,7 +29,7 @@ func (l *CertPolicyIVRequiresProvinceOrLocal) Initialize() error {
 }
 
 func (l *CertPolicyIVRequiresProvinceOrLocal) CheckApplies(cert *x509.Certificate) bool {
-	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BRIndividualValidatedOID)
+	return util.IsSubscriberCert(cert) && util.SliceContainsOID(cert.PolicyIdentifiers, util.BRIndividualValidatedOID)
 }
 
 func (l *CertPolicyIVRequiresProvinceOrLocal) Execute(cert *x509.Certificate) *LintResult {

--- a/lints/lint_cert_policy_ov_requires_province_or_locality.go
+++ b/lints/lint_cert_policy_ov_requires_province_or_locality.go
@@ -12,7 +12,8 @@
  * permissions and limitations under the License.
  */
 
-/*If the Certificate asserts the policy identifier of 2.23.140.1.2.2, then it MUST also include organizationName, localityName (to the extent such field is required under Section 7.1.4.2.2), stateOrProvinceName (to the extent such field is required under Section 7.1.4.2.2), and countryName in the Subject field.*/
+// 7.1.6.1: If the Certificate asserts the policy identifier of 2.23.140.1.2.2, then it MUST also include organizationName, localityName (to the extent such field is required under Section 7.1.4.2.2), stateOrProvinceName (to the extent such field is required under Section 7.1.4.2.2), and countryName in the Subject field.*/
+// 7.1.4.2.2 applies only to subscriber certificates.
 
 package lints
 
@@ -28,7 +29,7 @@ func (l *CertPolicyOVRequiresProvinceOrLocal) Initialize() error {
 }
 
 func (l *CertPolicyOVRequiresProvinceOrLocal) CheckApplies(cert *x509.Certificate) bool {
-	return util.SliceContainsOID(cert.PolicyIdentifiers, util.BROrganizationValidatedOID)
+	return util.IsSubscriberCert(cert) && util.SliceContainsOID(cert.PolicyIdentifiers, util.BROrganizationValidatedOID)
 }
 
 func (l *CertPolicyOVRequiresProvinceOrLocal) Execute(cert *x509.Certificate) *LintResult {


### PR DESCRIPTION
See #206 for discussion.

From 7.1.6.1: (https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.5.6.pdf)
> If the Certificate asserts the policy identifier of 2.23.140.1.2.2, then it MUST also include organizationName, localityName (to the extent such field is required under Section 7.1.4.2.2), stateOrProvinceName (to the extent such field is required under Section 7.1.4.2.2), and countryName in the Subject field. If the Certificate asserts the policy identifier of 2.23.140.1.2.3, then it MUST also include (i) either organizationName or givenName and surname, (ii) localityName (to the extent such field is required under Section 7.1.4.2.2), (iii) stateOrProvinceName (to the extent required under Section 7.1.4.2.2), and (iv) countryName in the Subject field.

And from 7.1.4.2 applies (only) to subscriber certificates.
