### PR TITLE
CI: Switch to Go 1.13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 dist: trusty
 
 go:
-  - "1.12.x"
+  - "1.13.x"
 
 script:
   # Fast-fail on non-zero exit codes


### PR DESCRIPTION
The `makefile` could have the `GO_ENV` cleaned up to remove `GO111MODULE="on"` (the new default in Go 1.13) but for now I've left it to aid with Go 1.12.x compatibility.