### PR TITLE
lint_sub_cert_eku_extra_values.go is not checking subscriber certificates only

### DIFF
--- a/lints/lint_sub_cert_eku_extra_values.go
+++ b/lints/lint_sub_cert_eku_extra_values.go
@@ -32,7 +32,7 @@ func (l *subExtKeyUsageLegalUsage) Initialize() error {
 }
 
 func (l *subExtKeyUsageLegalUsage) CheckApplies(c *x509.Certificate) bool {
-	return c.ExtKeyUsage != nil
+	return util.IsSubscriberCert(c) && c.ExtKeyUsage != nil
 }
 
 func (l *subExtKeyUsageLegalUsage) Execute(c *x509.Certificate) *LintResult {


### PR DESCRIPTION
lint_sub_cert_eku_extra_values.go should check subcriber certificates only as it comes from BRs, "7.1.2.3. Subscriber Certificate", "f. extKeyUsage (required)".