### PR TITLE
Fix misuse of lint-global state

### DIFF
--- a/lints/lint_generalized_time_not_in_zulu.go
+++ b/lints/lint_generalized_time_not_in_zulu.go
@@ -33,8 +33,6 @@ import (
 )
 
 type generalizedNotZulu struct {
-	date1Gen bool
-	date2Gen bool
 }
 
 func (l *generalizedNotZulu) Initialize() error {
@@ -44,19 +42,22 @@ func (l *generalizedNotZulu) Initialize() error {
 func (l *generalizedNotZulu) CheckApplies(c *x509.Certificate) bool {
 	firstDate, secondDate := util.GetTimes(c)
 	beforeTag, afterTag := util.FindTimeType(firstDate, secondDate)
-	l.date1Gen = beforeTag == 24
-	l.date2Gen = afterTag == 24
-	return l.date1Gen || l.date2Gen
+	date1Gen := beforeTag == 24
+	date2Gen := afterTag == 24
+	return date1Gen || date2Gen
 }
 
 func (l *generalizedNotZulu) Execute(c *x509.Certificate) *LintResult {
 	date1, date2 := util.GetTimes(c)
-	if l.date1Gen {
+	beforeTag, afterTag := util.FindTimeType(date1, date2)
+	date1Gen := beforeTag == 24
+	date2Gen := afterTag == 24
+	if date1Gen {
 		if date1.Bytes[len(date1.Bytes)-1] != 'Z' {
 			return &LintResult{Status: Error}
 		}
 	}
-	if l.date2Gen {
+	if date2Gen {
 		if date2.Bytes[len(date2.Bytes)-1] != 'Z' {
 			return &LintResult{Status: Error}
 		}

--- a/lints/lint_utc_time_not_in_zulu.go
+++ b/lints/lint_utc_time_not_in_zulu.go
@@ -41,8 +41,6 @@ import (
 )
 
 type utcTimeGMT struct {
-	date1Utc bool
-	date2Utc bool
 }
 
 func (l *utcTimeGMT) Initialize() error {
@@ -52,18 +50,22 @@ func (l *utcTimeGMT) Initialize() error {
 func (l *utcTimeGMT) CheckApplies(c *x509.Certificate) bool {
 	firstDate, secondDate := util.GetTimes(c)
 	beforeTag, afterTag := util.FindTimeType(firstDate, secondDate)
-	l.date1Utc = beforeTag == 23
-	l.date2Utc = afterTag == 23
-	return l.date1Utc || l.date2Utc
+	date1Utc := beforeTag == 23
+	date2Utc := afterTag == 23
+	return date1Utc || date2Utc
 }
 
 func (l *utcTimeGMT) Execute(c *x509.Certificate) *LintResult {
 	var r LintStatus
-	if l.date1Utc {
+	firstDate, secondDate := util.GetTimes(c)
+	beforeTag, afterTag := util.FindTimeType(firstDate, secondDate)
+	date1Utc := beforeTag == 23
+	date2Utc := afterTag == 23
+	if date1Utc {
 		// UTC Tests on notBefore
 		utcNotGmt(c.NotBefore, &r)
 	}
-	if l.date2Utc {
+	if date2Utc {
 		// UTC Tests on NotAfter
 		utcNotGmt(c.NotAfter, &r)
 	}


### PR DESCRIPTION
Re: issue #212.

Previously, the lint object -- which is shared for all certificates -- was being used to store state for an individual certificate, under the assumption that `CheckApplies(cert1)` would be followed immediately by `Execute(cert1)`.

This is not even necessarily so in a single-threaded case, let alone a multi-threaded case.