### PR TITLE
e_subject_common_name_not_from_san incorrectly fails on case sensitive match

### DIFF
--- a/lints/lint_subject_common_name_not_from_san.go
+++ b/lints/lint_subject_common_name_not_from_san.go
@@ -22,6 +22,8 @@ contained in the Certificate’s subjectAltName extension (see Section 7.1.4.2.1
 ************************************************/
 
 import (
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )
@@ -40,7 +42,7 @@ func (l *subjectCommonNameNotFromSAN) Execute(c *x509.Certificate) *LintResult {
 	cn := c.Subject.CommonName
 
 	for _, dn := range c.DNSNames {
-		if cn == dn {
+		if strings.ToLower(cn) == strings.ToLower(dn) {
 			return &LintResult{Status: Pass}
 		}
 	}

--- a/lints/lint_subject_common_name_not_from_san_test.go
+++ b/lints/lint_subject_common_name_not_from_san_test.go
@@ -35,3 +35,12 @@ func TestCnFromSAN(t *testing.T) {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
+
+func TestCnCaseNotMatchingSAN(t *testing.T) {
+	inputPath := "../testlint/testCerts/SANCaseNotMatchingCN.pem"
+	expected := Pass
+	out := Lints["e_subject_common_name_not_from_san"].Execute(ReadCertificate(inputPath))
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/lints/lint_subject_common_name_not_from_san_test.go
+++ b/lints/lint_subject_common_name_not_from_san_test.go
@@ -36,7 +36,7 @@ func TestCnFromSAN(t *testing.T) {
 	}
 }
 
-func TestCnCaseNotMatchingSAN(t *testing.T) {
+func TestSANCaseNotMatchingCN(t *testing.T) {
 	inputPath := "../testlint/testCerts/SANCaseNotMatchingCN.pem"
 	expected := Pass
 	out := Lints["e_subject_common_name_not_from_san"].Execute(ReadCertificate(inputPath))

--- a/testlint/testCerts/SANCaseNotMatchingCN.pem
+++ b/testlint/testCerts/SANCaseNotMatchingCN.pem
@@ -1,0 +1,55 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 123456 (0x1e240)
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = gov.us
+        Validity
+            Not Before: Nov  8 21:35:53 2018 GMT
+            Not After : Jan  1 00:00:00 1 GMT
+        Subject: CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:d6:86:65:9b:85:26:53:19:44:0e:1a:fb:56:c4:
+                    84:3f:0e:be:d7:54:2b:63:d1:66:4c:9d:65:1f:d2:
+                    a6:b0:9c:d7:5c:c8:a5:1b:a8:be:2a:24:be:2d:96:
+                    77:5b:75:0a:5f:ac:64:65:82:b1:24:83:78:b6:cb:
+                    9e:c7:90:84:b9:b4:7e:d5:26:4f:a8:89:90:30:75:
+                    0b:0c:47:a4:0b:b0:63:78:f6:c4:dd:ee:ae:41:42:
+                    34:9b:10:c4:41:ba:dd:18:0f:0f:7b:5f:fc:b3:cb:
+                    d7:7d:7d:0e:98:c3:3f:de:27:99:ab:57:55:69:55:
+                    37:35:8a:65:c2:d7:f9:9b:bd:a8:f5:59:94:28:bc:
+                    99:a3:c0:cf:06:f9:99:73:5f:62:d8:d1:cb:d1:0a:
+                    2d:e7:33:0f:d2:80:b6:33:9d:2f:4d:95:cb:15:60:
+                    f5:30:3f:13:d2:2d:9d:88:bf:df:9d:cc:ed:53:ac:
+                    30:28:5d:8d:cd:6e:2d:bc:b2:14:a6:97:5f:96:ff:
+                    d2:fc:a4:13:26:32:76:cb:6e:fc:d4:4f:9a:7f:64:
+                    38:ba:59:a9:42:6a:b9:16:a5:10:a8:a0:c2:06:51:
+                    69:a5:ba:54:2a:59:e9:cd:e1:62:52:37:a4:ea:b5:
+                    dc:db:48:46:b4:e9:d0:47:7b:8f:e3:6a:54:5f:ee:
+                    68:21
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Alternative Name: 
+                DNS:GOV.US, DNS:*.GOV.us
+    Signature Algorithm: sha256WithRSAEncryption
+         5c:cc:0e:08:6d:d7:2d:53:04:87:15:86:30:40:78:19:e3:c8:
+         eb:ba:37:16:7b:bc:25:25:30:1b:90:12:73:9c:e0:b6:26:6a:
+         ca:a6:ff:d6:ca:d4:02:05:f6:12:f9:81:52:0e:ca:f2:13:ba:
+         4e:a7:2d:5c:e0:33:b4:68:4b:7e:cf:64:a1:80:aa:87:f6:ce:
+         2c:23:68:51:e2:ae:7e:33:52:bc:2c:33:69:76:a0:cc:76:cd:
+         8d:6e:a4:fb:84:ae:5f:44:a7:b2:a8:fa:df:e7:3f:9b:e0:d3:
+         35:bb:f5:12:bb:58:c4:13:e5:bf:2d:99:af:07:f7:68:d7:3a:
+         95:7e:fc:6c:fc:28:41:7a:65:df:85:76:71:aa:b3:6b:e2:ab:
+         aa:84:ec:2f:67:18:a6:89:c2:bf:d8:78:ed:8f:ae:f4:07:5c:
+         00:da:cb:79:71:1f:a3:e0:cc:fa:2b:b9:0a:45:48:3c:18:f5:
+         54:71:21:89:5b:f6:20:b6:b5:a3:28:cb:9c:c1:10:85:76:07:
+         26:76:16:0f:e7:77:c6:a8:0e:dc:97:ad:72:79:23:f6:d5:04:
+         d3:4d:58:d3:b9:4f:e2:97:72:13:af:0b:45:d7:ad:92:ba:ed:
+         5c:8c:52:f1:60:d0:af:cc:ab:82:20:d1:a2:d2:a1:37:55:ed:
+         58:d4:32:c7
+-----BEGIN CERTIFICATE-----
+MIICwDCCAaigAwIBAgIDAeJAMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMTBmdvdi51czAgFw0xODExMDgyMTM1NTNaGA8wMDAxMDEwMTAwMDAwMFowETEPMA0GA1UEAxMGZ292LnVzMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1oZlm4UmUxlEDhr7VsSEPw6+11QrY9FmTJ1lH9KmsJzXXMilG6i+KiS+LZZ3W3UKX6xkZYKxJIN4tsuex5CEubR+1SZPqImQMHULDEekC7BjePbE3e6uQUI0mxDEQbrdGA8Pe1/8s8vXfX0OmMM/3ieZq1dVaVU3NYplwtf5m72o9VmUKLyZo8DPBvmZc19i2NHL0Qot5zMP0oC2M50vTZXLFWD1MD8T0i2diL/fncztU6wwKF2NzW4tvLIUppdflv/S/KQTJjJ2y2781E+af2Q4ulmpQmq5FqUQqKDCBlFppbpUKlnpzeFiUjek6rXc20hGtOnQR3uP42pUX+5oIQIDAQABox8wHTAbBgNVHREEFDASggZHT1YuVVOCCCouR09WLnVzMA0GCSqGSIb3DQEBCwUAA4IBAQBczA4IbdctUwSHFYYwQHgZ48jrujcWe7wlJTAbkBJznOC2JmrKpv/WytQCBfYS+YFSDsryE7pOpy1c4DO0aEt+z2ShgKqH9s4sI2hR4q5+M1K8LDNpdqDMds2NbqT7hK5fRKeyqPrf5z+b4NM1u/USu1jEE+W/LZmvB/do1zqVfvxs/ChBemXfhXZxqrNr4quqhOwvZximicK/2Hjtj670B1wA2st5cR+j4Mz6K7kKRUg8GPVUcSGJW/YgtrWjKMucwRCFdgcmdhYP53fGqA7cl61yeSP21QTTTVjTuU/il3ITrwtF162Suu1cjFLxYNCvzKuCINGi0qE3Ve1Y1DLH
+-----END CERTIFICATE-----


### PR DESCRIPTION
This PR fixes a bug in the `e_subject_common_name_not_from_san` linter which causes an error to be returned when the CN field contains a name that matches a SAN with inconsistent case.

For reference,

Pre-Pull Request
CN: gov.us, SANS: [GOV.us] -- FAIL
CN: gov.us, SANS: [gov.us] -- PASS

Post-Pull Request
CN: gov.us, SANS: [GOV.us] -- PASS
CN: gov.us, SANS: [gov.us] -- PASS