### PR TITLE
util: faster GetExtFromCert using ExtensionsMap.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/zmap/zlint
 require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/weppos/publicsuffix-go v0.4.0
-	github.com/zmap/zcrypto v0.0.0-20190726170612-6da6ff3e2049
+	github.com/zmap/zcrypto v0.0.0-20190729165852-9051775e6a2e
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
 	golang.org/x/text v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/weppos/publicsuffix-go v0.4.0 h1:YSnfg3V65LcCFKtIGKGoBhkyKolEd0hlipcX
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=
 github.com/zmap/zcertificate v0.0.0-20180516150559-0e3d58b1bac4/go.mod h1:5iU54tB79AMBcySS0R2XIyZBAVmeHranShAFELYx7is=
-github.com/zmap/zcrypto v0.0.0-20190726170612-6da6ff3e2049 h1:vOx/ceYpsQAmmB2WyBB8VwIh5dGr7n1A9uWHhtkYDEg=
-github.com/zmap/zcrypto v0.0.0-20190726170612-6da6ff3e2049/go.mod h1:w7kd3qXHh8FNaczNjslXqvFQiv5mMWRXlL9klTUAHc8=
+github.com/zmap/zcrypto v0.0.0-20190729165852-9051775e6a2e h1:mvOa4+/DXStR4ZXOks/UsjeFdn5O5JpLUtzqk9U8xXw=
+github.com/zmap/zcrypto v0.0.0-20190729165852-9051775e6a2e/go.mod h1:w7kd3qXHh8FNaczNjslXqvFQiv5mMWRXlL9klTUAHc8=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/util/oid.go
+++ b/util/oid.go
@@ -110,10 +110,12 @@ func IsExtInCert(cert *x509.Certificate, oid asn1.ObjectIdentifier) bool {
 // GetExtFromCert returns the extension with the matching OID, if present. If
 // the extension if not present, it returns nil.
 func GetExtFromCert(cert *x509.Certificate, oid asn1.ObjectIdentifier) *pkix.Extension {
-	for i := range cert.Extensions {
-		if oid.Equal(cert.Extensions[i].Id) {
-			return &(cert.Extensions[i])
-		}
+	// Since this function is called by many Lint CheckApplies functions we use
+	// the x509.Certificate.ExtensionsMap field added by zcrypto to check for
+	// the extension in O(1) instead of looping through the
+	// `x509.Certificate.Extensions` in O(n).
+	if ext, found := cert.ExtensionsMap[oid.String()]; found {
+		return &ext
 	}
 	return nil
 }

--- a/vendor/github.com/zmap/zcrypto/x509/x509.go
+++ b/vendor/github.com/zmap/zcrypto/x509/x509.go
@@ -693,6 +693,14 @@ type Certificate struct {
 	// field is ignored, see ExtraExtensions.
 	Extensions []pkix.Extension
 
+	// ExtensionsMap contains raw x.509 extensions keyed by OID (in string
+	// representation). It allows fast membership testing of specific OIDs. Like
+	// the Extensions field this field is ignored when marshaling certificates. If
+	// multiple extensions with the same OID are present only the last
+	// pkix.Extension will be in this map. Consult the `Extensions` slice when it
+	// is required to process all extensions including duplicates.
+	ExtensionsMap map[string]pkix.Extension
+
 	// ExtraExtensions contains extensions to be copied, raw, into any
 	// marshaled certificates. Values override any extensions that would
 	// otherwise be produced based on the other fields. The ExtraExtensions
@@ -1541,8 +1549,10 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 	out.IssuerUniqueId = in.TBSCertificate.UniqueId
 	out.SubjectUniqueId = in.TBSCertificate.SubjectUniqueId
 
+	out.ExtensionsMap = make(map[string]pkix.Extension, len(in.TBSCertificate.Extensions))
 	for _, e := range in.TBSCertificate.Extensions {
 		out.Extensions = append(out.Extensions, e)
+		out.ExtensionsMap[e.Id.String()] = e
 
 		if len(e.Id) == 4 && e.Id[0] == 2 && e.Id[1] == 5 && e.Id[2] == 29 {
 			switch e.Id[3] {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/konsorten/go-windows-terminal-sequences
 github.com/sirupsen/logrus
 # github.com/weppos/publicsuffix-go v0.4.0
 github.com/weppos/publicsuffix-go/publicsuffix
-# github.com/zmap/zcrypto v0.0.0-20190726170612-6da6ff3e2049
+# github.com/zmap/zcrypto v0.0.0-20190729165852-9051775e6a2e
 github.com/zmap/zcrypto/x509
 github.com/zmap/zcrypto/x509/ct
 github.com/zmap/zcrypto/x509/pkix


### PR DESCRIPTION
The [`github.com/zmap/zcrypto`](https://github.com/zmap/zcrypto/) library that provides certificate parsing for zlint has been [updated to add an `ExtensionsMap` field](https://github.com/zmap/zcrypto/commit/9051775e6a2e3a89ec27977077b09f4496febecf) on parsed Certificates.

In this PR the zlint `util.GetExtFromCert` function is updated to use the `ExtensionsMap` field for O(1) extension access by OID instead of needing an O(n) search of the `Extensions` slice.

Running a `-cpuprofile` of the benchmarks in master gives the following `top10` in `pprof`:
```
$ cd $GOPATH/src/github.com/zmap/zlint
$ go test --run=XXX -bench=. -cpuprofile all.profile
<snipped>
$ go tool pprof all.profile
File: zlint.test
Type: cpu
Time: Jul 26, 2019 at 10:58am (EDT)
Duration: 4.13mins, Total samples = 4.79mins (115.90%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10
Showing nodes accounting for 146.71s, 51.07% of 287.25s total
Dropped 522 nodes (cum <= 1.44s)
Showing top 10 nodes out of 221
      flat  flat%   sum%        cum   cum%
    45.89s 15.98% 15.98%    142.36s 49.56%  runtime.mallocgc
    31.59s 11.00% 26.97%     39.26s 13.67%  runtime.heapBitsSetType
    18.20s  6.34% 33.31%     18.20s  6.34%  runtime.nextFreeFast
    11.27s  3.92% 37.23%     20.05s  6.98%  runtime.scanobject
     9.90s  3.45% 40.68%      9.90s  3.45%  runtime.memclrNoHeapPointers
     8.31s  2.89% 43.57%      8.31s  2.89%  encoding/asn1.ObjectIdentifier.Equal
     6.92s  2.41% 45.98%     13.52s  4.71%  github.com/zmap/zlint/util.GetExtFromCert
     5.63s  1.96% 47.94%         7s  2.44%  runtime.heapBitsForAddr
     4.60s  1.60% 49.54%    130.51s 45.43%  runtime.newobject
     4.40s  1.53% 51.07%    245.67s 85.52%  github.com/zmap/zlint.BenchmarkZlint.func4
```

Notably we can see `github.com/zmap/zlint/util.GetExtFromCert` and `encoding/asn1.ObjectIdentifier.Equal` representing 4.71% and 2.89% of cumulative CPU usage respectively.

With this branch's fix applied the `top10` changes:
```
$ cd $GOPATH/src/github.com/zmap/zlint
$ go test --run=XXX -bench=. -cpuprofile all.new.profile
<snipped>
$ go tool pprof all.new.profile
File: zlint.test
Type: cpu
Time: Jul 29, 2019 at 3:38pm (EDT)
Duration: 4.21mins, Total samples = 4.89mins (116.10%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10
Showing nodes accounting for 142.94s, 48.69% of 293.55s total
Dropped 513 nodes (cum <= 1.47s)
Showing top 10 nodes out of 233
      flat  flat%   sum%        cum   cum%
    48.05s 16.37% 16.37%    138.73s 47.26%  runtime.mallocgc
    28.32s  9.65% 26.02%     37.09s 12.63%  runtime.heapBitsSetType
    14.54s  4.95% 30.97%     14.54s  4.95%  runtime.nextFreeFast
    12.19s  4.15% 35.12%     21.52s  7.33%  runtime.scanobject
    10.59s  3.61% 38.73%     30.52s 10.40%  runtime.concatstrings
     9.60s  3.27% 42.00%      9.60s  3.27%  runtime.memclrNoHeapPointers
     5.60s  1.91% 43.91%      6.88s  2.34%  runtime.heapBitsForAddr
     4.85s  1.65% 45.56%    252.74s 86.10%  github.com/zmap/zlint.BenchmarkZlint.func4
     4.73s  1.61% 47.17%    118.13s 40.24%  runtime.newobject
     4.47s  1.52% 48.69%      4.47s  1.52%  runtime.memmove
```

Now there's no more `github.com/zmap/zlint/util.GetExtFromCert` or `encoding/asn1.ObjectIdentifier.Equal` nodes present in the top 10 :tada: