### PR TITLE
New SANOtherName test cert with CONSTRUCTED OtherName value

### DIFF
--- a/testlint/testCerts/SANOtherName.pem
+++ b/testlint/testCerts/SANOtherName.pem
@@ -1,118 +1,82 @@
+Generated with:
+#!/bin/bash -e
+echo "subjectAltName=DNS:dns.com,otherName:2.3.3;UTF8:hello" > SANOtherName.ext
+openssl req -new -subj '/CN=OtherName' -days 3650 -newkey rsa:2048 -sha256 -nodes -keyout SANOtherName.key -out SANOtherName.csr
+if ! [ -f "root.key" ]; then
+	echo "Generating self-signed root signer"
+	openssl req -new -x509 -subj "//CN=TestRoot" -days 3650 -newkey rsa:2048 -sha256 -nodes -keyout root.key -out root.cer
+fi
+openssl x509 -req -CA root.cer -CAkey root.key -CAcreateserial -in SANOtherName.csr -out SANOtherName.cer -days 3650 -extfile SANOtherName.ext
+openssl x509 -text < SANOtherName.cer > SANOtherName.pem
+
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 18008675309 (0x4316693ed)
+        Serial Number:
+            f7:f4:00:77:18:1b:21:f6
     Signature Algorithm: sha256WithRSAEncryption
-        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Name constraint
+        Issuer: CN=TestRoot
         Validity
-            Not Before: Dec  1 06:07:08 2055 GMT
-            Not After : Sep  2 04:05:10 2056 GMT
-        Subject: C = US, O = Extreme Discord, OU = Chaos, L = Tallahassee, ST = FL, street = 3210 Holly Mill Run, postalCode = 30062, CN = gov.us
+            Not Before: Mar 14 19:20:13 2018 GMT
+            Not After : Mar 11 19:20:13 2028 GMT
+        Subject: CN=OtherName
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (2048 bit)
                 Modulus:
-                    00:b3:37:11:a4:fa:aa:16:06:57:85:b6:9f:53:a4:
-                    cc:2b:20:1d:d7:bb:fe:63:b5:44:ee:8c:a8:f9:5e:
-                    4b:bd:ea:ca:1e:54:65:48:18:ba:15:4d:51:78:71:
-                    52:db:50:5f:ae:d1:03:25:a5:b9:1f:fe:ad:67:cb:
-                    04:58:6f:9c:ee:b9:9d:ac:89:fc:f4:49:f9:0c:6f:
-                    22:a7:96:5f:2a:ff:b3:b9:83:d0:da:11:56:bb:19:
-                    ff:1d:2b:21:2e:96:13:33:3d:89:80:49:8a:32:6d:
-                    db:aa:ee:f3:e9:a4:0d:3e:3b:5e:db:18:cb:00:a5:
-                    d7:cf:07:2e:51:7d:02:7f:d3:55:da:77:dd:6c:73:
-                    1b:ed:57:e7:36:92:58:25:46:20:71:0e:93:fe:6c:
-                    2e:c8:fe:62:fb:c9:28:dd:86:1f:25:1a:49:b5:3d:
-                    23:42:23:e4:75:0d:89:ac:b3:52:89:61:1d:1f:05:
-                    fb:83:6b:76:1a:ad:a6:b0:20:7f:3b:89:d6:c7:5b:
-                    7f:26:9f:ae:4e:ed:91:e3:b9:44:89:dd:c0:43:c5:
-                    09:85:4c:c4:66:45:d8:9d:68:42:3c:52:48:20:93:
-                    2d:df:2f:33:05:47:e1:90:ff:f4:2f:12:9a:bc:57:
-                    5f:f1:a6:fb:9b:07:58:a9:30:27:03:cc:fb:79:99:
-                    79:53
+                    00:bd:a4:07:88:60:35:46:fa:05:ef:25:17:9f:32:
+                    fc:94:57:4e:62:a9:26:85:49:bb:fb:58:88:5f:ef:
+                    54:4a:3a:89:b8:ce:02:f5:e0:a1:61:08:24:67:6a:
+                    ca:b1:df:17:90:2e:20:2e:64:63:6d:17:88:b7:8b:
+                    c6:e7:f2:01:1d:c5:64:25:87:e5:a8:3f:ea:a9:4c:
+                    eb:1d:39:35:ea:92:71:f3:ae:0f:ad:90:4c:94:ef:
+                    93:b3:3f:91:ac:6e:3b:b4:38:fd:0c:e8:0b:e5:a4:
+                    b9:5b:b0:0a:e3:9e:1f:19:cc:f8:ef:b8:b7:80:f1:
+                    03:98:49:35:05:fd:17:3b:0e:1b:b4:b9:96:f4:22:
+                    28:c8:4e:26:25:70:3b:94:9d:e0:45:18:14:e6:42:
+                    b0:80:48:50:9e:2d:78:5b:bf:50:55:e1:03:0f:c2:
+                    20:b8:ef:b4:1a:88:12:10:a6:29:c8:f4:02:e6:24:
+                    09:a8:31:d3:e8:4c:81:b5:17:7c:67:6c:12:51:9d:
+                    56:95:47:ef:57:a7:a0:b1:15:ba:db:be:07:ea:d6:
+                    b9:2d:a7:3e:75:e8:29:4d:c1:a3:5d:ab:39:ed:3a:
+                    a8:29:87:e3:43:35:83:04:f1:4f:d5:2b:0c:3b:24:
+                    b5:71:b1:ab:5d:e1:3c:5d:e2:4e:84:b8:a7:0b:e7:
+                    a4:bb
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
-            X509v3 Key Usage: critical
-                Digital Signature, Key Encipherment, Certificate Sign
-            X509v3 Extended Key Usage: 
-                TLS Web Client Authentication, TLS Web Server Authentication
-            X509v3 Basic Constraints: critical
-                CA:TRUE
-            X509v3 Authority Key Identifier: 
-                keyid:01:02:03
-
-            Authority Information Access: 
-                OCSP - URI:http://theca.net/ocsp
-                CA Issuers - URI:http://theca.net/totallythecert.crt
-
             X509v3 Subject Alternative Name: 
