### PR TITLE
lints: fix comment typos for IPv6 arpa zone.

### DIFF
--- a/lints/lint_subject_contains_malformed_arpa_ip.go
+++ b/lints/lint_subject_contains_malformed_arpa_ip.go
@@ -37,7 +37,7 @@ func (l *arpaMalformedIP) Initialize() error {
 }
 
 // CheckApplies returns true if the certificate contains any names that end in
-// one of the two designated zones for reverse DNS: in-addr.arpa or ipv6.arpa.
+// one of the two designated zones for reverse DNS: in-addr.arpa or ip6.arpa.
 func (l *arpaMalformedIP) CheckApplies(c *x509.Certificate) bool {
 	names := append([]string{c.Subject.CommonName}, c.DNSNames...)
 	for _, name := range names {
@@ -63,7 +63,7 @@ func (l *arpaMalformedIP) Execute(c *x509.Certificate) *LintResult {
 			// DNS name.
 			err = lintReversedIPAddressLabels(name, false)
 		} else if strings.HasSuffix(name, rdnsIPv6Suffix) {
-			// If the name has the ipv6.arpa suffix then it should be an IPv6 reverse
+			// If the name has the ip6.arpa suffix then it should be an IPv6 reverse
 			// DNS name.
 			err = lintReversedIPAddressLabels(name, true)
 		}

--- a/lints/lint_subject_contains_reserved_arpa_ip.go
+++ b/lints/lint_subject_contains_reserved_arpa_ip.go
@@ -60,7 +60,7 @@ func (l *arpaReservedIP) Initialize() error {
 }
 
 // CheckApplies returns true if the certificate contains any names that end in
-// one of the two designated zones for reverse DNS: in-addr.arpa or ipv6.arpa.
+// one of the two designated zones for reverse DNS: in-addr.arpa or ip6.arpa.
 func (l *arpaReservedIP) CheckApplies(c *x509.Certificate) bool {
 	names := append([]string{c.Subject.CommonName}, c.DNSNames...)
 	for _, name := range names {
@@ -88,7 +88,7 @@ func (l *arpaReservedIP) Execute(c *x509.Certificate) *LintResult {
 			// DNS name.
 			err = lintReversedIPAddress(name, false)
 		} else if strings.HasSuffix(name, rdnsIPv6Suffix) {
-			// If the name has the ipv6.arpa suffix then it should be an IPv6 reverse
+			// If the name has the ip6.arpa suffix then it should be an IPv6 reverse
 			// DNS name.
 			err = lintReversedIPAddress(name, true)
 		}


### PR DESCRIPTION
Flagged in [a review on the already merged PR](https://github.com/zmap/zlint/pull/260#pullrequestreview-217506386) by @DrMattChristian.