### PR TITLE
util: remove updatetld.sh in favour of updateTLDs.sh

### DIFF
--- a/util/updatetld.sh
+++ b/util/updatetld.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-# Script to update the list of gTLDs
-curl -o newgtlds.txt http://data.iana.org/TLD/tlds-alpha-by-domain.txt


### PR DESCRIPTION
There is a more robust TLD update script in the root of the project directory under the name 'updateTLDs.sh'. I believe the `util/updatetld.sh` script is a left-over.

**Note to reviewers**: I did a quick scan of the repository to try and find references to `util/updatetld.sh`. I didn't find any but it would be prudent for folks to check that there aren't any external users of this script that will be surprised when it disappears. 