-                0.....S...hello..dns.com
-            X509v3 Certificate Policies: 
-                Policy: 2.23.140.1.2.2
-                Policy: 1.2.3.4.5
-
-            X509v3 Name Constraints: 
-                Permitted:
-                  email:good_email@gg.com
-                  email:LulMail
-                  DNS:permitted.com
-                  DirName:C = US, O = UIUC, OU = ECE, L = Champaign, ST = IL, street = 601 Wright St, postalCode = 61820, CN = uiuc.net
-                  IP:74.125.224.72/255.255.0.0
-                Excluded:
-                  email:bad_email@gg.com
-                  email:LulMail
-                  DNS:banned.com
-                  DirName:C = US, O = Umich, OU = CS, L = Ann Arbor, ST = MI, street = 500 State St, postalCode = 48109, CN = umich.net
-                  IP:192.168.1.1/255.255.0.0
-
+                DNS:dns.com, othername:<unsupported>
     Signature Algorithm: sha256WithRSAEncryption
-         22:96:f6:7f:6b:1e:79:b7:b0:ce:50:66:d0:a2:c6:b1:4b:d2:
-         35:a5:fd:bd:06:00:20:18:2a:ce:41:69:6f:01:6f:bc:96:a2:
-         21:ac:64:e7:f6:2d:3a:0b:0c:aa:73:39:12:dc:af:0e:a7:ef:
-         08:10:83:6a:63:d6:93:57:53:ae:da:93:48:26:38:4f:37:02:
-         55:e0:80:fe:01:ff:78:66:9f:b8:75:82:66:57:7d:19:9d:0c:
-         21:41:7f:af:af:2e:bc:b3:33:6f:d2:f7:d3:2a:a8:0b:d9:2c:
-         ae:dc:75:5b:86:27:51:8d:ce:2a:24:e5:9d:b7:c5:01:2a:df:
-         ff:d9:c6:79:80:aa:65:d7:c3:17:a6:ae:19:6c:f2:32:87:98:
-         46:78:4e:33:2a:dd:d9:89:15:f6:9b:ae:db:90:24:2d:b9:7e:
-         90:8a:a8:4d:8a:04:e1:49:78:84:66:5b:fe:2e:4f:80:a4:65:
-         42:c3:3a:b3:8c:96:06:97:fe:8b:b3:33:03:ea:be:5c:30:75:
-         e5:f1:2c:d1:7b:6f:08:6c:ef:e4:35:67:09:88:3f:d2:bd:0f:
-         92:30:99:e3:e7:38:b7:4f:fa:fb:e8:d7:92:5d:72:16:6e:3a:
-         1d:44:fb:0d:4c:f5:80:4f:4b:24:96:b0:38:05:2e:aa:9e:5c:
-         fd:cb:33:22
+         62:af:d3:2c:de:e6:23:95:e7:d0:34:7c:bf:06:67:15:b2:b5:
+         ca:ed:ef:0f:2a:4e:7c:a8:03:1d:1f:3f:a0:87:73:58:c1:6f:
+         b5:be:d5:e7:fc:72:35:3d:39:99:c2:51:98:8d:7c:78:97:7c:
+         e3:1f:f7:89:26:25:7b:1a:06:be:1a:cb:df:7d:3b:aa:76:65:
+         8c:92:af:82:e5:b1:58:4a:ae:e5:15:50:63:7d:f2:34:4c:3c:
+         cc:c0:3f:2d:56:50:1a:ce:2d:c5:7c:37:fb:af:55:bc:c7:a8:
+         1e:5f:10:3f:01:a5:94:dc:7e:69:dd:9f:80:b4:21:6f:74:62:
+         8e:be:05:95:8d:85:e2:7e:ad:df:47:a2:01:61:7b:47:75:a1:
+         87:6c:12:bf:03:19:60:60:d0:fd:f7:f3:46:f3:f8:8a:5b:18:
+         76:b0:94:05:6b:95:d7:b8:54:ad:96:a9:5d:e2:58:21:a7:43:
+         38:91:1d:0d:e1:93:1d:c7:38:7a:c5:05:94:e0:ae:a5:9e:32:
+         fc:0e:a4:58:4d:40:15:ac:29:2e:95:d7:8e:d8:70:31:98:79:
+         fa:1f:2f:74:03:a2:94:38:a6:a5:0c:d1:91:f5:77:4e:4e:64:
+         e1:40:9e:5b:c1:8a:87:62:74:19:ca:51:9f:3a:20:cf:33:32:
+         5c:d7:bf:0f
 -----BEGIN CERTIFICATE-----
