### PR TITLE
ci: use GOFLAGS, enforce gofmt -s.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,13 @@ go:
   - "1.12.x"
 
 script:
+  # Fast-fail on non-zero exit codes
+  - set -e
+  # Build commands
   - make
+  # Verify that all files have been gofmt'd with simplification
+  - make format-check
+  # Run unit tests
   - make test
 
 notifications:

--- a/makefile
+++ b/makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 CMDS = zlint zlint-gtld-update
 CMD_PREFIX = ./cmd/
 GO_ENV = GO111MODULE="on" GOFLAGS="-mod=vendor"
@@ -19,6 +21,6 @@ test:
 	$(TEST) ./...
 
 format-check:
-	find . -name '*.go' -not -path './vendor/*' -print | xargs -n1 gofmt -l
+	diff <(find . -name '*.go' -not -path './vendor/*' -print | xargs -n1 gofmt -l) <(printf "")
 
 .PHONY: clean zlint zlint-gtld-update test format-check

--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 CMDS = zlint zlint-gtld-update
 CMD_PREFIX = ./cmd/
-GO_ENV = GO111MODULE=on
-BUILD = $(GO_ENV) go build -mod=vendor
-TEST = $(GO_ENV) GORACE=halt_on_error=1 go test -mod=vendor -race
+GO_ENV = GO111MODULE="on" GOFLAGS="-mod=vendor"
+BUILD = $(GO_ENV) go build
+TEST = $(GO_ENV) GORACE=halt_on_error=1 go test -race
 
 all: $(CMDS)
 
@@ -18,4 +18,7 @@ clean:
 test:
 	$(TEST) ./...
 
-.PHONY: clean zlint zlint-gtld-update test
+format-check:
+	find . -name '*.go' -not -path './vendor/*' -print | xargs -n1 gofmt -l
+
+.PHONY: clean zlint zlint-gtld-update test format-check


### PR DESCRIPTION
This PR sets up a global `GOFLAGS` to avoid needing to repeat it for each command.

It also changes the script to exit on the first error, and to enforce that all non-vendored `.go` files satisfy `gofmt -s` without diffs. This will make sure all code is consistently formatted and help contributors
do the right thing by default.

(Matches the `zcrypto` PR: https://github.com/zmap/zcrypto/pull/195 - I'll leave it up to you folks if you'd like to add similar checks to the other `zmap` repositories, `zcertificate`, etc)