### PR TITLE
README: Add a section on users/integrations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,24 @@ generate`:
 	go get github.com/zmap/zlint/cmd/zlint-gtld-update
 	go generate github.com/zmap/zlint/...
 
+Zlint Users/Integrations
+-------------------------
+
+Pre-issuance linting is **strongly recommended** by the [Mozilla root
+program](https://wiki.allizom.org/CA/Required_or_Recommended_Practices#Pre-Issuance_Linting).
+Here are some projects/CAs known to integrate with ZLint in some fashion:
+
+* [CFSSL](https://github.com/cloudflare/cfssl/pull/1015)
+* [crt.sh](https://crt.sh/lintcert)
+* [Digicert](https://bugzilla.mozilla.org/show_bug.cgi?id=1550645#c9)
+* [Government of Spain, FNMT](https://bugzilla.mozilla.org/show_bug.cgi?id=1495507#c8)
+* [Globalsign](https://cabforum.org/pipermail/public/2018-April/013233.html)
+* [Let's Encrypt](https://letsencrypt.org) and [Boulder](https://github.com/letsencrypt/boulder)
+* [Siemens](https://bugzilla.mozilla.org/show_bug.cgi?id=1391063#c32)
+* [QuoVadis](https://bugzilla.mozilla.org/show_bug.cgi?id=1521950#c3)
+
+Please submit a pull request to update the README if you are aware of
+another CA/project that uses zlint.
 
 License and Copyright
 ---------------------

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ program](https://wiki.allizom.org/CA/Required_or_Recommended_Practices#Pre-Issua
 Here are some projects/CAs known to integrate with ZLint in some fashion:
 
 * [CFSSL](https://github.com/cloudflare/cfssl/pull/1015)
-* [crt.sh](https://crt.sh/lintcert)
+* [Sectigo and crt.sh](https://groups.google.com/forum/#!msg/mozilla.dev.security.policy/sjXswrcsvrE/Nl3OLd4PAAAJ)
 * [Digicert](https://bugzilla.mozilla.org/show_bug.cgi?id=1550645#c9)
 * [Government of Spain, FNMT](https://bugzilla.mozilla.org/show_bug.cgi?id=1495507#c8)
 * [Globalsign](https://cabforum.org/pipermail/public/2018-April/013233.html)

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Here are some projects/CAs known to integrate with ZLint in some fashion:
 * [Digicert](https://bugzilla.mozilla.org/show_bug.cgi?id=1550645#c9)
 * [Government of Spain, FNMT](https://bugzilla.mozilla.org/show_bug.cgi?id=1495507#c8)
 * [Globalsign](https://cabforum.org/pipermail/public/2018-April/013233.html)
+* [GoDaddy](https://bugzilla.mozilla.org/show_bug.cgi?id=1462844#c6)
 * [Izenpe](https://bugzilla.mozilla.org/show_bug.cgi?id=1528290#c5)
 * [Let's Encrypt](https://letsencrypt.org) and [Boulder](https://github.com/letsencrypt/boulder)
 * [Siemens](https://bugzilla.mozilla.org/show_bug.cgi?id=1391063#c32)

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Here are some projects/CAs known to integrate with ZLint in some fashion:
 * [Digicert](https://bugzilla.mozilla.org/show_bug.cgi?id=1550645#c9)
 * [Government of Spain, FNMT](https://bugzilla.mozilla.org/show_bug.cgi?id=1495507#c8)
 * [Globalsign](https://cabforum.org/pipermail/public/2018-April/013233.html)
+* [Izenpe](https://bugzilla.mozilla.org/show_bug.cgi?id=1528290#c5)
 * [Let's Encrypt](https://letsencrypt.org) and [Boulder](https://github.com/letsencrypt/boulder)
 * [Siemens](https://bugzilla.mozilla.org/show_bug.cgi?id=1391063#c32)
 * [QuoVadis](https://bugzilla.mozilla.org/show_bug.cgi?id=1521950#c3)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Here are some projects/CAs known to integrate with ZLint in some fashion:
 * [CFSSL](https://github.com/cloudflare/cfssl/pull/1015)
 * [Sectigo and crt.sh](https://groups.google.com/forum/#!msg/mozilla.dev.security.policy/sjXswrcsvrE/Nl3OLd4PAAAJ)
 * [Digicert](https://bugzilla.mozilla.org/show_bug.cgi?id=1550645#c9)
+* [EJBCA](https://download.primekey.com/docs/EJBCA-Enterprise/6_11_1/adminguide.html#Post%20Processing%20Validators%20(Pre-Certificate%20or%20Certificate%20Validation))
 * [Government of Spain, FNMT](https://bugzilla.mozilla.org/show_bug.cgi?id=1495507#c8)
 * [Globalsign](https://cabforum.org/pipermail/public/2018-April/013233.html)
 * [GoDaddy](https://bugzilla.mozilla.org/show_bug.cgi?id=1462844#c6)


### PR DESCRIPTION
This PR adds a brief section mentioning some of the users of ZLint.

When you start looking at the CAs/projects that use ZLint it's pretty remarkable how many certificates this library ends up touching pre and post-issuance :eyes:

I suspect there are other Bugzilla/MDSP posts where CAs mention using `zlint` and I would welcome follow-up PRs adding those users to the README. These are the ones I had noted myself.