-MIIGGDCCBQKgAwIBAgIFBDFmk+0wCwYJKoZIhvcNAQELMFYxCzAJBgNVBAYTAlVT
-MRYwFAYDVQQKEw1Nb3RoZXIgTmF0dXJlMRMwEQYDVQQLEwpFdmVyeXRoaW5nMRgw
-FgYDVQQDEw9OYW1lIGNvbnN0cmFpbnQxADAiGA8yMDU1MTIwMTA2MDcwOFoYDzIw
-NTYwOTAyMDQwNTEwWjCBmzELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD0V4dHJlbWUg
-RGlzY29yZDEOMAwGA1UECxMFQ2hhb3MxFDASBgNVBAcTC1RhbGxhaGFzc2VlMQsw
-CQYDVQQIEwJGTDEcMBoGA1UECRMTMzIxMCBIb2xseSBNaWxsIFJ1bjEOMAwGA1UE
-ERMFMzAwNjIxDzANBgNVBAMTBmdvdi51czEAMIIBIjANBgkqhkiG9w0BAQEFAAOC
-AQ8AMIIBCgKCAQEAszcRpPqqFgZXhbafU6TMKyAd17v+Y7VE7oyo+V5LverKHlRl
-SBi6FU1ReHFS21BfrtEDJaW5H/6tZ8sEWG+c7rmdrIn89En5DG8ip5ZfKv+zuYPQ
-2hFWuxn/HSshLpYTMz2JgEmKMm3bqu7z6aQNPjte2xjLAKXXzwcuUX0Cf9NV2nfd
-bHMb7VfnNpJYJUYgcQ6T/mwuyP5i+8ko3YYfJRpJtT0jQiPkdQ2JrLNSiWEdHwX7
-g2t2Gq2msCB/O4nWx1t/Jp+uTu2R47lEid3AQ8UJhUzEZkXYnWhCPFJIIJMt3y8z
-BUfhkP/0LxKavFdf8ab7mwdYqTAnA8z7eZl5UwIDAQABo4ICpTCCAqEwDgYDVR0P
-AQH/BAQDAgCkMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAPBgNVHRMB
-Af8EBTADAQH/MA4GA1UdIwQHMAWAAwECAzBiBggrBgEFBQcBAQRWMFQwIQYIKwYB
-BQUHMAGGFWh0dHA6Ly90aGVjYS5uZXQvb2NzcDAvBggrBgEFBQcwAoYjaHR0cDov
-L3RoZWNhLm5ldC90b3RhbGx5dGhlY2VydC5jcnQwHwYDVR0RBBgwFqALBgJTAxMF
-aGVsbG+CB2Rucy5jb20wGwYDVR0gBBQwEjAIBgZngQwBAgIwBgYEKgMEBTCCAasG
-A1UdHgSCAaIwggGeoIHOMBOBEWdvb2RfZW1haWxAZ2cuY29tMAmBB0x1bE1haWww
-D4INcGVybWl0dGVkLmNvbTCBjqSBizCBiDELMAkGA1UEBhMCVVMxDTALBgNVBAoT
-BFVJVUMxDDAKBgNVBAsTA0VDRTESMBAGA1UEBxMJQ2hhbXBhaWduMQswCQYDVQQI
-EwJJTDEWMBQGA1UECRMNNjAxIFdyaWdodCBTdDEOMAwGA1UEERMFNjE4MjAxETAP
-BgNVBAMTCHVpdWMubmV0MQAwCocISn3gSP//AAChgcowEoEQYmFkX2VtYWlsQGdn
-LmNvbTAJgQdMdWxNYWlsMAyCCmJhbm5lZC5jb20wgY6kgYswgYgxCzAJBgNVBAYT
-AlVTMQ4wDAYDVQQKEwVVbWljaDELMAkGA1UECxMCQ1MxEjAQBgNVBAcTCUFubiBB
-cmJvcjELMAkGA1UECBMCTUkxFTATBgNVBAkTDDUwMCBTdGF0ZSBTdDEOMAwGA1UE
-ERMFNDgxMDkxEjAQBgNVBAMTCXVtaWNoLm5ldDEAMAqHCMCoAQH//wAAMAsGCSqG
-SIb3DQEBCwOCAQEAIpb2f2seebewzlBm0KLGsUvSNaX9vQYAIBgqzkFpbwFvvJai
-Iaxk5/YtOgsMqnM5EtyvDqfvCBCDamPWk1dTrtqTSCY4TzcCVeCA/gH/eGafuHWC
-Zld9GZ0MIUF/r68uvLMzb9L30yqoC9ksrtx1W4YnUY3OKiTlnbfFASrf/9nGeYCq
-ZdfDF6auGWzyMoeYRnhOMyrd2YkV9puu25AkLbl+kIqoTYoE4Ul4hGZb/i5PgKRl
-QsM6s4yWBpf+i7MzA+q+XDB15fEs0XtvCGzv5DVnCYg/0r0PkjCZ4+c4t0/6++jX
-kl1yFm46HUT7DUz1gE9LJJawOAUuqp5c/cszIg==
+MIICzzCCAbegAwIBAgIJAPf0AHcYGyH2MA0GCSqGSIb3DQEBCwUAMBMxETAPBgNV
+BAMTCFRlc3RSb290MB4XDTE4MDMxNDE5MjAxM1oXDTI4MDMxMTE5MjAxM1owFDES
+MBAGA1UEAxMJT3RoZXJOYW1lMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAvaQHiGA1RvoF7yUXnzL8lFdOYqkmhUm7+1iIX+9USjqJuM4C9eChYQgkZ2rK
+sd8XkC4gLmRjbReIt4vG5/IBHcVkJYflqD/qqUzrHTk16pJx864PrZBMlO+Tsz+R
+rG47tDj9DOgL5aS5W7AK454fGcz477i3gPEDmEk1Bf0XOw4btLmW9CIoyE4mJXA7
+lJ3gRRgU5kKwgEhQni14W79QVeEDD8IguO+0GogSEKYpyPQC5iQJqDHT6EyBtRd8
+Z2wSUZ1WlUfvV6egsRW6274H6ta5Lac+degpTcGjXas57TqoKYfjQzWDBPFP1SsM
+OyS1cbGrXeE8XeJOhLinC+ekuwIDAQABoyUwIzAhBgNVHREEGjAYggdkbnMuY29t
+oA0GAlMDoAcMBWhlbGxvMA0GCSqGSIb3DQEBCwUAA4IBAQBir9Ms3uYjlefQNHy/
+BmcVsrXK7e8PKk58qAMdHz+gh3NYwW+1vtXn/HI1PTmZwlGYjXx4l3zjH/eJJiV7
+Gga+GsvffTuqdmWMkq+C5bFYSq7lFVBjffI0TDzMwD8tVlAazi3FfDf7r1W8x6ge
+XxA/AaWU3H5p3Z+AtCFvdGKOvgWVjYXifq3fR6IBYXtHdaGHbBK/AxlgYND99/NG
+8/iKWxh2sJQFa5XXuFStlqld4lghp0M4kR0N4ZMdxzh6xQWU4K6lnjL8DqRYTUAV
+rCkuldeO2HAxmHn6Hy90A6KUOKalDNGR9XdOTmThQJ5bwYqHYnQZylGfOiDPMzJc
+178P
 -----END CERTIFICATE-----


### PR DESCRIPTION
Re issue #211. After updating, `go test` passes with on `docker run --rm -it golang:1.10`.

The new certificate is  quite different from the original (which was ~pathological~ challenging in a number of other ways), but it does have an OtherName SAN attribute, which seems to be the relevant attribute.