### PR TITLE
lowercase effective domain label when checking if TLD is legitimate

### DIFF
--- a/util/gtld.go
+++ b/util/gtld.go
@@ -71,7 +71,7 @@ func (p GTLDPeriod) Valid(when time.Time) error {
 // HasValidTLD checks that a domain ends in a valid TLD that was delegated in
 // the root DNS at the time specified.
 func HasValidTLD(domain string, when time.Time) bool {
-	labels := strings.Split(domain, ".")
+	labels := strings.Split(strings.ToLower(domain), ".")
 	rightLabel := labels[len(labels)-1]
 	// if the rightmost label is not present in the tldMap, it isn't valid and
 	// never was.

--- a/util/gtld_test.go
+++ b/util/gtld_test.go
@@ -1,0 +1,46 @@
+/*
+ * ZLint Copyright 2018 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHasValidTLD(t *testing.T) {
+	domain := "google.com"
+	expected := true
+	actual := HasValidTLD(domain, time.Now())
+	if expected != actual {
+		t.Error(
+			"For", domain,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}
+
+func TestHasValidTLDUppercaseName(t *testing.T) {
+	domain := "GOOGLE.COM"
+	expected := true
+	actual := HasValidTLD(domain, time.Now())
+	if expected != actual {
+		t.Error(
+			"For", domain,
+			"expected", expected,
+			"got", actual,
+		)
+	}
+}


### PR DESCRIPTION
Related to #240, lower case the domain before checking if the TLD is in the TLD map.