### PR TITLE
lints: consistently name lints by lint status result.

### DIFF
--- a/lints/lint_ct_sct_policy_count_unsatisfied.go
+++ b/lints/lint_ct_sct_policy_count_unsatisfied.go
@@ -146,7 +146,7 @@ func appleCTPolicyExpectedSCTs(cert *x509.Certificate) int {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ct_sct_policy_count_unsatisfied",
+		Name:          "w_ct_sct_policy_count_unsatisfied",
 		Description:   "Check if certificate has enough embedded SCTs to meet Apple CT Policy",
 		Citation:      "https://support.apple.com/en-us/HT205280",
 		Source:        AppleCTPolicy,

--- a/lints/lint_ct_sct_policy_count_unsatisfied_test.go
+++ b/lints/lint_ct_sct_policy_count_unsatisfied_test.go
@@ -102,7 +102,7 @@ func TestSCTCountPolicyUnsatisified(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			inputPath := fmt.Sprintf("%s%s", testCaseDir, tc.Filename)
-			result := Lints["ct_sct_policy_count_unsatisfied"].Execute(ReadCertificate(inputPath))
+			result := Lints["w_ct_sct_policy_count_unsatisfied"].Execute(ReadCertificate(inputPath))
 			if result.Status != tc.ExpectedResult {
 				t.Errorf("expected result %v was %v", tc.ExpectedResult, result.Status)
 			}

--- a/lints/lint_ext_tor_service_descriptor_hash_invalid.go
+++ b/lints/lint_ext_tor_service_descriptor_hash_invalid.go
@@ -200,7 +200,7 @@ func (l *torServiceDescHashInvalid) Execute(c *x509.Certificate) *LintResult {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "ext_tor_service_descriptor_hash_invalid",
+		Name:          "e_ext_tor_service_descriptor_hash_invalid",
 		Description:   "certificates with .onion names need valid TorServiceDescriptors in extension",
 		Citation:      "BRS: Ballot 201",
 		Source:        CABFBaselineRequirements,

--- a/lints/lint_ext_tor_service_descriptor_hash_invalid_test.go
+++ b/lints/lint_ext_tor_service_descriptor_hash_invalid_test.go
@@ -63,7 +63,7 @@ func TestTorDescHashInvalid(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			inputPath := fmt.Sprintf("%s%s", testCaseDir, tc.InputFilename)
-			result := Lints["ext_tor_service_descriptor_hash_invalid"].Execute(ReadCertificate(inputPath))
+			result := Lints["e_ext_tor_service_descriptor_hash_invalid"].Execute(ReadCertificate(inputPath))
 			if result.Status != tc.ExpectedResult {
 				t.Errorf("expected result %v was %v", tc.ExpectedResult, result.Status)
 			}

--- a/lints/lint_onion_subject_validity_time_too_large.go
+++ b/lints/lint_onion_subject_validity_time_too_large.go
@@ -56,7 +56,7 @@ func (l *torValidityTooLarge) Execute(c *x509.Certificate) *LintResult {
 
 func init() {
 	RegisterLint(&Lint{
-		Name: "onion_subject_validity_time_too_large",
+		Name: "e_onion_subject_validity_time_too_large",
 		Description: fmt.Sprintf(
 			"certificates with .onion names can not be valid for more than %d months",
 			maxOnionValidityMonths),

--- a/lints/lint_onion_subject_validity_time_too_large_test.go
+++ b/lints/lint_onion_subject_validity_time_too_large_test.go
@@ -31,7 +31,7 @@ func TestTorValidityTooLarge(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			inputPath := fmt.Sprintf("%s%s", testCaseDir, tc.InputFilename)
-			result := Lints["onion_subject_validity_time_too_large"].Execute(ReadCertificate(inputPath))
+			result := Lints["e_onion_subject_validity_time_too_large"].Execute(ReadCertificate(inputPath))
 			if result.Status != tc.ExpectedResult {
 				t.Errorf("expected result %v was %v", tc.ExpectedResult, result.Status)
 			}

--- a/lints/lint_san_dns_name_onion_not_ev_cert.go
+++ b/lints/lint_san_dns_name_onion_not_ev_cert.go
@@ -62,7 +62,7 @@ func (l *onionNotEV) Execute(c *x509.Certificate) *LintResult {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "san_dns_name_onion_not_ev_cert",
+		Name:          "e_san_dns_name_onion_not_ev_cert",
 		Description:   "certificates with a .onion subject name must be issued in accordance with EV Guidelines",
 		Citation:      "CABF Ballot 144",
 		Source:        CABFBaselineRequirements,

--- a/lints/lint_san_dns_name_onion_not_ev_cert_test.go
+++ b/lints/lint_san_dns_name_onion_not_ev_cert_test.go
@@ -33,7 +33,7 @@ func TestOnionNotEV(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			inputPath := fmt.Sprintf("%s%s", testCaseDir, tc.InputFilename)
-			result := Lints["san_dns_name_onion_not_ev_cert"].Execute(ReadCertificate(inputPath))
+			result := Lints["e_san_dns_name_onion_not_ev_cert"].Execute(ReadCertificate(inputPath))
 			if result.Status != tc.ExpectedResult {
 				t.Errorf("expected result %v was %v", tc.ExpectedResult, result.Status)
 			}

--- a/lints/lint_subject_contains_malformed_arpa_ip.go
+++ b/lints/lint_subject_contains_malformed_arpa_ip.go
@@ -129,7 +129,7 @@ func lintReversedIPAddressLabels(name string, ipv6 bool) error {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_contains_malformed_arpa_ip",
+		Name:          "w_subject_contains_malformed_arpa_ip",
 		Description:   "Checks no subject domain name contains a rDNS entry in an .arpa zone with the wrong number of labels",
 		Citation:      "BRs: 7.1.4.2.1",
 		Source:        CABFBaselineRequirements,

--- a/lints/lint_subject_contains_malformed_arpa_ip_test.go
+++ b/lints/lint_subject_contains_malformed_arpa_ip_test.go
@@ -61,7 +61,7 @@ func TestSubjectMalformedDNSARPA(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			inputPath := fmt.Sprintf("%s%s", testCaseDir, tc.InputFilename)
-			result := Lints["subject_contains_malformed_arpa_ip"].Execute(ReadCertificate(inputPath))
+			result := Lints["w_subject_contains_malformed_arpa_ip"].Execute(ReadCertificate(inputPath))
 			if result.Status != tc.ExpectedResult {
 				t.Errorf("expected result %v was %v", tc.ExpectedResult, result.Status)
 			}

--- a/lints/lint_subject_contains_reserved_arpa_ip.go
+++ b/lints/lint_subject_contains_reserved_arpa_ip.go
@@ -222,7 +222,7 @@ func lintReversedIPAddress(name string, ipv6 bool) error {
 
 func init() {
 	RegisterLint(&Lint{
-		Name:          "subject_contains_reserved_arpa_ip",
+		Name:          "e_subject_contains_reserved_arpa_ip",
 		Description:   "Checks no subject domain name contains a rDNS entry in an .arpa zone specifying a reserved IP address",
 		Citation:      "BRs: 7.1.4.2.1",
 		Source:        CABFBaselineRequirements,

--- a/lints/lint_subject_contains_reserved_arpa_ip_test.go
+++ b/lints/lint_subject_contains_reserved_arpa_ip_test.go
@@ -63,7 +63,7 @@ func TestSubjectReverseDNSARPA(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			inputPath := fmt.Sprintf("%s%s", testCaseDir, tc.InputFilename)
-			result := Lints["subject_contains_reserved_arpa_ip"].Execute(ReadCertificate(inputPath))
+			result := Lints["e_subject_contains_reserved_arpa_ip"].Execute(ReadCertificate(inputPath))
 			if result.Status != tc.ExpectedResult {
 				t.Errorf("expected result %v was %v", tc.ExpectedResult, result.Status)
 			}

--- a/zlint_test.go
+++ b/zlint_test.go
@@ -1,0 +1,30 @@
+package zlint
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zmap/zlint/lints"
+)
+
+func TestLintNames(t *testing.T) {
+	allowedPrefixes := []string{
+		"i_", "n_", // Both "i_" and "n_" are used for lints.Notice.
+		"w_", // lints.Warn
+		"e_", // lints.Error
+	}
+
+	for name, _ := range lints.Lints {
+		var valid bool
+		for _, prefix := range allowedPrefixes {
+			if strings.HasPrefix(name, prefix) {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			t.Errorf("lint name %q does not start with an allowed prefix (%v)\n",
+				name, allowedPrefixes)
+		}
+	}
+}

--- a/zlint_test.go
+++ b/zlint_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestLintNames(t *testing.T) {
 	allowedPrefixes := []string{
-		"i_", "n_", // Both "i_" and "n_" are used for lints.Notice.
+		"n_", // lints.Notice
 		"w_", // lints.Warn
 		"e_", // lints.Error
 	}

--- a/zlint_test.go
+++ b/zlint_test.go
@@ -14,7 +14,7 @@ func TestLintNames(t *testing.T) {
 		"e_", // lints.Error
 	}
 
-	for name, _ := range lints.Lints {
+	for name := range lints.Lints {
 		var valid bool
 		for _, prefix := range allowedPrefixes {
 			if strings.HasPrefix(name, prefix) {


### PR DESCRIPTION
Prior to recently I had been contributing lints without matching the project convention of naming the lint with a prefix based on its potential lint status result (e.g. `e_` for `lints.Error`, `w_` for `lints.Warn`, etc). :sweat: 

This branch fixes the `Name` of all of the lints that didn't match the convention and adds a new test in `zlint_test.go` that will enforce that all new lints meet the convention moving forward.