### PR TITLE
Update to tests to conform with RFC5891

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -141,7 +141,7 @@ func BenchmarkZlint(b *testing.B) {
 					"w_rsa_mod_factors_smaller_than_752", "e_dnsname_bad_character_in_label", "w_subject_dn_leading_whitespace",
 					"w_subject_dn_trailing_whitespace", "w_multiple_subject_rdn", "e_ext_san_dns_not_ia5_string",
 					"e_ext_san_empty_name", "e_dnsname_not_valid_tld", "e_dnsname_contains_bare_iana_suffix",
-					"e_dnsname_wildcard_only_in_left_label", "e_international_dns_name_not_nfkc", "e_dnsname_left_label_wildcard_correct",
+					"e_dnsname_wildcard_only_in_left_label", "e_international_dns_name_not_nfc", "e_dnsname_left_label_wildcard_correct",
 					"e_international_dns_name_not_unicode", "w_issuer_dn_trailing_whitespace", "w_issuer_dn_leading_whitespace",
 					"w_multiple_issuer_rdn", "e_dnsname_empty_label", "e_dnsname_label_too_long", "e_distribution_point_incomplete",
 					"e_wrong_time_format_pre2050", "e_utc_time_does_not_include_seconds", "e_sub_cert_not_is_ca", "w_rsa_mod_not_odd",

--- a/lints/lint_idn_dnsname_must_be_nfc.go
+++ b/lints/lint_idn_dnsname_must_be_nfc.go
@@ -23,17 +23,17 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-type IDNNotNFKC struct{}
+type IDNNotNFC struct{}
 
-func (l *IDNNotNFKC) Initialize() error {
+func (l *IDNNotNFC) Initialize() error {
 	return nil
 }
 
-func (l *IDNNotNFKC) CheckApplies(c *x509.Certificate) bool {
+func (l *IDNNotNFC) CheckApplies(c *x509.Certificate) bool {
 	return util.IsExtInCert(c, util.SubjectAlternateNameOID)
 }
 
-func (l *IDNNotNFKC) Execute(c *x509.Certificate) *LintResult {
+func (l *IDNNotNFC) Execute(c *x509.Certificate) *LintResult {
 	for _, dns := range c.DNSNames {
 		labels := strings.Split(dns, ".")
 		for _, label := range labels {
@@ -42,7 +42,7 @@ func (l *IDNNotNFKC) Execute(c *x509.Certificate) *LintResult {
 				if err != nil {
 					return &LintResult{Status: NA}
 				}
-				if !norm.NFKC.IsNormalString(unicodeLabel) {
+				if !norm.NFC.IsNormalString(unicodeLabel) {
 					return &LintResult{Status: Error}
 				}
 			}
@@ -53,11 +53,11 @@ func (l *IDNNotNFKC) Execute(c *x509.Certificate) *LintResult {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "e_international_dns_name_not_nfkc",
-		Description:   "Internationalized DNSNames must be normalized by unicode normalization form KC",
-		Citation:      "RFC 3490",
-		Source:        RFC5280,
-		EffectiveDate: util.RFC3490Date,
-		Lint:          &IDNNotNFKC{},
+		Name:          "e_international_dns_name_not_nfc",
+		Description:   "Internationalized DNSNames must be normalized by unicode normalization form C",
+		Citation:      "RFC 5890",
+		Source:        RFC5891,
+		EffectiveDate: util.RFC5890Date,
+		Lint:          &IDNNotNFC{},
 	})
 }

--- a/lints/lint_idn_dnsname_must_be_nfc_test.go
+++ b/lints/lint_idn_dnsname_must_be_nfc_test.go
@@ -18,19 +18,19 @@ import (
 	"testing"
 )
 
-func TestIDNDnsNameNotNFKC(t *testing.T) {
-	inputPath := "../testlint/testCerts/dnsNamesNotNFKC.pem"
+func TestIDNDnsNameNotNFC(t *testing.T) {
+	inputPath := "../testlint/testCerts/dnsNamesNotNFC.pem"
 	expected := Error
-	out := Lints["e_international_dns_name_not_nfkc"].Execute(ReadCertificate(inputPath))
+	out := Lints["e_international_dns_name_not_nfc"].Execute(ReadCertificate(inputPath))
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
 
-func TestIDNDnsNameIsNFKC(t *testing.T) {
-	inputPath := "../testlint/testCerts/dnsNamesNFKC.pem"
+func TestIDNDnsNameIsNFC(t *testing.T) {
+	inputPath := "../testlint/testCerts/dnsNamesNFC.pem"
 	expected := Pass
-	out := Lints["e_international_dns_name_not_nfkc"].Execute(ReadCertificate(inputPath))
+	out := Lints["e_international_dns_name_not_nfc"].Execute(ReadCertificate(inputPath))
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}

--- a/testlint/testCerts/dnsNamesNFC.pem
+++ b/testlint/testCerts/dnsNamesNFC.pem
@@ -1,0 +1,136 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            33:eb:70:07:cc:9e:25:87:68:e0:58:6b:f2:7b:4f:ea
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, O=thawte, Inc., OU=Domain Validated SSL, CN=thawte DV SSL CA - G2
+        Validity
+            Not Before: Aug 26 00:00:00 2016 GMT
+            Not After : Aug 26 23:59:59 2017 GMT
+        Subject: CN=\xD0\xB0\xD0\xB4\xD0\xB2\xD0\xBE\xD0\xBA\xD0\xB0\xD1\x82\xD1\x81\xD0\xBA\xD0\xB0\xD1\x8F-\xD0\xBA\xD0\xBE\xD0\xBD\xD1\x82\xD0\xBE\xD1\x80\xD0\xB0.\xD0\xBC\xD0\xBE\xD1\x81\xD0\xBA\xD0\xB2\xD0\xB0
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c1:2c:87:02:18:56:ab:dd:16:14:5f:c5:07:5d:
+                    8d:61:ef:4e:73:ac:5e:16:e5:90:ff:01:64:15:f9:
+                    4a:37:1b:50:0a:40:0f:84:fe:a9:2d:b3:0f:e7:f3:
+                    e0:90:5b:4b:40:b1:ce:e3:35:1b:73:61:14:67:53:
+                    d1:06:1a:93:f9:c5:11:2e:3b:73:3a:5e:95:ab:0a:
+                    14:aa:92:04:c7:eb:fa:8f:9e:3c:6c:b2:82:da:39:
+                    63:c0:ab:ff:1b:8f:67:29:e8:0e:8e:11:cd:7c:10:
+                    00:f9:d4:0a:01:7c:16:9e:cd:02:65:bf:ff:be:b7:
+                    1f:c9:ef:64:d0:31:46:e0:a0:55:6b:19:9e:ce:5e:
+                    57:44:58:ce:67:3c:70:d2:b3:93:e1:e8:42:47:d0:
+                    17:80:f6:70:a5:af:f6:4e:25:9d:c6:5e:cb:76:97:
+                    53:6c:ab:44:ae:c7:bc:bf:77:19:b1:75:e0:d4:d5:
+                    bc:88:26:d2:27:19:71:eb:9c:c0:da:75:f2:c6:4c:
+                    4e:fc:c8:35:e4:2e:54:e8:c6:14:5d:52:8d:ba:0e:
+                    d9:84:09:ed:14:3d:a3:06:7e:60:f2:b4:da:bf:ef:
+                    2a:49:e0:85:ea:bc:a1:22:55:22:65:a6:da:ef:ae:
+                    d5:94:03:92:db:78:a0:2f:b4:f3:e3:11:e5:f0:04:
+                    30:ed
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Alternative Name: 
+                DNS:xn----7sbaabin3cbc7afgb4aiqh6v.xn--80adxhks, DNS:www.xn----7sbaabin3cbc7afgb4aiqh6v.xn--80adxhks
+            X509v3 Basic Constraints: 
+                CA:FALSE
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://tn.symcb.com/tn.crl
+
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+                  CPS: https://www.thawte.com/cps
+                  User Notice:
+                    Explicit Text: https://www.thawte.com/repository
+
+            X509v3 Authority Key Identifier: 
+                keyid:9F:B8:C1:A9:6C:F2:F5:C0:22:2A:94:ED:5C:99:AC:D4:EC:D7:C6:07
+
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            Authority Information Access: 
+                OCSP - URI:http://tn.symcd.com
+                CA Issuers - URI:http://tn.symcb.com/tn.crt
+
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1(0)
+                    Log ID    : DD:EB:1D:2B:7A:0D:4F:A6:20:8B:81:AD:81:68:70:7E:
+                                2E:8E:9D:01:D5:5C:88:8D:3D:11:C4:CD:B6:EC:BE:CC
+                    Timestamp : Aug 26 19:16:18.144 2016 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:45:02:21:00:CD:9B:62:A1:52:80:36:A3:B8:F6:FA:
+                                6F:42:9A:95:88:5D:C9:12:09:E0:E4:C8:9B:1E:AF:5A:
+                                66:02:44:0F:AA:02:20:35:49:9B:2F:2B:73:58:E9:11:
+                                B3:D9:38:C3:9F:3A:FB:BA:08:99:39:5A:1D:67:34:3B:
+                                71:2E:EF:5E:42:FF:DE
+                Signed Certificate Timestamp:
+                    Version   : v1(0)
+                    Log ID    : A4:B9:09:90:B4:18:58:14:87:BB:13:A2:CC:67:70:0A:
+                                3C:35:98:04:F9:1B:DF:B8:E3:77:CD:0E:C8:0D:DC:10
+                    Timestamp : Aug 26 19:16:18.476 2016 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:46:02:21:00:A9:6B:80:D1:F4:C6:52:37:B2:EF:9E:
+                                56:F9:D2:FC:16:95:ED:DD:8D:A5:47:67:AB:67:D5:00:
+                                64:29:DE:BE:FA:02:21:00:A4:1E:3E:AD:0E:5D:1D:8F:
+                                C5:73:BD:1B:43:93:D5:1B:64:72:0C:CD:44:DB:78:B4:
+                                9C:C2:91:C8:9D:6B:77:1D
+    Signature Algorithm: sha256WithRSAEncryption
+         26:8c:ad:f2:c6:2b:58:c8:8c:85:f3:1b:0a:27:9b:20:7a:db:
+         82:af:e4:08:25:29:7b:29:2a:69:97:e0:d6:4a:60:0f:d5:29:
+         8c:f1:85:68:83:c0:78:30:ec:99:16:22:c9:1d:4c:42:20:0b:
+         83:97:79:16:65:05:22:13:aa:0a:90:84:18:9c:36:37:0f:ad:
+         ac:9f:2e:98:e0:51:7e:f5:81:39:f0:4e:b4:a4:12:d0:59:54:
+         7f:dc:37:15:c7:31:c6:6e:0b:69:8b:c4:91:83:bf:fd:f8:3c:
+         66:fe:f5:13:d7:5a:88:f3:42:53:eb:97:41:be:09:78:a7:a6:
+         c2:b9:72:b0:14:92:46:e5:98:31:84:8a:89:b7:f1:89:82:2d:
+         c5:ff:17:bd:fa:a6:de:8c:67:9c:ac:28:90:a5:c3:40:ae:a7:
+         50:d2:c2:a4:08:93:75:7f:ca:49:d1:c0:0e:c7:d0:dc:39:58:
+         62:28:7f:f8:a7:4b:cc:04:16:0f:91:2b:9b:7f:2d:71:d3:ab:
+         6a:f6:ed:fb:86:d4:d6:7a:18:18:40:92:75:83:65:60:11:1e:
+         55:81:62:dd:12:1d:bb:60:b6:17:a5:8e:07:3c:6c:50:10:8d:
+         4b:6f:4c:58:b0:ea:5a:43:74:cf:50:e6:fa:66:72:ed:5e:72:
+         74:87:3b:68
+-----BEGIN CERTIFICATE-----
+MIIF8zCCBNugAwIBAgIQM+twB8yeJYdo4Fhr8ntP6jANBgkqhkiG9w0BAQsFADBj
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMdGhhd3RlLCBJbmMuMR0wGwYDVQQLExRE
+b21haW4gVmFsaWRhdGVkIFNTTDEeMBwGA1UEAxMVdGhhd3RlIERWIFNTTCBDQSAt
+IEcyMB4XDTE2MDgyNjAwMDAwMFoXDTE3MDgyNjIzNTk1OVowPTE7MDkGA1UEAwwy
+0LDQtNCy0L7QutCw0YLRgdC60LDRjy3QutC+0L3RgtC+0YDQsC7QvNC+0YHQutCy
+0LAwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDBLIcCGFar3RYUX8UH
+XY1h705zrF4W5ZD/AWQV+Uo3G1AKQA+E/qktsw/n8+CQW0tAsc7jNRtzYRRnU9EG
+GpP5xREuO3M6XpWrChSqkgTH6/qPnjxssoLaOWPAq/8bj2cp6A6OEc18EAD51AoB
+fBaezQJlv/++tx/J72TQMUbgoFVrGZ7OXldEWM5nPHDSs5Ph6EJH0BeA9nClr/ZO
+JZ3GXst2l1Nsq0Sux7y/dxmxdeDU1byIJtInGXHrnMDadfLGTE78yDXkLlToxhRd
+Uo26DtmECe0UPaMGfmDytNq/7ypJ4IXqvKEiVSJlptrvrtWUA5LbeKAvtPPjEeXw
+BDDtAgMBAAGjggLHMIICwzBnBgNVHREEYDBegit4bi0tLS03c2JhYWJpbjNjYmM3
+YWZnYjRhaXFoNnYueG4tLTgwYWR4aGtzgi93d3cueG4tLS0tN3NiYWFiaW4zY2Jj
+N2FmZ2I0YWlxaDZ2LnhuLS04MGFkeGhrczAJBgNVHRMEAjAAMCsGA1UdHwQkMCIw
+IKAeoByGGmh0dHA6Ly90bi5zeW1jYi5jb20vdG4uY3JsMG4GA1UdIARnMGUwYwYG
+Z4EMAQIBMFkwJgYIKwYBBQUHAgEWGmh0dHBzOi8vd3d3LnRoYXd0ZS5jb20vY3Bz
+MC8GCCsGAQUFBwICMCMMIWh0dHBzOi8vd3d3LnRoYXd0ZS5jb20vcmVwb3NpdG9y
+eTAfBgNVHSMEGDAWgBSfuMGpbPL1wCIqlO1cmazU7NfGBzAOBgNVHQ8BAf8EBAMC
+BaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMFcGCCsGAQUFBwEBBEsw
+STAfBggrBgEFBQcwAYYTaHR0cDovL3RuLnN5bWNkLmNvbTAmBggrBgEFBQcwAoYa
+aHR0cDovL3RuLnN5bWNiLmNvbS90bi5jcnQwggEFBgorBgEEAdZ5AgQCBIH2BIHz
+APEAdgDd6x0reg1PpiCLga2BaHB+Lo6dAdVciI09EcTNtuy+zAAAAVbISARgAAAE
+AwBHMEUCIQDNm2KhUoA2o7j2+m9CmpWIXckSCeDkyJser1pmAkQPqgIgNUmbLytz
+WOkRs9k4w586+7oImTlaHWc0O3Eu715C/94AdwCkuQmQtBhYFIe7E6LMZ3AKPDWY
+BPkb37jjd80OyA3cEAAAAVbISAWsAAAEAwBIMEYCIQCpa4DR9MZSN7Lvnlb50vwW
+le3djaVHZ6tn1QBkKd6++gIhAKQePq0OXR2PxXO9G0OT1RtkcgzNRNt4tJzCkcid
+a3cdMA0GCSqGSIb3DQEBCwUAA4IBAQAmjK3yxitYyIyF8xsKJ5sgetuCr+QIJSl7
+KSppl+DWSmAP1SmM8YVog8B4MOyZFiLJHUxCIAuDl3kWZQUiE6oKkIQYnDY3D62s
+ny6Y4FF+9YE58E60pBLQWVR/3DcVxzHGbgtpi8SRg7/9+Dxm/vUT11qI80JT65dB
+vgl4p6bCuXKwFJJG5ZgxhIqJt/GJgi3F/xe9+qbejGecrCiQpcNArqdQ0sKkCJN1
+f8pJ0cAOx9DcOVhiKH/4p0vMBBYPkSubfy1x06tq9u37htTWehgYQJJ1g2VgER5V
+gWLdEh27YLYXpY4HPGxQEI1Lb0xYsOpaQ3TPUOb6ZnLtXnJ0hzto
+-----END CERTIFICATE-----

--- a/testlint/testCerts/dnsNamesNotNFC.pem
+++ b/testlint/testCerts/dnsNamesNotNFC.pem
@@ -1,0 +1,164 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            03:9f:94:ba:dc:79:8e:ea:44:f8:c8:1c:eb:05:15:02:48:71
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=US, O=Let's Encrypt, CN=Let's Encrypt Authority X3
+        Validity
+            Not Before: Aug 10 06:16:00 2017 GMT
+            Not After : Nov  8 06:16:00 2017 GMT
+        Subject: CN=xn--80aqafgnbi.xn--b1addckdrqixje4a.xn--p1ai
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:9d:71:73:1e:10:e8:82:44:fd:ba:31:e3:0d:bc:
+                    cf:61:25:28:e4:11:c1:a2:4d:e2:7e:e6:93:93:55:
+                    98:e9:38:26:67:f6:46:6e:cd:bb:1f:78:2d:e6:ed:
+                    51:6d:dd:f5:d7:78:cd:08:b8:87:f9:96:2a:8a:22:
+                    8d:54:a0:e4:f9:b8:5b:16:e2:93:4b:bd:3b:7c:9e:
+                    15:4b:38:bc:1e:95:bc:fc:d3:f6:e6:57:55:a8:26:
+                    d9:ba:69:0f:72:bb:4d:0f:0d:cd:77:55:6f:91:87:
+                    d6:56:99:27:c3:2a:8a:f9:da:83:b0:78:69:77:16:
+                    b2:24:32:ea:5a:41:7a:14:e4:78:c0:82:99:5c:b1:
+                    5f:e8:89:b2:32:72:53:ec:8d:14:3a:31:eb:cd:24:
+                    91:c1:9d:4d:78:b6:68:e0:e6:a2:52:c6:c4:12:95:
+                    d3:18:0e:24:49:5b:d3:b2:31:66:dd:c4:e0:1e:24:
+                    47:2f:2e:c6:bc:55:ce:d0:b2:04:27:44:f5:f0:dc:
+                    6e:5f:aa:9a:7d:59:31:5a:9b:53:ea:9e:c3:8a:63:
+                    91:b0:c1:73:d4:5f:51:56:aa:79:2f:10:1c:c5:28:
+                    e6:04:d9:2c:0e:b1:22:bc:6e:6d:01:ea:28:f5:b5:
+                    43:6c:c8:0d:04:bb:7e:50:31:75:06:f7:8f:02:02:
+                    8b:e7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                4B:A8:D1:93:E3:A6:27:D3:20:07:B2:5E:B0:92:94:F3:FF:97:C6:C6
+            X509v3 Authority Key Identifier: 
+                keyid:A8:4A:6A:63:04:7D:DD:BA:E6:D1:39:B7:A6:45:65:EF:F3:A8:EC:A1
+
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.int-x3.letsencrypt.org
+                CA Issuers - URI:http://cert.int-x3.letsencrypt.org/
+
+            X509v3 Subject Alternative Name: 
+                DNS:xn-----blcihca2aqinbjzlgp0hrd8c.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn----stbbzbh.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn---26-eddosn7a0ak4c.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--107-5cdaa2chp5aetkelu1c3g.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--109-3veba6djs1bfxlfmx6c9g.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--14-9kciiba3aqubi7af8gzc.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--178-5cdal0dh0aakkkhh1o3b.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--21-6kchp4azaxdj0m.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--43-6kcax4ab9bla4dyf.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--45-mlcapln4a3a9aq.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--46-mlcapln4a3a9aq.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--53-6kcax4ab9bla4dyf.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--79-6kcaa5bgn2aerjekt8bxg.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aa0ae6d.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aa2agjmejdq8j.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aae5ai2ao.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aaid2am2aa3a.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aalfubeujccihfbdgksb.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aalwqglfe.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aamvb5b.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aaprggi2f8a.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aaxgcd7ba.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80ab0ao1a1d.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80ab0aoui0e.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80abehftithlykeq2l.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80acvfdesq.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80afhlnque.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80ajjheoz9b0d.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80akigivw6f.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80akjla6aie.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80apatkjk7a7ea.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aqafgnbi.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80atubbebi.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--87-6kcden2ebx.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--90aeebatcosbh5acc0a6e7c.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--90aeebavmqbg3ad6ftc.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--90afcnzgq4e.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1acfsu9c.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1aebnvlkge.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1afkbfmlcogdgec.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1afkfklbqbiegx.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1afmgkbdfatdhn9d1c.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1ag8ag.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--c1akecd2av.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--e1aajhjwx1ao.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--e1aaqibces2d.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--e1agf3afz.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--g1ani7c.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--h1aaeyfh.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--h1aajcffjkhy9ij.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--h1adbc4dyb.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--i1ajfdfdg2g.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--j1aa0a.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--j1aacdjbokgr8i.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--j1acchbggkgr9i.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--j1ak.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--j1ao.xn--b1addckdrqixje4a.xn--p1ai
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+                Policy: 1.3.6.1.4.1.44947.1.1.1
+                  CPS: http://cps.letsencrypt.org
+                  User Notice:
+                    Explicit Text: This Certificate may only be relied upon by Relying Parties and only in accordance with the Certificate Policy found at https://letsencrypt.org/repository/
+
+    Signature Algorithm: sha256WithRSAEncryption
+         61:48:1c:0e:0c:10:78:74:70:0a:3a:43:45:67:26:8d:9e:aa:
+         52:40:20:a1:95:fa:31:b0:a4:61:ff:0a:e6:ba:ec:7e:9c:27:
+         d7:bd:73:80:07:6c:fb:7a:8f:5a:00:ba:24:9a:4b:a0:17:73:
+         6f:19:3f:28:3a:8e:39:f1:8f:5e:56:ce:9b:67:69:54:45:00:
+         1b:d5:68:14:a1:97:e7:f0:37:29:f5:2a:46:ae:ed:05:6d:71:
+         2b:4d:f2:92:8f:55:2f:70:61:f8:02:16:72:b7:51:85:91:24:
+         6d:38:c5:97:48:22:f9:e3:12:88:3b:c2:3a:b1:99:98:1b:dd:
+         a5:1d:90:9d:57:58:61:06:8e:3b:fa:5c:f7:b0:fe:10:60:f1:
+         a5:36:f4:55:f7:77:5d:d5:17:41:f1:66:2e:4a:d5:51:f6:d7:
+         2b:7d:a6:6e:4c:c4:63:9b:68:20:c8:ab:b6:be:45:8a:56:ab:
+         f1:19:66:bf:ac:e8:ec:b5:15:06:16:f4:18:71:61:91:e2:9e:
+         b4:d2:6b:30:cf:2d:07:d6:91:15:ab:8b:f3:ca:dc:e5:9a:f8:
+         cb:2a:69:dc:14:59:e4:7f:8b:2d:ac:5b:90:8d:9f:08:18:14:
+         36:91:03:c9:0c:57:00:77:00:65:72:a2:38:af:67:03:13:ea:
+         06:8a:b2:53
+-----BEGIN CERTIFICATE-----
+MIIQKTCCDxGgAwIBAgISA5+Uutx5jupE+Mgc6wUVAkhxMA0GCSqGSIb3DQEBCwUA
+MEoxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MSMwIQYDVQQD
+ExpMZXQncyBFbmNyeXB0IEF1dGhvcml0eSBYMzAeFw0xNzA4MTAwNjE2MDBaFw0x
+NzExMDgwNjE2MDBaMDcxNTAzBgNVBAMTLHhuLS04MGFxYWZnbmJpLnhuLS1iMWFk
+ZGNrZHJxaXhqZTRhLnhuLS1wMWFpMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEAnXFzHhDogkT9ujHjDbzPYSUo5BHBok3ifuaTk1WY6TgmZ/ZGbs27H3gt
+5u1Rbd3113jNCLiH+ZYqiiKNVKDk+bhbFuKTS707fJ4VSzi8HpW8/NP25ldVqCbZ
+umkPcrtNDw3Nd1VvkYfWVpknwyqK+dqDsHhpdxayJDLqWkF6FOR4wIKZXLFf6Imy
+MnJT7I0UOjHrzSSRwZ1NeLZo4OaiUsbEEpXTGA4kSVvTsjFm3cTgHiRHLy7GvFXO
+0LIEJ0T18NxuX6qafVkxWptT6p7DimORsMFz1F9RVqp5LxAcxSjmBNksDrEivG5t
+Aeoo9bVDbMgNBLt+UDF1BvePAgKL5wIDAQABo4INGjCCDRYwDgYDVR0PAQH/BAQD
+AgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAA
+MB0GA1UdDgQWBBRLqNGT46Yn0yAHsl6wkpTz/5fGxjAfBgNVHSMEGDAWgBSoSmpj
+BH3duubRObemRWXv86jsoTBvBggrBgEFBQcBAQRjMGEwLgYIKwYBBQUHMAGGImh0
+dHA6Ly9vY3NwLmludC14My5sZXRzZW5jcnlwdC5vcmcwLwYIKwYBBQUHMAKGI2h0
+dHA6Ly9jZXJ0LmludC14My5sZXRzZW5jcnlwdC5vcmcvMIILIwYDVR0RBIILGjCC
+CxaCPXhuLS0tLS1ibGNpaGNhMmFxaW5ianpsZ3AwaHJkOGMueG4tLWIxYWRkY2tk
+cnFpeGplNGEueG4tLXAxYWmCK3huLS0tLXN0YmJ6YmgueG4tLWIxYWRkY2tkcnFp
+eGplNGEueG4tLXAxYWmCM3huLS0tMjYtZWRkb3NuN2EwYWs0Yy54bi0tYjFhZGRj
+a2RycWl4amU0YS54bi0tcDFhaYI7eG4tLTEwNy01Y2RhYTJjaHA1YWV0a2VsdTFj
+M2cueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCO3huLS0xMDktM3ZlYmE2
+ZGpzMWJmeGxmbXg2YzlnLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgjl4
+bi0tMTQtOWtjaWliYTNhcXViaTdhZjhnemMueG4tLWIxYWRkY2tkcnFpeGplNGEu
+eG4tLXAxYWmCOnhuLS0xNzgtNWNkYWwwZGgwYWFra2toaDFvM2IueG4tLWIxYWRk
+Y2tkcnFpeGplNGEueG4tLXAxYWmCM3huLS0yMS02a2NocDRhemF4ZGowbS54bi0t
+YjFhZGRja2RycWl4amU0YS54bi0tcDFhaYI1eG4tLTQzLTZrY2F4NGFiOWJsYTRk
+eWYueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCM3huLS00NS1tbGNhcGxu
+NGEzYTlhcS54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFhaYIzeG4tLTQ2LW1s
+Y2FwbG40YTNhOWFxLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgjV4bi0t
+NTMtNmtjYXg0YWI5YmxhNGR5Zi54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFh
+aYI6eG4tLTc5LTZrY2FhNWJnbjJhZXJqZWt0OGJ4Zy54bi0tYjFhZGRja2RycWl4
+amU0YS54bi0tcDFhaYIreG4tLTgwYWEwYWU2ZC54bi0tYjFhZGRja2RycWl4amU0
+YS54bi0tcDFhaYIxeG4tLTgwYWEyYWdqbWVqZHE4ai54bi0tYjFhZGRja2RycWl4
+amU0YS54bi0tcDFhaYIteG4tLTgwYWFlNWFpMmFvLnhuLS1iMWFkZGNrZHJxaXhq
+ZTRhLnhuLS1wMWFpgjB4bi0tODBhYWlkMmFtMmFhM2EueG4tLWIxYWRkY2tkcnFp
+eGplNGEueG4tLXAxYWmCOHhuLS04MGFhbGZ1YmV1amNjaWhmYmRna3NiLnhuLS1i
+MWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgi14bi0tODBhYWx3cWdsZmUueG4tLWIx
+YWRkY2tkcnFpeGplNGEueG4tLXAxYWmCK3huLS04MGFhbXZiNWIueG4tLWIxYWRk
+Y2tkcnFpeGplNGEueG4tLXAxYWmCL3huLS04MGFhcHJnZ2kyZjhhLnhuLS1iMWFk
+ZGNrZHJxaXhqZTRhLnhuLS1wMWFpgi14bi0tODBhYXhnY2Q3YmEueG4tLWIxYWRk
+Y2tkcnFpeGplNGEueG4tLXAxYWmCLXhuLS04MGFiMGFvMWExZC54bi0tYjFhZGRj
+a2RycWl4amU0YS54bi0tcDFhaYIteG4tLTgwYWIwYW91aTBlLnhuLS1iMWFkZGNr
+ZHJxaXhqZTRhLnhuLS1wMWFpgjR4bi0tODBhYmVoZnRpdGhseWtlcTJsLnhuLS1i
+MWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgix4bi0tODBhY3ZmZGVzcS54bi0tYjFh
+ZGRja2RycWl4amU0YS54bi0tcDFhaYIseG4tLTgwYWZobG5xdWUueG4tLWIxYWRk
+Y2tkcnFpeGplNGEueG4tLXAxYWmCL3huLS04MGFqamhlb3o5YjBkLnhuLS1iMWFk
+ZGNrZHJxaXhqZTRhLnhuLS1wMWFpgi14bi0tODBha2lnaXZ3NmYueG4tLWIxYWRk
+Y2tkcnFpeGplNGEueG4tLXAxYWmCLXhuLS04MGFramxhNmFpZS54bi0tYjFhZGRj
+a2RycWl4amU0YS54bi0tcDFhaYIweG4tLTgwYXBhdGtqazdhN2VhLnhuLS1iMWFk
+ZGNrZHJxaXhqZTRhLnhuLS1wMWFpgix4bi0tODBhcWFmZ25iaS54bi0tYjFhZGRj
+a2RycWl4amU0YS54bi0tcDFhaYIseG4tLTgwYXR1YmJlYmkueG4tLWIxYWRkY2tk
+cnFpeGplNGEueG4tLXAxYWmCL3huLS04Ny02a2NkZW4yZWJ4LnhuLS1iMWFkZGNr
+ZHJxaXhqZTRhLnhuLS1wMWFpgjl4bi0tOTBhZWViYXRjb3NiaDVhY2MwYTZlN2Mu
+eG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCNXhuLS05MGFlZWJhdm1xYmcz
+YWQ2ZnRjLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgi14bi0tOTBhZmNu
+emdxNGUueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCK3huLS1iMWFjZnN1
+OWMueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCLXhuLS1iMWFlYm52bGtn
+ZS54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFhaYIyeG4tLWIxYWZrYmZtbGNv
+Z2RnZWMueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCMXhuLS1iMWFma2Zr
+bGJxYmllZ3gueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCNXhuLS1iMWFm
+bWdrYmRmYXRkaG45ZDFjLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgil4
+bi0tYjFhZzhhZy54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFhaYIseG4tLWMx
+YWtlY2QyYXYueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCLnhuLS1lMWFh
+amhqd3gxYW8ueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCLnhuLS1lMWFh
+cWliY2VzMmQueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCK3huLS1lMWFn
+ZjNhZnoueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCKXhuLS1nMWFuaTdj
+LnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgip4bi0taDFhYWV5ZmgueG4t
+LWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCMXhuLS1oMWFhamNmZmpraHk5aWou
+eG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCLHhuLS1oMWFkYmM0ZHliLnhu
+LS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgi14bi0taTFhamZkZmRnMmcueG4t
+LWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCKHhuLS1qMWFhMGEueG4tLWIxYWRk
+Y2tkcnFpeGplNGEueG4tLXAxYWmCMHhuLS1qMWFhY2RqYm9rZ3I4aS54bi0tYjFh
+ZGRja2RycWl4amU0YS54bi0tcDFhaYIweG4tLWoxYWNjaGJnZ2tncjlpLnhuLS1i
+MWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgiZ4bi0tajFhay54bi0tYjFhZGRja2Ry
+cWl4amU0YS54bi0tcDFhaYImeG4tLWoxYW8ueG4tLWIxYWRkY2tkcnFpeGplNGEu
+eG4tLXAxYWkwgf4GA1UdIASB9jCB8zAIBgZngQwBAgEwgeYGCysGAQQBgt8TAQEB
+MIHWMCYGCCsGAQUFBwIBFhpodHRwOi8vY3BzLmxldHNlbmNyeXB0Lm9yZzCBqwYI
+KwYBBQUHAgIwgZ4MgZtUaGlzIENlcnRpZmljYXRlIG1heSBvbmx5IGJlIHJlbGll
+ZCB1cG9uIGJ5IFJlbHlpbmcgUGFydGllcyBhbmQgb25seSBpbiBhY2NvcmRhbmNl
+IHdpdGggdGhlIENlcnRpZmljYXRlIFBvbGljeSBmb3VuZCBhdCBodHRwczovL2xl
+dHNlbmNyeXB0Lm9yZy9yZXBvc2l0b3J5LzANBgkqhkiG9w0BAQsFAAOCAQEAYUgc
+DgwQeHRwCjpDRWcmjZ6qUkAgoZX6MbCkYf8K5rrsfpwn171zgAds+3qPWgC6JJpL
+oBdzbxk/KDqOOfGPXlbOm2dpVEUAG9VoFKGX5/A3KfUqRq7tBW1xK03yko9VL3Bh
++AIWcrdRhZEkbTjFl0gi+eMSiDvCOrGZmBvdpR2QnVdYYQaOO/pc97D+EGDxpTb0
+Vfd3XdUXQfFmLkrVUfbXK32mbkzEY5toIMirtr5Filar8Rlmv6zo7LUVBhb0GHFh
+keKetNJrMM8tB9aRFauL88rc5Zr4yypp3BRZ5H+LLaxbkI2fCBgUNpEDyQxXAHcA
+ZXKiOK9nAxPqBoqyUw==
+-----END CERTIFICATE-----

--- a/util/time.go
+++ b/util/time.go
@@ -27,6 +27,7 @@ var (
 	RFC2459Date                = time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)
 	RFC3280Date                = time.Date(2002, time.April, 1, 0, 0, 0, 0, time.UTC)
 	RFC3490Date                = time.Date(2003, time.March, 1, 0, 0, 0, 0, time.UTC)
+	RFC5890Date                = time.Date(2010, time.August, 1, 0, 0, 0, 0, time.UTC)
 	RFC4325Date                = time.Date(2005, time.December, 1, 0, 0, 0, 0, time.UTC)
 	RFC4630Date                = time.Date(2006, time.August, 1, 0, 0, 0, 0, time.UTC)
 	RFC5280Date                = time.Date(2008, time.May, 1, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
RFC 3490 referenced in lint_idn_dnsname_must_be_nfkc.go, requires normalization NFKC; however that BR is being replaced by RFC 5891 which requires normalization NFC.

Stefano Chang
GoDaddy PKI Dev
