### PR TITLE
README: add guidance on choosing a lint result level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ following Go conventions, e.g., `subjectCommonNameNotFromSAN`. Example:
 This will generate a new lint in the `lints` directory with the necessary
 fields filled out.
 
+**Choosing a Lint Result Level.** When choosing what `lints.LintStatus` your new
+lint should return (e.g. `Notice`,`Warn`, `Error`, or `Fatal`) the following
+general guidance may help. `Error` should be used for clear violations of RFC/BR
+`MUST` or `MUST NOT` requirements and include strong citations. `Warn` should be
+used for violations of RFC/BR `SHOULD` or `SHOULD NOT` requirements and again
+should include strong citations. `Notice` should be used for more general "FYI"
+statements that violate non-codified community standards or for cases where
+citations are unclear. Lastly `Fatal` should be used when there is an
+unresolvable error in `zlint`, `zcrypto` or some other part of the certificate
+processing.
+
 **Scoping a Lint.** Lints are executed in three steps. First, the ZLint
 framework determines whether a certificate falls within the scope of a given
 lint by calling `CheckApplies`. This is often used to scope lints to only check


### PR DESCRIPTION
Clarifying the historic context on the lint levels in the README will help new lint contributors (and consumers of the lint results) understand the rationale behind which lints return which result.

The text is largely stolen from [@zakird's comment](https://github.com/zmap/zlint/issues/291#issuecomment-514413055) on an unrelated issue.
