### PR TITLE
lints: implement json.Unmarshaler for LintStatus.

### DIFF
--- a/lints/result_test.go
+++ b/lints/result_test.go
@@ -1,0 +1,68 @@
+package lints
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshalingLintStatus(t *testing.T) {
+	testCases := []struct {
+		result       LintStatus
+		expectedJSON string
+	}{
+		{
+			result:       Reserved,
+			expectedJSON: `"reserved"`,
+		},
+		{
+			result:       NA,
+			expectedJSON: `"NA"`,
+		},
+		{
+			result:       NE,
+			expectedJSON: `"NE"`,
+		},
+		{
+			result:       Pass,
+			expectedJSON: `"pass"`,
+		},
+		{
+			result:       Notice,
+			expectedJSON: `"info"`,
+		},
+		{
+			result:       Warn,
+			expectedJSON: `"warn"`,
+		},
+		{
+			result:       Error,
+			expectedJSON: `"error"`,
+		},
+		{
+			result:       Fatal,
+			expectedJSON: `"fatal"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.result.String(), func(t *testing.T) {
+			j, err := json.Marshal(tc.result)
+			if err != nil {
+				t.Error("Failed to marshal LintStatus")
+			}
+			if string(j) != tc.expectedJSON {
+				t.Errorf("Expected LintStatus to marshal to JSON %q, got %q",
+					tc.expectedJSON,
+					j)
+			}
+			var in LintStatus
+			if err := json.Unmarshal(j, &in); err != nil {
+				t.Errorf("Expected to unmarshal %q without error. Got %v", j, err)
+			}
+			if in != tc.result {
+				t.Errorf("Expected to unmarshal %q to %#v, got %#v", j, tc.result, in)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
The `lints.LintStatus` type implements `json.Marshaler` to marshal to a human readable string (e.g. `"error"` instead of `6`). Without providing a compatible `json.Unmarshaler` implementation downstream users that marshal a `lints.LintStatus` to JSON will encounter an error when they try to unmarshal it due to a mismatch of types (`int` vs `string`).

Notably this is causing me problems because when I added pre-issuance linting to [CFSSL](https://github.com/cloudflare/cfssl/pull/1015) I made the configuration value on the `cfssl.config.SigningProfile` type [a `zlint.lints.LintStatus`](https://github.com/cloudflare/cfssl/blob/633726f6bcb7574626ae05ae72ca3c8dbc51810f/config/config.go#L94-L102) after a suggestion by the maintainers. That seemed fine at the time but I later discovered in Boulder we expect to be able to [round-trip our CFSSL config to/from JSON without error](https://github.com/letsencrypt/boulder/blob/bb005e1c79f3972ef8c7f24e3bd44779bbced9e5/ca/ca.go#L209-L218).

Without the changes in this branch the de-serialization of the CFSSL config fails with an error like:

> Failed to create CA: {"code":5200,"message":"failed to unmarshal configuration: json: cannot unmarshal string into Go struct field SigningProfile.lint_error_level of type lints.LintStatus"}

