### PR TITLE
Fix lint description

### DIFF
--- a/lints/lint_sub_cert_eku_extra_values.go
+++ b/lints/lint_sub_cert_eku_extra_values.go
@@ -55,7 +55,7 @@ func (l *subExtKeyUsageLegalUsage) Execute(c *x509.Certificate) *LintResult {
 func init() {
 	RegisterLint(&Lint{
 		Name:          "w_sub_cert_eku_extra_values",
-		Description:   "Subscriber Certificate: extKeyUsage either the value id-kp-serverAuth or id-kp-clientAuth or both values MUST be present.",
+		Description:   "Subscriber Certificate: extKeyUsage values other than id-kp-serverAuth, id-kp-clientAuth, and id-kp-emailProtection SHOULD NOT be present.",
 		Citation:      "BRs: 7.1.2.3",
 		Source:        CABFBaselineRequirements,
 		EffectiveDate: util.CABEffectiveDate,


### PR DESCRIPTION
The lint description was incorrectly duplicated from `e_sub_cert_eku_server_auth_client_auth_missing`.

Discussion at https://groups.google.com/d/msg/mozilla.dev.security.policy/qeP4LBr72kI/pgfovCB6BAAJ.