### PR TITLE
CI: update to Go 1.11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 dist: trusty
 go:
-- 1.9
+- "1.11"
 before_install:
 - go get ./...
 - go get -t ./...

--- a/util/ip.go
+++ b/util/ip.go
@@ -75,16 +75,16 @@ func IsIANAReserved(ip net.IP) bool {
 
 func init() {
 	var networks = map[subnetCategory][]string{
-		privateUse:         {"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"},
-		sharedAddressSpace: {"100.64.0.0/10"},
-		benchmarking:       {"198.18.0.0/15", "2001:2::/48"},
-		documentation:      {"192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24", "2001:db8::/32"},
-		reserved:           {"240.0.0.0/4", "0400::/6", "0800::/5", "1000::/4", "4000::/3", "6000::/3", "8000::/3", "a000::/3", "c000::/3", "e000::/4", "f000::/5", "f800::/6", "fe00::/9"}, // https://www.iana.org/assignments/ipv6-address-space/ipv6-address-space.xhtml
-		protocolAssignment: {"192.0.0.0/24", "2001::/23"},                                                                                                                                   // 192.0.0.0/24 contains 192.0.0.0/29 - IPv4 Service Continuity Prefix
-		as112:              {"192.31.196.0/24", "192.175.48.0/24", "2001:4:112::/48", "2620:4f:8000::/48"},
-		amt:                {"192.52.193.0/24", "2001:3::/32"},
-		orchidV2:           {"2001:20::/28"},
-		lisp:               {"2001:5::/32"}, // TODO: this could expire at 2019-09. Please check  https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml for updates
+		privateUse:                           {"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"},
+		sharedAddressSpace:                   {"100.64.0.0/10"},
+		benchmarking:                         {"198.18.0.0/15", "2001:2::/48"},
+		documentation:                        {"192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24", "2001:db8::/32"},
+		reserved:                             {"240.0.0.0/4", "0400::/6", "0800::/5", "1000::/4", "4000::/3", "6000::/3", "8000::/3", "a000::/3", "c000::/3", "e000::/4", "f000::/5", "f800::/6", "fe00::/9"}, // https://www.iana.org/assignments/ipv6-address-space/ipv6-address-space.xhtml
+		protocolAssignment:                   {"192.0.0.0/24", "2001::/23"},                                                                                                                                   // 192.0.0.0/24 contains 192.0.0.0/29 - IPv4 Service Continuity Prefix
+		as112:                                {"192.31.196.0/24", "192.175.48.0/24", "2001:4:112::/48", "2620:4f:8000::/48"},
+		amt:                                  {"192.52.193.0/24", "2001:3::/32"},
+		orchidV2:                             {"2001:20::/28"},
+		lisp:                                 {"2001:5::/32"}, // TODO: this could expire at 2019-09. Please check  https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml for updates
 		thisHostOnThisNetwork:                {"0.0.0.0/8"},
 		translatableAddress4to6:              {"2002::/16"},
 		translatableAddress6to4:              {"64:ff9b::/96", "64:ff9b:1::/48"},


### PR DESCRIPTION
Previously CI was running tests [under Go 1.9.x](https://github.com/zmap/zlint/blob/a797fdc8b16c70478920913adc010e65f604610a/.travis.yml#L4) and this is no longer [listed as a stable version](https://golang.org/dl/). Using Go 1.11.x tests against the newest stable version available at the time of writing.

In addition to changing the CI version one file ([`util/ip.go`](https://github.com/zmap/zlint/blob/master/util/ip.go)) requires a `go fmt -s` update using the Go 1.11.x toolchain in order for ([`TestGoFmt`](https://github.com/zmap/zlint/blob/a797fdc8b16c70478920913adc010e65f604610a/gofmt_test.go#L23)) to pass.

Before the update:
```
$ go version
go1.11.5 linux/amd64
$ make test
GORACE=halt_on_error=1 go test -race ./...
--- FAIL: TestGofmt (0.25s)
    gofmt_test.go:37: glob util/*.go not gofmt'ed
    FAIL
    FAIL  github.com/zmap/zlint 0.275s
<snipped>
```

After:
```
$ go version
go1.11.5 linux/amd64
$ make test
ok  	github.com/zmap/zlint	0.191s
<snipped>
```