### PR TITLE
Added notice if the DNSNames are duplicated in the SANS extension.

### DIFF
--- a/lints/lint_san_dns_name_duplicate.go
+++ b/lints/lint_san_dns_name_duplicate.go
@@ -1,0 +1,57 @@
+/*
+ * ZLint Copyright 2017 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package lints
+
+import (
+	"strings"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/util"
+)
+
+type SANDNSDuplicate struct{}
+
+func (l *SANDNSDuplicate) Initialize() error {
+	return nil
+}
+
+func (l *SANDNSDuplicate) CheckApplies(c *x509.Certificate) bool {
+	return util.IsExtInCert(c, util.SubjectAlternateNameOID)
+}
+
+func (l *SANDNSDuplicate) Execute(c *x509.Certificate) *LintResult {
+	checkedDNSNames := map[string]struct{}{}
+	for _, dns := range c.DNSNames {
+		normalizedDNSName := strings.ToLower(dns)
+		if _, isPresent := checkedDNSNames[normalizedDNSName]; isPresent {
+			return &LintResult{Status: Notice}
+		}
+
+		checkedDNSNames[normalizedDNSName] = struct{}{}
+	}
+
+	return &LintResult{Status: Pass}
+}
+
+func init() {
+	RegisterLint(&Lint{
+		Name:          "n_san_dns_name_duplicate",
+		Description:   "SAN DNSName contains duplicate values",
+		Citation:      "awslabs certlint",
+		Source:        AWSLabs,
+		EffectiveDate: util.ZeroDate,
+		Lint:          &SANDNSDuplicate{},
+	})
+}

--- a/lints/lint_san_dns_name_duplicate_test.go
+++ b/lints/lint_san_dns_name_duplicate_test.go
@@ -1,0 +1,28 @@
+package lints
+
+/*
+ * ZLint Copyright 2018 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"testing"
+)
+
+func TestBrSANDNSDuplicate(t *testing.T) {
+	inputPath := "../testlint/testCerts/SANDNSDuplicate.pem"
+	expected := Notice
+	out := Lints["n_san_dns_name_duplicate"].Execute(ReadCertificate(inputPath))
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/testlint/testCerts/SANDNSDuplicate.pem
+++ b/testlint/testCerts/SANDNSDuplicate.pem
@@ -1,0 +1,70 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            31:37:37:39:31:38:35:30:36:30:34:31:32:39:38:34
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = gov.us
+        Validity
+            Not Before: Nov 13 21:09:39 2018 GMT
+            Not After : Nov 13 21:09:39 2019 GMT
+        Subject: CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:d0:e0:9b:c1:2e:49:10:60:7f:f6:f6:1a:c2:bc:
+                    88:b0:ba:f3:a4:0b:2e:3c:dd:e2:8a:a6:1e:07:26:
+                    ad:a2:5b:34:a4:41:55:30:96:f2:89:4a:05:6d:d2:
+                    28:11:74:ca:70:b5:e3:52:52:45:4d:47:84:46:8b:
+                    6f:8b:c6:70:db:7c:2e:47:b6:3b:7d:e5:76:23:ff:
+                    3d:69:18:fa:c3:6e:d6:38:30:b3:c1:1d:d2:59:9f:
+                    c0:eb:94:3f:8d:19:47:77:27:4c:c5:45:08:71:fd:
+                    dc:27:a8:e5:67:03:f5:0a:44:47:fd:3b:f1:ef:9f:
+                    a9:2b:90:a9:7c:dc:89:78:95:9c:2a:01:91:ea:35:
+                    fe:e7:81:7c:6d:96:c0:24:dd:95:4d:fc:c8:6b:f6:
+                    fa:41:b3:c5:80:09:d1:03:26:f6:2e:f5:04:6e:1b:
+                    d9:90:42:19:c1:85:2c:5b:21:c7:d8:49:f8:ff:77:
+                    06:e5:1b:83:29:50:1c:21:ac:b3:41:06:62:4b:89:
+                    45:d4:13:4d:b1:6b:ca:ba:6e:4e:8a:65:c1:67:2b:
+                    1d:16:b2:f5:fb:75:8d:88:a7:61:82:50:4a:03:81:
+                    32:a9:74:f8:14:e1:83:34:1a:bd:5e:12:84:8e:31:
+                    93:53:71:99:31:c4:39:3b:96:99:46:0d:77:5e:5e:
+                    a7:83
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Alternative Name: 
+                DNS:GOV.us, DNS:gov.us
+    Signature Algorithm: sha256WithRSAEncryption
+         0f:10:a4:4e:a0:38:06:41:10:a9:db:99:3c:3b:47:6d:84:e7:
+         f2:f5:fe:1c:0b:fa:22:87:a7:6c:b7:e9:d9:90:6f:ef:0f:49:
+         d5:fc:a7:5b:0f:fd:5b:22:49:14:d0:fb:d0:1d:08:81:0d:e2:
+         89:b6:02:95:d1:16:35:14:09:dc:bc:dd:25:81:c7:66:72:b4:
+         75:00:76:75:5c:86:5d:59:3a:7c:4b:1b:d3:5e:5d:c5:24:11:
+         83:22:ea:12:41:92:26:a9:ee:7b:30:e6:62:17:3b:56:c8:b0:
+         72:5f:ad:8a:d6:1d:27:b5:9b:f1:c5:11:07:a2:05:a7:46:2c:
+         a9:58:17:d4:b8:6f:7b:73:fc:3f:4d:8e:6b:12:25:dc:f6:0c:
+         4e:1d:c3:4a:ca:c6:1c:b2:d2:d4:62:88:46:b6:98:37:cf:f1:
+         01:fe:f6:25:2e:7d:62:a7:64:bd:68:af:f4:b7:d3:26:6d:12:
+         7f:56:77:7a:32:47:3c:c0:b9:91:65:2d:f7:16:ce:c4:50:cb:
+         4f:04:96:55:22:01:59:c9:57:53:21:e8:3f:7b:0b:59:9d:e3:
+         ed:11:3b:e5:a3:5e:47:74:06:3d:22:8e:b1:f6:b7:af:c4:89:
+         5f:75:3e:2a:57:b5:3f:df:c8:29:22:53:70:f5:cd:c7:52:0e:
+         38:db:c8:02
+-----BEGIN CERTIFICATE-----
+MIICyTCCAbGgAwIBAgIQMTc3OTE4NTA2MDQxMjk4NDANBgkqhkiG9w0BAQsFADAR
+MQ8wDQYDVQQDEwZnb3YudXMwHhcNMTgxMTEzMjEwOTM5WhcNMTkxMTEzMjEwOTM5
+WjARMQ8wDQYDVQQDEwZnb3YudXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDQ4JvBLkkQYH/29hrCvIiwuvOkCy483eKKph4HJq2iWzSkQVUwlvKJSgVt
+0igRdMpwteNSUkVNR4RGi2+LxnDbfC5Htjt95XYj/z1pGPrDbtY4MLPBHdJZn8Dr
+lD+NGUd3J0zFRQhx/dwnqOVnA/UKREf9O/Hvn6krkKl83Il4lZwqAZHqNf7ngXxt
+lsAk3ZVN/Mhr9vpBs8WACdEDJvYu9QRuG9mQQhnBhSxbIcfYSfj/dwblG4MpUBwh
+rLNBBmJLiUXUE02xa8q6bk6KZcFnKx0WsvX7dY2Ip2GCUEoDgTKpdPgU4YM0Gr1e
+EoSOMZNTcZkxxDk7lplGDXdeXqeDAgMBAAGjHTAbMBkGA1UdEQQSMBCCBkdPVi51
+c4IGZ292LnVzMA0GCSqGSIb3DQEBCwUAA4IBAQAPEKROoDgGQRCp25k8O0dthOfy
+9f4cC/oih6dst+nZkG/vD0nV/KdbD/1bIkkU0PvQHQiBDeKJtgKV0RY1FAncvN0l
+gcdmcrR1AHZ1XIZdWTp8SxvTXl3FJBGDIuoSQZImqe57MOZiFztWyLByX62K1h0n
+tZvxxREHogWnRiypWBfUuG97c/w/TY5rEiXc9gxOHcNKysYcstLUYohGtpg3z/EB
+/vYlLn1ip2S9aK/0t9MmbRJ/Vnd6Mkc8wLmRZS33Fs7EUMtPBJZVIgFZyVdTIeg/
+ewtZnePtETvlo15HdAY9Io6x9revxIlfdT4qV7U/38gpIlNw9c3HUg4428gC
+-----END CERTIFICATE-----


### PR DESCRIPTION
PR to fix #205.

I couldn't find any references in the CA/B or RFC 5280 that explicitly calls out that DNSNames shouldn't be duplicated in the SANs extension, so I made it a notice rather than a warning or error.