### PR TITLE
CI: Update to Go 1.12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 dist: trusty
 
 go:
-  - "1.11"
+  - "1.12"
 
 script:
   - make


### PR DESCRIPTION
Go 1.12.x is the latest stable release at the time of writing.