### PR TITLE
integration: restructure expected data to use lints vs. cert FPs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ script:
   # Run integration tests
   - make integration PARALLELISM=3
 
-cache:
-  directories:
-    - data
-
 notifications:
   email:
   - dkumar11@illinois.edu

--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ func (l *caCRLSignNotSet) RunTest(c *x509.Certificate) *ResultStruct {
 }
 ```
 
-**Creating Tests.** Every lint should also have two corresponding tests for a
-success and failure condition. We have typically generated test certificates
-using Go (see https://golang.org/pkg/crypto/x509/#CreateCertificate for
-details), but OpenSSL could also be used. Test certificates should be placed in
-`testlint/testCerts` and called from the test file created by `newLint.sh`.
+**Creating Unit Tests.** Every lint should also have two corresponding unit
+tests for a success and failure condition. We have typically generated test
+certificates using Go (see https://golang.org/pkg/crypto/x509/#CreateCertificate
+for details), but OpenSSL could also be used. Test certificates should be placed
+in `testlint/testCerts` and called from the test file created by `newLint.sh`.
 Prepend the PEM with the output of `openssl x509 -text`.
 
 Example:
@@ -159,6 +159,16 @@ func TestBasicConstNotCritical(t *testing.T) {
 }
 
 ```
+
+**Integration Tests.** ZLint's [continuous
+integration](https://travis-ci.org/zmap/zlint) includes an integration test
+phase where all lints are run against a large corpus of certificates. The number
+of notice, warning, error and fatal results for each lint are captured and
+compared to a set of expected values in a configuration file. You may need to
+update these expected values when you add/change lints. Please see the
+[integration tests
+README](https://github.com/zmap/zlint/blob/master/integration/README.md) for
+more information.
 
 Updating the TLD Map
 --------------------

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,94 @@
+ZLint Integration Tests
+=======================
+
+Overview
+--------
+
+Integration tests are run during Travis with the `make integration` target of
+the Zlint makefile. This uses the default configuration located in
+`integration/config.json`.
+
+At a high level the integration test process involves fetching configured CSV
+data files, parsing certificates from the data file rows, linting the
+certificates, and finally comparing the results to the expected values from the
+configuration file. Any differences between the results and the expected values
+will fail the integration test.
+
+The ZLint integration tests are intended to make it easier to develop and test
+new lints against representative data as well as to catch regressions and bugs
+with existing lints.
+
+Running the integration tests
+-----------------------------
+
+To run the integration tests with the default configuration use the
+`integration` make target:
+
+```
+make integration
+```
+
+To increase the number of linting Go routines set the `PARALLELISM` variable:
+
+```
+make integration PARALLELISM=10
+```
+
+To pass other integration test command line parameters use the `INT_TEST`
+variable:
+
+```
+make integration INT_FLAGS="-lintSummary -fingerprintSummary -lintFilter='^e_' -config small.config.json"
+```
+
+Config options
+--------------
+
+* `-parallelism` - number of linting Go routines to spawn (_Default: 5_)
+
+* `-configFile` - integration test config file (_Default `integration/config.json`_)
+
+* `-forceDownload` - ignore cached data files on disk forcing it to be downloaded fresh (_Default false_)
+
+* `-overwriteExpected` - overwrite the expected results map in the `-configFile` with the results of the test run. This is useful when new lints or bugfixes are added and the changes in the results map have been vetted and are ready to be committed to the repository. (_Default false_)
+
+* `-fingerprintSummarize` - print a summary of all certificate fingerprints that had lint findings. Can be quite spammy with the default data set. (_Default false_)
+
+* `-fingerprintFilterString` - only lint certificates with hex encoded fingerprints that match the provided regular expression (_Default none_)
+
+* `-lintSummarize` - print a summary of result type counts by lint name. (_Default false_)
+
+* `-lintFilterString` - only lint certificates with lints that have a name that matches the provided regular expression (_Default: none_)
+
+* `-outputTick` - number of certificates to lint before printing a "." marker to output (_Default 1000_)
+
+Data
+----
+
+The certificate data used by the integration tests were collected from
+[Censys](https://censys.io/) using [a
+query](https://github.com/zmap/zlint-test-corpus/blob/847bdf990a0f1ca4f709457d235c850a7a891b73/query.sql)
+intended to select random samples of certificates that chain to a Mozilla
+trusted root
+
+The exported CSV data files created by this query live in a separate Github
+repository to avoid bloating the ZLint repo:
+[zmap/zlint-test-corpus](https://github.com/zmap/zlint-test-corpus).
+
+The default configuration uses 60 CSV files from the `zlint-test-corpus`
+repository. This represents just shy of 600,000 certificates.
+
+Care is taken by the integration test tooling to download the data only once.
+Cached copies on-disk are used for subsequent runs unless the `-forceDownload`
+flag is provided.
+
+
+Adding a new lint
+-----------------
+
+TODO(@cpu)
+
+Investigating failures
+----------------------
+
+TODO(@cpu)

--- a/integration/README.md
+++ b/integration/README.md
@@ -65,7 +65,7 @@ Config options
 Data
 ----
 
-The certificate data used by the integration tests were collected from
+The certificate data used by the integration tests was collected from
 [Censys](https://censys.io/) using [a
 query](https://github.com/zmap/zlint-test-corpus/blob/847bdf990a0f1ca4f709457d235c850a7a891b73/query.sql)
 intended to select random samples of certificates that chain to a Mozilla
@@ -82,13 +82,217 @@ Care is taken by the integration test tooling to download the data only once.
 Cached copies on-disk are used for subsequent runs unless the `-forceDownload`
 flag is provided.
 
+Example failure investigation 
+-----------------------------
 
-Adding a new lint
------------------
+Here's an example of using the integration test tooling to investing a linter
+bug.
 
-TODO(@cpu)
+First, let's revert [a
+bugfix](https://github.com/cpu/zlint/commit/5dcecad773158b82b5e52064ee2782d1b8a79314)
+for the `e_subject_printable_string_badalpha` lint.
 
-Investigating failures
-----------------------
+* `git revert 5dcecad773158b82b5e52064ee2782d1b8a79314`
 
-TODO(@cpu)
+Now let's run the integration tests. We'll use a higher than default
+parallelism value since our dev machine probably has a few cores laying around.
+
+This will take approximately ~15 minutes. Longer if you haven't downloaded the
+integration test data when running the tests previously. If you want to tighten
+the iteration time (e.g. while you're developing a new lint vs chasing a bug)
+try specifying a `-config` that has fewer data files.
+
+* `make integration PARALLELISM=6`
+
+As we'd expect after reverting a bugfix the integration tests fail.
+
+```
+--- FAIL: TestCorpus (448.05s)
+    corpus_test.go:139: linted 599997 certificates
+    corpus_test.go:163: expected lint "e_subject_printable_string_badalpha" to have result fatals: 0    errs: 7    warns: 0    infos: 0    got fatals: 0    errs: 221  warns: 0    infos: 0   
+FAIL
+FAIL	github.com/zmap/zlint/integration	448.244s
+FAIL
+make: *** [makefile:33: integration] Error 1
+```
+
+The `e_subject_printable_string_badalpha` lint was expected to find only 7
+certificates with errors and it found 221!
+
+The next step is to find out which certificates in the integration test data
+are failing. To do that we'll re-run the integration tests specifying a
+`-lintFilter` flag so that only the `e_subject_printable_string_badalpha` is
+run and a `-fingerprintSummary` flag so the certificate fingerprints that have
+a non-pass result from this lint are printed.
+
+* `make integration PARALLELISM=6 INT_FLAGS="-fingerprintSummary -lintFilter='e_subject_printable_string_badalpha'"`
+
+Once that completes (which should be faster than before now that we're only running one lint per certificate) the 221 certificate fingerprints that failed the lint are printed:
+
+```
+2019/11/23 18:52:43 Finished reading data from 60 CSV files. Closing work channel
+
+summary of result type by certificate fingerprint:
+0037ae7546555efca0935dfedf3cef79b1a0301b18bb6a86382becf6aa53f1c4  fatals: 0    errs: 1    warns: 0    infos: 0
+004e38dd0ae5410010a0ebfc6afddeed2020008b146908fd635dc725960fad53  fatals: 0    errs: 1    warns: 0    infos: 0
+0066f781f91c6e694e7ad98babc89c9f96cf1087005e8f713559b1ceb16d417b  fatals: 0    errs: 1    warns: 0    infos: 0
+008bedb904a6c7a8219c14da91d433863d9d27fbb225c12bfcc7dc3a59657999  fatals: 0    errs: 1    warns: 0    infos: 0
+00b308aafa26b3315a9c7371c5ff14807fcd567ea4f543a70dabfa873502d3fb  fatals: 0    errs: 1    warns: 0    infos: 0
+00b579f8b86ddca8e2a9d2d610f91786db1bace28327ee9d6c2d7099df78d3f8  fatals: 0    errs: 1    warns: 0    infos: 0
+<snipped>
+ffe2f3264d9b41980c8c1ebae0f69533b4ed6486e45827447e98ac27c3ddb791  fatals: 0    errs: 1    warns: 0    infos: 0
+fff61b942a56b87c5d5dd3725f43d3708bc646df87adb5db1792bbf61ad6875c  fatals: 0    errs: 1    warns: 0    infos: 0
+fffd96497d21df4d55fa5e8883645325e1b9472db99e1b1a322d4df8f5b0bd3a  fatals: 0    errs: 1    warns: 0    infos: 0
+
+--- FAIL: TestCorpus (126.13s)
+    corpus_test.go:139: linted 599997 certificates
+    corpus_test.go:163: expected lint "e_subject_printable_string_badalpha" to have result fatals: 0    errs: 7    warns: 0    infos: 0    got fatals: 0    errs: 221  warns: 0    infos: 0
+FAIL
+FAIL  github.com/zmap/zlint/integration 126.143s
+FAIL
+
+```
+
+The next step is to look at some of the certificates corresponding to the fingerprints shown. Since the full certificate data is already present on disk we can do this easily with a small utility script included with ZLint. E.g. to check out the first fingerprint `0037ae7546555efca0935dfedf3cef79b1a0301b18bb6a86382becf6aa53f1c4` we can run:
+
+```
+./integration/certByFP.sh 0037ae7546555efca0935dfedf3cef79b1a0301b18bb6a86382becf6aa53f1c4
+```
+
+This will find the certificate, parse it with OpenSSL, print the text version
+and the PEM version, and finally a Censys.io URL:
+
+```
+ integration/certByFP.sh 0037ae7546555efca0935dfedf3cef79b1a0301b18bb6a86382becf6aa53f1c4
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            3f:3d:fc:65:2d:d6:bc:ea:dc:70:4f:df
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = BE, O = GlobalSign nv-sa, CN = GlobalSign RSA OV SSL CA 2018
+        Validity
+            Not Before: Jun 19 08:54:52 2019 GMT
+            Not After : Jun 19 08:54:52 2021 GMT
+        Subject: C = CH, ST = Vaud, L = Lausanne, O = FONDATION ECOLE D'ETUDES SOCIALES ET PEDAGOGIQUES, CN = cuc01-ms.eesp.ch
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:b6:1b:b9:6a:7f:99:18:a8:1e:8b:43:ff:c4:81:
+                    90:9f:e3:42:7a:2f:53:39:bd:e9:6a:d3:7b:24:1c:
+                    6b:4f:65:61:35:03:c3:9a:7b:c7:6a:5f:a9:39:7f:
+                    0d:82:36:30:ac:03:4b:61:4c:bc:be:33:4c:e4:bb:
+                    aa:f9:4b:a6:1b:ef:d8:4d:e1:77:88:89:ad:16:db:
+                    7c:0e:fd:b1:de:07:7b:a5:78:a7:a0:9d:4d:55:18:
+                    ed:6c:9d:db:a6:c3:01:24:c7:5d:31:0c:93:86:e5:
+                    f3:f7:37:f2:31:04:3d:b5:7f:35:6c:bb:17:30:bb:
+                    8c:ae:24:6a:b9:57:12:71:97:a9:04:94:fd:8b:b5:
+                    06:07:eb:e6:c2:06:c3:73:47:89:6e:a6:42:44:fe:
+                    36:4b:fa:76:6d:4c:c7:78:1b:b9:98:75:d4:81:1c:
+                    d0:af:57:dd:14:ed:bb:b0:96:10:ff:85:67:e1:c0:
+                    e0:d4:b4:34:b1:ef:6f:d9:05:13:ce:71:99:8c:51:
+                    12:92:88:60:d5:ee:7d:9c:1b:69:c8:b0:e0:7d:43:
+                    05:d8:76:2e:fe:13:8f:46:e5:45:9b:a3:fe:98:af:
+                    8e:2d:3d:5b:8a:e1:1e:11:42:92:0e:f6:1f:7a:e3:
+                    c9:f5:5c:58:97:b0:10:fb:cd:e8:b6:f3:55:38:ea:
+                    8e:29
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            Authority Information Access: 
+                CA Issuers - URI:http://secure.globalsign.com/cacert/gsrsaovsslca2018.crt
+                OCSP - URI:http://ocsp.globalsign.com/gsrsaovsslca2018
+
+            X509v3 Certificate Policies: 
+                Policy: 1.3.6.1.4.1.4146.1.20
+                  CPS: https://www.globalsign.com/repository/
+                Policy: 2.23.140.1.2.2
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://crl.globalsign.com/gsrsaovsslca2018.crl
+
+            X509v3 Subject Alternative Name: 
+                DNS:cuc01-ms.eesp.ch, DNS:eesp.ch, DNS:cuc01.eesp.ch, DNS:cuc02.eesp.ch
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Authority Key Identifier: 
+                keyid:F8:EF:7F:F2:CD:78:67:A8:DE:6F:8F:24:8D:88:F1:87:03:02:B3:EB
+
+            X509v3 Subject Key Identifier: 
+                4A:23:C8:49:41:68:67:21:B8:C9:91:D2:3C:7B:F9:E6:2B:76:34:37
+            CT Precertificate Poison: critical
+                NULL
+    Signature Algorithm: sha256WithRSAEncryption
+         03:68:b9:11:c0:b9:43:a7:0b:17:55:95:83:30:40:a4:74:31:
+         ad:5b:8d:17:8b:26:ee:c3:a0:ce:a8:5f:53:55:34:75:11:33:
+         b1:25:58:33:6c:a8:db:e5:7a:40:da:c4:47:a0:3e:77:41:0f:
+         7b:29:7c:5d:54:cd:ac:98:f7:e2:7c:9c:f5:92:0f:da:bc:26:
+         ad:a7:44:26:b1:93:89:69:01:d8:18:a1:a1:bc:c2:9d:84:27:
+         45:c4:01:96:c1:b6:86:95:fe:82:01:75:a5:d0:e4:6e:6b:bb:
+         6b:22:15:83:71:67:dc:f2:54:30:90:4d:7b:be:6e:30:11:50:
+         3e:9d:94:eb:75:4a:7c:67:ee:d5:bd:3b:8a:db:58:c1:42:1e:
+         aa:5c:65:96:5e:83:b6:29:e2:5f:f4:4d:a5:2a:4f:19:01:e8:
+         2b:d8:14:16:da:c9:a1:68:15:d5:34:24:b9:4f:eb:d3:6c:1d:
+         26:d2:50:3a:0d:b4:f3:fd:cf:ce:91:2e:c4:4c:95:95:0c:3f:
+         2b:62:b4:97:8a:41:96:97:97:6a:4c:c0:12:20:9f:ac:87:9c:
+         f1:f7:09:f0:f0:43:72:e2:42:f4:ab:5e:33:9c:ec:14:8a:5f:
+         e9:3d:8e:f4:aa:dc:5e:b7:41:62:cd:ea:fb:08:1a:c2:01:e5:
+         f0:c3:c8:b0
+-----BEGIN CERTIFICATE-----
+MIIFYDCCBEigAwIBAgIMPz38ZS3WvOrccE/fMA0GCSqGSIb3DQEBCwUAMFAxCzAJ
+BgNVBAYTAkJFMRkwFwYDVQQKExBHbG9iYWxTaWduIG52LXNhMSYwJAYDVQQDEx1H
+bG9iYWxTaWduIFJTQSBPViBTU0wgQ0EgMjAxODAeFw0xOTA2MTkwODU0NTJaFw0y
+MTA2MTkwODU0NTJaMIGGMQswCQYDVQQGEwJDSDENMAsGA1UECBMEVmF1ZDERMA8G
+A1UEBxMITGF1c2FubmUxOjA4BgNVBAoTMUZPTkRBVElPTiBFQ09MRSBEJ0VUVURF
+UyBTT0NJQUxFUyBFVCBQRURBR09HSVFVRVMxGTAXBgNVBAMTEGN1YzAxLW1zLmVl
+c3AuY2gwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2G7lqf5kYqB6L
+Q//EgZCf40J6L1M5velq03skHGtPZWE1A8Oae8dqX6k5fw2CNjCsA0thTLy+M0zk
+u6r5S6Yb79hN4XeIia0W23wO/bHeB3uleKegnU1VGO1sndumwwEkx10xDJOG5fP3
+N/IxBD21fzVsuxcwu4yuJGq5VxJxl6kElP2LtQYH6+bCBsNzR4lupkJE/jZL+nZt
+TMd4G7mYddSBHNCvV90U7buwlhD/hWfhwODUtDSx72/ZBRPOcZmMURKSiGDV7n2c
+G2nIsOB9QwXYdi7+E49G5UWbo/6Yr44tPVuK4R4RQpIO9h9648n1XFiXsBD7zei2
+81U46o4pAgMBAAGjggIBMIIB/TAOBgNVHQ8BAf8EBAMCBaAwgY4GCCsGAQUFBwEB
+BIGBMH8wRAYIKwYBBQUHMAKGOGh0dHA6Ly9zZWN1cmUuZ2xvYmFsc2lnbi5jb20v
+Y2FjZXJ0L2dzcnNhb3Zzc2xjYTIwMTguY3J0MDcGCCsGAQUFBzABhitodHRwOi8v
+b2NzcC5nbG9iYWxzaWduLmNvbS9nc3JzYW92c3NsY2EyMDE4MFYGA1UdIARPME0w
+QQYJKwYBBAGgMgEUMDQwMgYIKwYBBQUHAgEWJmh0dHBzOi8vd3d3Lmdsb2JhbHNp
+Z24uY29tL3JlcG9zaXRvcnkvMAgGBmeBDAECAjAJBgNVHRMEAjAAMD8GA1UdHwQ4
+MDYwNKAyoDCGLmh0dHA6Ly9jcmwuZ2xvYmFsc2lnbi5jb20vZ3Nyc2FvdnNzbGNh
+MjAxOC5jcmwwQgYDVR0RBDswOYIQY3VjMDEtbXMuZWVzcC5jaIIHZWVzcC5jaIIN
+Y3VjMDEuZWVzcC5jaIINY3VjMDIuZWVzcC5jaDAdBgNVHSUEFjAUBggrBgEFBQcD
+AQYIKwYBBQUHAwIwHwYDVR0jBBgwFoAU+O9/8s14Z6jeb48kjYjxhwMCs+swHQYD
+VR0OBBYEFEojyElBaGchuMmR0jx7+eYrdjQ3MBMGCisGAQQB1nkCBAMBAf8EAgUA
+MA0GCSqGSIb3DQEBCwUAA4IBAQADaLkRwLlDpwsXVZWDMECkdDGtW40Xiybuw6DO
+qF9TVTR1ETOxJVgzbKjb5XpA2sRHoD53QQ97KXxdVM2smPfifJz1kg/avCatp0Qm
+sZOJaQHYGKGhvMKdhCdFxAGWwbaGlf6CAXWl0ORua7trIhWDcWfc8lQwkE17vm4w
+EVA+nZTrdUp8Z+7VvTuK21jBQh6qXGWWXoO2KeJf9E2lKk8ZAegr2BQW2smhaBXV
+NCS5T+vTbB0m0lA6DbTz/c/OkS7ETJWVDD8rYrSXikGWl5dqTMASIJ+sh5zx9wnw
+8ENy4kL0q14znOwUil/pPY70qtxet0Fizer7CBrCAeXww8iw
+-----END CERTIFICATE-----
+
++ View on Censys: https://censys.io/certificates/0037ae7546555efca0935dfedf3cef79b1a0301b18bb6a86382becf6aa53f1c4
+
+```
+
+If we wanted to step through the linter in question in a debugger when it's
+linting this certificate we could run the integration tests again specifying a
+`-fingerprintFilter` that limits linting to the certificate we're interested
+in:
+
+* `make integration PARALLELISM=6 INT_FLAGS="-fingerprintSummary -lintFilter='e_subject_printable_string_badalpha' -fingerprintFilter='0037ae7546555efca0935dfedf3cef79b1a0301b18bb6a86382becf6aa53f1c4'"`
+
+By spot-checking a few of the new 221 certificate fingerprints with
+`certByFP.sh` and with `-lintFilter/-fingerprintFilter` we're likely to notice
+that all of the certificates causing new error results have a `'` character in
+their PrintableString encoded Subjects, which should be allowed.
+
+The `'` character being omitted from the regexp used by the
+`e_subject_printable_string_badalpha` lint was the root cause of the bugfix we
+reverted and so the integration tests have done the right thing and flagged an
+unintended regression.

--- a/integration/README.md
+++ b/integration/README.md
@@ -85,22 +85,23 @@ flag is provided.
 Example failure investigation 
 -----------------------------
 
-Here's an example of using the integration test tooling to investing a linter
+Here's an example of using the integration test tooling to investigate a linter
 bug.
 
 First, let's revert [a
 bugfix](https://github.com/cpu/zlint/commit/5dcecad773158b82b5e52064ee2782d1b8a79314)
-for the `e_subject_printable_string_badalpha` lint.
+for the `e_subject_printable_string_badalpha` lint so we can see what happens
+when there's a difference between the test results and the expected results.
 
 * `git revert 5dcecad773158b82b5e52064ee2782d1b8a79314`
 
 Now let's run the integration tests. We'll use a higher than default
 parallelism value since our dev machine probably has a few cores laying around.
 
-This will take approximately ~15 minutes. Longer if you haven't downloaded the
-integration test data when running the tests previously. If you want to tighten
-the iteration time (e.g. while you're developing a new lint vs chasing a bug)
-try specifying a `-config` that has fewer data files.
+This will take approximately ~15 minutes (Longer if you haven't downloaded the
+integration test data in previous runs). If you want to tighten the iteration
+time (e.g. while you're developing a new lint vs chasing a bug) try specifying
+a `-config` file that has fewer data files than the default one.
 
 * `make integration PARALLELISM=6`
 
@@ -153,17 +154,25 @@ FAIL
 
 ```
 
-The next step is to look at some of the certificates corresponding to the fingerprints shown. Since the full certificate data is already present on disk we can do this easily with a small utility script included with ZLint. E.g. to check out the first fingerprint `0037ae7546555efca0935dfedf3cef79b1a0301b18bb6a86382becf6aa53f1c4` we can run:
+The next step is to look at some of the certificates corresponding to the
+fingerprints shown. Since the full certificate data is already present on disk
+we can do this easily with a small utility script (`integrate/certByFP.sh`)
+included with ZLint. 
+
+To check out the first fingerprint from the summary output
+(`0037ae7546555efca0935dfedf3cef79b1a0301b18bb6a86382becf6aa53f1c4`) we can run:
 
 ```
 ./integration/certByFP.sh 0037ae7546555efca0935dfedf3cef79b1a0301b18bb6a86382becf6aa53f1c4
 ```
 
-This will find the certificate, parse it with OpenSSL, print the text version
-and the PEM version, and finally a Censys.io URL:
+This will find the matching certificate in the cached integration test data
+directory, parse it with OpenSSL, print the text version and the PEM version,
+and finally show a Censys.io URL:
 
 ```
- integration/certByFP.sh 0037ae7546555efca0935dfedf3cef79b1a0301b18bb6a86382becf6aa53f1c4
+./integration/certByFP.sh 0037ae7546555efca0935dfedf3cef79b1a0301b18bb6a86382becf6aa53f1c4
+
 Certificate:
     Data:
         Version: 3 (0x2)

--- a/integration/certByFP.sh
+++ b/integration/certByFP.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+cd "$(dirname "$0")"
+
+DATA="../data/*.csv"
+
+row=$(grep "$1" $DATA)
+
+echo "https://censys.io/certificates/$1"
+echo ""
+echo "$row" | \
+  awk -F "," '{print $(NF-1)}' | \
+  base64 -d | \
+  openssl x509 -inform DER -outform PEM -text

--- a/integration/certByFP.sh
+++ b/integration/certByFP.sh
@@ -6,9 +6,11 @@ DATA="../data/*.csv"
 
 row=$(grep "$1" $DATA)
 
-echo "https://censys.io/certificates/$1"
-echo ""
 echo "$row" | \
   awk -F "," '{print $(NF-1)}' | \
   base64 -d | \
   openssl x509 -inform DER -outform PEM -text
+
+echo ""
+echo "+ View on Censys: https://censys.io/certificates/$1"
+echo ""

--- a/integration/config.go
+++ b/integration/config.go
@@ -153,7 +153,7 @@ func (c config) PrepareCache(force bool) error {
 			log.Fatalf("error checking cache: %v\n", err)
 		} else if !exists || force {
 			log.Printf("Downloading data file %q (%d of %d, url: %q)",
-				i+1, len(c.Files), f.Name, f.URL)
+				f.Name, i+1, len(c.Files), f.URL)
 			if err := f.DownloadTo(c.CacheDir); err != nil {
 				log.Fatalf("Failed to download: %v", err)
 			}

--- a/integration/config.go
+++ b/integration/config.go
@@ -89,7 +89,7 @@ func (f dataFile) DownloadTo(dir string) error {
 type config struct {
 	CacheDir string
 	Files    []dataFile
-	Expected map[string]resultCount
+	Expected keyedCounts
 }
 
 // loadConfig returns a config struct populated from the JSON serialization in

--- a/integration/config.go
+++ b/integration/config.go
@@ -148,12 +148,12 @@ func (c config) PrepareCache(force bool) error {
 	} else {
 		log.Printf("Using existing cache directory %q\n", c.CacheDir)
 	}
-	for _, f := range c.Files {
+	for i, f := range c.Files {
 		if exists, err := f.ExistsIn(c.CacheDir); err != nil {
 			log.Fatalf("error checking cache: %v\n", err)
 		} else if !exists || force {
-			log.Printf("Downloading data file %q (url: %q)",
-				f.Name, f.URL)
+			log.Printf("Downloading data file %q (%d of %d, url: %q)",
+				i+1, len(c.Files), f.Name, f.URL)
 			if err := f.DownloadTo(c.CacheDir); err != nil {
 				log.Fatalf("Failed to download: %v", err)
 			}

--- a/integration/config.go
+++ b/integration/config.go
@@ -89,7 +89,7 @@ func (f dataFile) DownloadTo(dir string) error {
 type config struct {
 	CacheDir string
 	Files    []dataFile
-	Expected map[string]result
+	Expected map[string]resultCount
 }
 
 // loadConfig returns a config struct populated from the JSON serialization in

--- a/integration/config.json
+++ b/integration/config.json
@@ -241,5 +241,491 @@
       "Name": "xch.csv",
       "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xch.bz2"
     }
-  ]
+  ],
+  "Expected": {
+    "e_basic_constraints_not_critical": {
+      "ErrCount": 11
+    },
+    "e_ca_common_name_missing": {},
+    "e_ca_country_name_invalid": {
+      "ErrCount": 5
+    },
+    "e_ca_country_name_missing": {
+      "ErrCount": 31
+    },
+    "e_ca_crl_sign_not_set": {
+      "ErrCount": 1
+    },
+    "e_ca_is_ca": {},
+    "e_ca_key_cert_sign_not_set": {
+      "ErrCount": 1
+    },
+    "e_ca_key_usage_missing": {
+      "ErrCount": 9
+    },
+    "e_ca_key_usage_not_critical": {
+      "ErrCount": 21
+    },
+    "e_ca_organization_name_missing": {
+      "ErrCount": 64
+    },
+    "e_ca_subject_field_empty": {},
+    "e_cab_dv_conflicts_with_locality": {
+      "ErrCount": 12
+    },
+    "e_cab_dv_conflicts_with_org": {
+      "ErrCount": 12
+    },
+    "e_cab_dv_conflicts_with_postal": {},
+    "e_cab_dv_conflicts_with_province": {
+      "ErrCount": 12
+    },
+    "e_cab_dv_conflicts_with_street": {},
+    "e_cab_iv_requires_personal_name": {},
+    "e_cab_ov_requires_org": {
+      "ErrCount": 2
+    },
+    "e_cert_contains_unique_identifier": {},
+    "e_cert_extensions_version_not_3": {},
+    "e_cert_policy_iv_requires_country": {},
+    "e_cert_policy_iv_requires_province_or_locality": {},
+    "e_cert_policy_ov_requires_country": {},
+    "e_cert_policy_ov_requires_province_or_locality": {
+      "ErrCount": 66
+    },
+    "e_cert_unique_identifier_version_not_2_or_3": {},
+    "e_distribution_point_incomplete": {},
+    "e_dnsname_bad_character_in_label": {
+      "ErrCount": 167
+    },
+    "e_dnsname_contains_bare_iana_suffix": {},
+    "e_dnsname_empty_label": {
+      "ErrCount": 11
+    },
+    "e_dnsname_hyphen_in_sld": {},
+    "e_dnsname_label_too_long": {},
+    "e_dnsname_left_label_wildcard_correct": {
+      "ErrCount": 5
+    },
+    "e_dnsname_not_valid_tld": {
+      "ErrCount": 138
+    },
+    "e_dnsname_underscore_in_sld": {
+      "ErrCount": 1
+    },
+    "e_dnsname_wildcard_only_in_left_label": {},
+    "e_dsa_correct_order_in_subgroup": {},
+    "e_dsa_improper_modulus_or_divisor_size": {},
+    "e_dsa_params_missing": {},
+    "e_dsa_shorter_than_2048_bits": {},
+    "e_dsa_unique_correct_representation": {},
+    "e_ec_improper_curves": {},
+    "e_ev_business_category_missing": {
+      "ErrCount": 2
+    },
+    "e_ev_country_name_missing": {},
+    "e_ev_organization_name_missing": {},
+    "e_ev_serial_number_missing": {
+      "ErrCount": 1
+    },
+    "e_ev_valid_time_too_long": {},
+    "e_ext_aia_marked_critical": {},
+    "e_ext_authority_key_identifier_critical": {},
+    "e_ext_authority_key_identifier_missing": {
+      "ErrCount": 37
+    },
+    "e_ext_authority_key_identifier_no_key_identifier": {
+      "ErrCount": 65
+    },
+    "e_ext_cert_policy_disallowed_any_policy_qualifier": {},
+    "e_ext_cert_policy_duplicate": {},
+    "e_ext_cert_policy_explicit_text_ia5_string": {},
+    "e_ext_cert_policy_explicit_text_too_long": {
+      "ErrCount": 175
+    },
+    "e_ext_duplicate_extension": {},
+    "e_ext_freshest_crl_marked_critical": {},
+    "e_ext_ian_dns_not_ia5_string": {},
+    "e_ext_ian_empty_name": {},
+    "e_ext_ian_no_entries": {},
+    "e_ext_ian_rfc822_format_invalid": {},
+    "e_ext_ian_space_dns_name": {},
+    "e_ext_ian_uri_format_invalid": {},
+    "e_ext_ian_uri_host_not_fqdn_or_ip": {},
+    "e_ext_ian_uri_not_ia5": {},
+    "e_ext_ian_uri_relative": {},
+    "e_ext_key_usage_cert_sign_without_ca": {},
+    "e_ext_key_usage_without_bits": {},
+    "e_ext_name_constraints_not_critical": {
+      "ErrCount": 130
+    },
+    "e_ext_name_constraints_not_in_ca": {},
+    "e_ext_policy_constraints_empty": {},
+    "e_ext_policy_constraints_not_critical": {},
+    "e_ext_policy_map_any_policy": {},
+    "e_ext_san_contains_reserved_ip": {
+      "ErrCount": 1
+    },
+    "e_ext_san_directory_name_present": {
+      "ErrCount": 226
+    },
+    "e_ext_san_dns_name_too_long": {},
+    "e_ext_san_dns_not_ia5_string": {
+      "ErrCount": 1
+    },
+    "e_ext_san_edi_party_name_present": {},
+    "e_ext_san_empty_name": {
+      "ErrCount": 2
+    },
+    "e_ext_san_missing": {
+      "ErrCount": 93
+    },
+    "e_ext_san_no_entries": {
+      "ErrCount": 3
+    },
+    "e_ext_san_not_critical_without_subject": {},
+    "e_ext_san_other_name_present": {
+      "ErrCount": 19
+    },
+    "e_ext_san_registered_id_present": {},
+    "e_ext_san_rfc822_format_invalid": {},
+    "e_ext_san_rfc822_name_present": {
+      "ErrCount": 119
+    },
+    "e_ext_san_space_dns_name": {},
+    "e_ext_san_uniform_resource_identifier_present": {
+      "ErrCount": 1
+    },
+    "e_ext_san_uri_format_invalid": {},
+    "e_ext_san_uri_host_not_fqdn_or_ip": {},
+    "e_ext_san_uri_not_ia5": {},
+    "e_ext_san_uri_relative": {},
+    "e_ext_subject_directory_attr_critical": {},
+    "e_ext_subject_key_identifier_critical": {},
+    "e_ext_subject_key_identifier_missing_ca": {
+      "ErrCount": 5
+    },
+    "e_ext_tor_service_descriptor_hash_invalid": {},
+    "e_generalized_time_does_not_include_seconds": {},
+    "e_generalized_time_includes_fraction_seconds": {},
+    "e_generalized_time_not_in_zulu": {},
+    "e_ian_bare_wildcard": {},
+    "e_ian_dns_name_includes_null_char": {},
+    "e_ian_dns_name_starts_with_period": {},
+    "e_ian_wildcard_not_first": {},
+    "e_inhibit_any_policy_not_critical": {},
+    "e_international_dns_name_not_nfc": {},
+    "e_international_dns_name_not_unicode": {},
+    "e_invalid_certificate_version": {},
+    "e_issuer_dn_country_not_printable_string": {},
+    "e_issuer_field_empty": {},
+    "e_name_constraint_empty": {},
+    "e_name_constraint_maximum_not_absent": {},
+    "e_name_constraint_minimum_non_zero": {},
+    "e_old_root_ca_rsa_mod_less_than_2048_bits": {},
+    "e_old_sub_ca_rsa_mod_less_than_1024_bits": {},
+    "e_old_sub_cert_rsa_mod_less_than_1024_bits": {},
+    "e_onion_subject_validity_time_too_large": {},
+    "e_path_len_constraint_improperly_included": {
+      "ErrCount": 4
+    },
+    "e_path_len_constraint_zero_or_less": {},
+    "e_public_key_type_not_allowed": {},
+    "e_qcstatem_etsi_present_qcs_critical": {},
+    "e_qcstatem_etsi_type_as_statem": {
+      "ErrCount": 234
+    },
+    "e_qcstatem_mandatory_etsi_statems": {
+      "ErrCount": 141
+    },
+    "e_qcstatem_qccompliance_valid": {},
+    "e_qcstatem_qclimitvalue_valid": {},
+    "e_qcstatem_qcpds_valid": {},
+    "e_qcstatem_qcretentionperiod_valid": {},
+    "e_qcstatem_qcsscd_valid": {},
+    "e_qcstatem_qctype_valid": {
+      "ErrCount": 1
+    },
+    "e_root_ca_extended_key_usage_present": {},
+    "e_root_ca_key_usage_must_be_critical": {
+      "ErrCount": 14
+    },
+    "e_root_ca_key_usage_present": {
+      "ErrCount": 5
+    },
+    "e_rsa_exp_negative": {},
+    "e_rsa_mod_less_than_2048_bits": {
+      "ErrCount": 51
+    },
+    "e_rsa_no_public_key": {},
+    "e_rsa_public_exponent_not_odd": {},
+    "e_rsa_public_exponent_too_small": {},
+    "e_san_bare_wildcard": {},
+    "e_san_dns_name_includes_null_char": {},
+    "e_san_dns_name_onion_not_ev_cert": {},
+    "e_san_dns_name_starts_with_period": {},
+    "e_san_wildcard_not_first": {
+      "ErrCount": 2
+    },
+    "e_serial_number_longer_than_20_octets": {},
+    "e_serial_number_not_positive": {},
+    "e_signature_algorithm_not_supported": {},
+    "e_spki_rsa_encryption_parameter_not_null": {
+      "ErrCount": 7
+    },
+    "e_sub_ca_aia_does_not_contain_ocsp_url": {
+      "ErrCount": 147
+    },
+    "e_sub_ca_aia_marked_critical": {},
+    "e_sub_ca_aia_missing": {
+      "ErrCount": 110
+    },
+    "e_sub_ca_certificate_policies_missing": {
+      "ErrCount": 34
+    },
+    "e_sub_ca_crl_distribution_points_does_not_contain_url": {
+      "ErrCount": 1
+    },
+    "e_sub_ca_crl_distribution_points_marked_critical": {},
+    "e_sub_ca_crl_distribution_points_missing": {
+      "ErrCount": 3
+    },
+    "e_sub_cert_aia_does_not_contain_ocsp_url": {
+      "ErrCount": 93
+    },
+    "e_sub_cert_aia_marked_critical": {},
+    "e_sub_cert_aia_missing": {
+      "ErrCount": 66
+    },
+    "e_sub_cert_cert_policy_empty": {
+      "ErrCount": 8
+    },
+    "e_sub_cert_certificate_policies_missing": {
+      "ErrCount": 8
+    },
+    "e_sub_cert_country_name_must_appear": {
+      "ErrCount": 1
+    },
+    "e_sub_cert_crl_distribution_points_does_not_contain_url": {
+      "ErrCount": 29
+    },
+    "e_sub_cert_crl_distribution_points_marked_critical": {},
+    "e_sub_cert_eku_missing": {
+      "ErrCount": 84
+    },
+    "e_sub_cert_eku_server_auth_client_auth_missing": {},
+    "e_sub_cert_given_name_surname_contains_correct_policy": {
+      "ErrCount": 10
+    },
+    "e_sub_cert_key_usage_cert_sign_bit_set": {},
+    "e_sub_cert_key_usage_crl_sign_bit_set": {},
+    "e_sub_cert_locality_name_must_appear": {
+      "ErrCount": 95
+    },
+    "e_sub_cert_locality_name_must_not_appear": {
+      "ErrCount": 23
+    },
+    "e_sub_cert_not_is_ca": {
+      "ErrCount": 1
+    },
+    "e_sub_cert_or_sub_ca_using_sha1": {
+      "ErrCount": 12
+    },
+    "e_sub_cert_postal_code_must_not_appear": {
+      "ErrCount": 8
+    },
+    "e_sub_cert_province_must_appear": {
+      "ErrCount": 95
+    },
+    "e_sub_cert_province_must_not_appear": {
+      "ErrCount": 16
+    },
+    "e_sub_cert_street_address_should_not_exist": {
+      "ErrCount": 8
+    },
+    "e_sub_cert_valid_time_longer_than_39_months": {
+      "ErrCount": 109
+    },
+    "e_sub_cert_valid_time_longer_than_825_days": {
+      "ErrCount": 21
+    },
+    "e_subject_common_name_max_length": {
+      "ErrCount": 31
+    },
+    "e_subject_common_name_not_from_san": {
+      "ErrCount": 229
+    },
+    "e_subject_contains_noninformational_value": {
+      "ErrCount": 69
+    },
+    "e_subject_contains_reserved_arpa_ip": {},
+    "e_subject_contains_reserved_ip": {
+      "ErrCount": 1
+    },
+    "e_subject_country_not_iso": {
+      "ErrCount": 6
+    },
+    "e_subject_dn_country_not_printable_string": {},
+    "e_subject_dn_not_printable_characters": {
+      "ErrCount": 70
+    },
+    "e_subject_dn_serial_number_max_length": {},
+    "e_subject_dn_serial_number_not_printable_string": {
+      "ErrCount": 50
+    },
+    "e_subject_email_max_length": {},
+    "e_subject_empty_without_san": {},
+    "e_subject_given_name_max_length": {
+      "ErrCount": 2
+    },
+    "e_subject_info_access_marked_critical": {},
+    "e_subject_locality_name_max_length": {},
+    "e_subject_not_dn": {},
+    "e_subject_organization_name_max_length": {
+      "ErrCount": 38
+    },
+    "e_subject_organizational_unit_name_max_length": {
+      "ErrCount": 80
+    },
+    "e_subject_postal_code_max_length": {
+      "ErrCount": 2
+    },
+    "e_subject_printable_string_badalpha": {
+      "ErrCount": 7
+    },
+    "e_subject_state_name_max_length": {},
+    "e_subject_street_address_max_length": {},
+    "e_subject_surname_max_length": {},
+    "e_tbs_signature_rsa_encryption_parameter_not_null": {
+      "ErrCount": 96
+    },
+    "e_utc_time_does_not_include_seconds": {
+      "ErrCount": 1
+    },
+    "e_utc_time_not_in_zulu": {},
+    "e_validity_time_not_positive": {},
+    "e_wrong_time_format_pre2050": {
+      "ErrCount": 19
+    },
+    "n_ca_digital_signature_not_set": {
+      "NoticeCount": 212
+    },
+    "n_contains_redacted_dnsname": {
+      "NoticeCount": 203
+    },
+    "n_ecdsa_ee_invalid_ku": {
+      "NoticeCount": 29
+    },
+    "n_multiple_subject_rdn": {},
+    "n_san_dns_name_duplicate": {
+      "NoticeCount": 193
+    },
+    "n_sub_ca_eku_missing": {
+      "NoticeCount": 166
+    },
+    "n_sub_ca_eku_not_technically_constrained": {
+      "NoticeCount": 10
+    },
+    "n_subject_common_name_included": {
+      "NoticeCount": 45
+    },
+    "w_ct_sct_policy_count_unsatisfied": {
+      "NoticeCount": 72
+    },
+    "w_distribution_point_missing_ldap_or_uri": {
+      "WarnCount": 5
+    },
+    "w_dnsname_underscore_in_trd": {
+      "WarnCount": 83
+    },
+    "w_dnsname_wildcard_left_of_public_suffix": {
+      "WarnCount": 1
+    },
+    "w_eku_critical_improperly": {},
+    "w_ext_aia_access_location_missing": {
+      "WarnCount": 28
+    },
+    "w_ext_cert_policy_contains_noticeref": {
+      "WarnCount": 23
+    },
+    "w_ext_cert_policy_explicit_text_includes_control": {
+      "WarnCount": 1
+    },
+    "w_ext_cert_policy_explicit_text_not_nfc": {},
+    "w_ext_cert_policy_explicit_text_not_utf8": {
+      "WarnCount": 144
+    },
+    "w_ext_crl_distribution_marked_critical": {},
+    "w_ext_ian_critical": {},
+    "w_ext_key_usage_not_critical": {
+      "WarnCount": 115
+    },
+    "w_ext_policy_map_not_critical": {
+      "WarnCount": 3
+    },
+    "w_ext_policy_map_not_in_cert_policy": {
+      "WarnCount": 3
+    },
+    "w_ext_san_critical_with_subject_dn": {
+      "WarnCount": 30
+    },
+    "w_ext_subject_key_identifier_missing_sub_cert": {
+      "WarnCount": 58
+    },
+    "w_ian_iana_pub_suffix_empty": {},
+    "w_issuer_dn_leading_whitespace": {},
+    "w_issuer_dn_trailing_whitespace": {},
+    "w_multiple_issuer_rdn": {},
+    "w_name_constraint_on_edi_party_name": {},
+    "w_name_constraint_on_registered_id": {},
+    "w_name_constraint_on_x400": {},
+    "w_qcstatem_qcpds_lang_case": {
+      "WarnCount": 49
+    },
+    "w_qcstatem_qctype_web": {
+      "ErrCount": 1,
+      "WarnCount": 25
+    },
+    "w_root_ca_basic_constraints_path_len_constraint_field_present": {},
+    "w_root_ca_contains_cert_policy": {
+      "WarnCount": 3
+    },
+    "w_rsa_mod_factors_smaller_than_752": {},
+    "w_rsa_mod_not_odd": {},
+    "w_rsa_public_exponent_not_in_range": {
+      "WarnCount": 45
+    },
+    "w_san_iana_pub_suffix_empty": {
+      "WarnCount": 35
+    },
+    "w_sub_ca_aia_does_not_contain_issuing_ca_url": {
+      "WarnCount": 62
+    },
+    "w_sub_ca_certificate_policies_marked_critical": {},
+    "w_sub_ca_eku_critical": {
+      "WarnCount": 9
+    },
+    "w_sub_ca_name_constraints_not_critical": {
+      "WarnCount": 93
+    },
+    "w_sub_cert_aia_does_not_contain_issuing_ca_url": {
+      "WarnCount": 100
+    },
+    "w_sub_cert_certificate_policies_marked_critical": {},
+    "w_sub_cert_eku_extra_values": {
+      "WarnCount": 233
+    },
+    "w_sub_cert_sha1_expiration_too_long": {
+      "WarnCount": 10
+    },
+    "w_subject_contains_malformed_arpa_ip": {
+      "WarnCount": 2
+    },
+    "w_subject_dn_leading_whitespace": {
+      "WarnCount": 17
+    },
+    "w_subject_dn_trailing_whitespace": {
+      "WarnCount": 64
+    }
+  }
 }

--- a/integration/corpus_test.go
+++ b/integration/corpus_test.go
@@ -158,9 +158,9 @@ func TestCorpus(t *testing.T) {
 			*configFile)
 	} else {
 		// Otherwise enforce the maps match
-		for k, v := range resultsByFP {
+		for k, v := range resultsByLint {
 			if conf.Expected[k] != v {
-				t.Errorf("expected fingerprint %q to have result %s got %s\n",
+				t.Errorf("expected lint %q to have result %s got %s\n",
 					k, conf.Expected[k], v)
 			}
 		}
@@ -175,7 +175,7 @@ func TestCorpus(t *testing.T) {
 	if *overwriteExpected {
 		t.Logf("overwriting expected map in config file %q",
 			*configFile)
-		conf.Expected = resultsByFP
+		conf.Expected = resultsByLint
 		if err := conf.Save(*configFile); err != nil {
 			t.Errorf("failed to save expected map to config file %q: %v", *configFile, err)
 		}

--- a/integration/corpus_test.go
+++ b/integration/corpus_test.go
@@ -125,12 +125,8 @@ func TestCorpus(t *testing.T) {
 
 	// No expected to confirm against, save a new expected
 	if len(conf.Expected) == 0 {
-		t.Logf("config file %q had no expected map. "+
-			"Saving results from this execution as the new expected map", *configFile)
-		conf.Expected = resultsMap
-		if err := conf.Save(*configFile); err != nil {
-			t.Errorf("failed to save expected map to config file %q: %v", *configFile, err)
-		}
+		t.Logf("config file %q had no expected map to enforce results against",
+			*configFile)
 	} else {
 		// Otherwise enforce the maps match
 		for k, v := range resultsMap {
@@ -138,6 +134,21 @@ func TestCorpus(t *testing.T) {
 				t.Errorf("expected serial %q to have result %s got %s\n",
 					k, conf.Expected[k], v)
 			}
+		}
+	}
+
+	// If *overwriteExpected is true overwrite the expected map with the results
+	// from this run and save the updated configuration to disk. If there were
+	// t.Errorf's in this run then they will pass next run because the
+	// expectations will match reality. This should primarily be used to bootstrap
+	// an initial expectedMap or to update the expectedMap with vetted changes to
+	// the corpus that result from new lints, bugfixes, etc.
+	if *overwriteExpected {
+		t.Logf("overwriting expected map in config file %q",
+			*configFile)
+		conf.Expected = resultsMap
+		if err := conf.Save(*configFile); err != nil {
+			t.Errorf("failed to save expected map to config file %q: %v", *configFile, err)
 		}
 	}
 }

--- a/integration/corpus_test.go
+++ b/integration/corpus_test.go
@@ -24,16 +24,7 @@ func lintCertificate(work workItem) certResult {
 	resultSet := zlint.LintCertificate(work.Certificate)
 	for lintName, r := range resultSet.Results {
 		cr.LintSummary[lintName] = r.Status
-		switch r.Status {
-		case lints.Notice:
-			cr.Result.NoticeCount++
-		case lints.Warn:
-			cr.Result.WarnCount++
-		case lints.Error:
-			cr.Result.ErrCount++
-		case lints.Fatal:
-			cr.Result.FatalCount++
-		}
+		cr.Result.Inc(r.Status)
 	}
 	return cr
 }
@@ -82,10 +73,8 @@ func TestCorpus(t *testing.T) {
 	var total int
 	var fatalResults int
 	resultsBySerial := make(map[string]resultCount)
-	doneChan := make(chan bool, 1)
-
 	resultsByLint := make(map[string]resultCount)
-
+	doneChan := make(chan bool, 1)
 	go func() {
 		// Read results as they arrive on the channel until it is closed.
 		for r := range results {
@@ -98,17 +87,7 @@ func TestCorpus(t *testing.T) {
 				resultsBySerial[r.Fingerprint] = r.Result
 				for lintName, status := range r.LintSummary {
 					cur := resultsByLint[lintName]
-
-					switch status {
-					case lints.Notice:
-						cur.NoticeCount++
-					case lints.Warn:
-						cur.WarnCount++
-					case lints.Error:
-						cur.ErrCount++
-					case lints.Fatal:
-						cur.FatalCount++
-					}
+					cur.Inc(status)
 					resultsByLint[lintName] = cur
 				}
 			}

--- a/integration/corpus_test.go
+++ b/integration/corpus_test.go
@@ -117,7 +117,7 @@ func TestCorpus(t *testing.T) {
 		t.Errorf("expected 0 fatal results, found %d\n", fatalResults)
 	}
 
-	if *summarize {
+	if *serialSummarize {
 		for serial, result := range resultsMap {
 			fmt.Printf("%s\t%s\n", serial, result)
 		}

--- a/integration/corpus_test.go
+++ b/integration/corpus_test.go
@@ -81,10 +81,10 @@ func TestCorpus(t *testing.T) {
 	// results into the results map
 	var total int
 	var fatalResults int
-	resultsBySerial := make(map[string]result)
+	resultsBySerial := make(map[string]resultCount)
 	doneChan := make(chan bool, 1)
 
-	resultsByLint := make(map[string]result)
+	resultsByLint := make(map[string]resultCount)
 
 	go func() {
 		// Read results as they arrive on the channel until it is closed.

--- a/integration/csv.go
+++ b/integration/csv.go
@@ -96,6 +96,12 @@ func loadCSVFile(workChannel chan<- workItem, path string, skipHeader bool) erro
 			continue
 		}
 
+		// If a fingerprint filter is configured only include records with
+		// a fingerprint that matches the filter regexp.
+		if fpFilter != nil && !fpFilter.MatchString(record[csvFingerprint]) {
+			continue
+		}
+
 		// Parse a certificate from the record's csvRaw index and write it to the
 		// work channel.
 		cert, err := parseCertificate(record[csvRaw])

--- a/integration/csv.go
+++ b/integration/csv.go
@@ -50,7 +50,8 @@ func loadCSV(workChannel chan<- workItem, directory string) {
 	log.Printf("Reading data from %d CSV files", len(conf.Files))
 	for i, dataFile := range conf.Files {
 		path := path.Join(conf.CacheDir, dataFile.Name)
-		log.Printf("Reading data from %q\n", path)
+		log.Printf("Reading data from %q (%d of %d)\n",
+			path, i+1, len(conf.Files))
 		if err := loadCSVFile(workChannel, path, i == 0); err != nil {
 			log.Fatalf("Failed reading CSV file %q: %v", path, err)
 		}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -15,9 +15,9 @@ var (
 	parallelism = flag.Int("parallelism", 5, "number of linting Go routines to spawn")
 	// configFile is a flag for specifying the config file JSON.
 	configFile = flag.String("config", "./config.json", "integration test config file")
-	// force is a flag for forcing the download of data files even if they are in
+	// forceDownload is a flag for forcing the download of data files even if they are in
 	// the cache dir already.
-	force = flag.Bool("force", false, "ignore cached data and force new download")
+	forceDownload = flag.Bool("forceDownload", false, "ignore cached data and force new download")
 	// serialSummarize is a flag for controlling whether a summary of the serial numbers
 	// with lint findings (e.g. one or more fatal, error, warning or info level
 	// findings) should be printed at the end of TestCorpus. Defaults to false
@@ -50,8 +50,9 @@ func TestMain(m *testing.M) {
 		log.Fatalf("error processing config file %q: %v", *configFile, err)
 	}
 
-	// Prepare cache, downloading data files if required
-	if err := c.PrepareCache(*force); err != nil {
+	// Prepare cache, downloading data files if required (or if forced by user
+	// request with forceDownload)
+	if err := c.PrepareCache(*forceDownload); err != nil {
 		log.Fatalf("error preparing cache: %v\n", err)
 	}
 	// Save the config to a global accessible to tests.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"regexp"
 	"testing"
 )
 
@@ -21,15 +22,21 @@ var (
 	// saveExpected is a flag for controlling whether the expectedMap is saved to
 	// the configuration or not.
 	overwriteExpected = flag.Bool("overwriteExpected", false, "save test results as the new expected map in config file")
-	// serialSummarize is a flag for controlling whether a summary of the serial numbers
+	// fpSummarize is a flag for controlling whether a summary of the cert fingerprints
 	// with lint findings (e.g. one or more fatal, error, warning or info level
 	// findings) should be printed at the end of TestCorpus. Defaults to false
 	// because it is very spammy with a large corpus.
-	serialSummarize = flag.Bool("serialSummary", false, "print summary of all serials with lint findings")
+	fpSummarize = flag.Bool("fingerprintSummary", false, "print summary of all certificate fingerprints with lint findings")
 	// lintSummarize is a flag for controlling whether a summary of result types
 	// by lint name is printed at the end of TestCorpus. Defaults to false because
 	// it is very spammy with a large corpus.
 	lintSummarize = flag.Bool("lintSummary", false, "print summary of result type counts by lint name")
+	// fpFilterString is a flag for controlling which certificate fingerprints are run
+	// through the lints.
+	fpFilterString = flag.String("fingerprintFilter", "", "if not-empty only certificate fingerprints that match the provided regexp will be run")
+	// lintFilterString is a flag for controlling which lints are run against the test
+	// corpus.
+	lintFilterString = flag.String("lintFilter", "", "if not-empty only lints with a name that match the provided regexp will be run")
 	// outputTick is a flag for controlling the number of certificates that are
 	// linted before a '.' is printed in the console. This controls the mechanism
 	// used to keep Travis from thinking the job is dead because there hasn't been
@@ -41,12 +48,32 @@ var (
 var (
 	// config is a global var for the integration test configuration.
 	conf *config
+
+	// fpFilter and lintFilter are regexps for filtering certificate fingerprints
+	// to be linted and lints to be run.
+	fpFilter, lintFilter *regexp.Regexp
 )
 
 // TestMain loads the integration test config, validates it, and prepares the
 // cache (downloading configured CSV data files if needed), and then runs all tests.
 func TestMain(m *testing.M) {
 	flag.Parse()
+
+	if *fpFilterString != "" {
+		filter, err := regexp.Compile(*fpFilterString)
+		if err != nil {
+			log.Fatalf("error compiling -fingerprintFilter regexp %q: %v", *fpFilterString, err)
+		}
+		fpFilter = filter
+	}
+
+	if *lintFilterString != "" {
+		filter, err := regexp.Compile(*lintFilterString)
+		if err != nil {
+			log.Fatalf("error compiling -lintFilter regexp %q: %v", *lintFilterString, err)
+		}
+		lintFilter = filter
+	}
 
 	// Load and validate configuration
 	c, err := loadConfig(*configFile)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -18,11 +18,11 @@ var (
 	// force is a flag for forcing the download of data files even if they are in
 	// the cache dir already.
 	force = flag.Bool("force", false, "ignore cached data and force new download")
-	// summarize is a flag for controlling whether a summary of the serial numbers
+	// serialSummarize is a flag for controlling whether a summary of the serial numbers
 	// with lint findings (e.g. one or more fatal, error, warning or info level
 	// findings) should be printed at the end of TestCorpus. Defaults to false
 	// because it is very spammy with a large corpus.
-	summarize = flag.Bool("summary", false, "print summary of all serials with lint findings")
+	serialSummarize = flag.Bool("serialSummary", false, "print summary of all serials with lint findings")
 	// outputTick is a flag for controlling the number of certificates that are
 	// linted before a '.' is printed in the console. This controls the mechanism
 	// used to keep Travis from thinking the job is dead because there hasn't been

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -58,6 +58,5 @@ func TestMain(m *testing.M) {
 	conf = c
 
 	// Run all tests.
-	result := m.Run()
-	os.Exit(result)
+	os.Exit(m.Run())
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -18,6 +18,9 @@ var (
 	// forceDownload is a flag for forcing the download of data files even if they are in
 	// the cache dir already.
 	forceDownload = flag.Bool("forceDownload", false, "ignore cached data and force new download")
+	// saveExpected is a flag for controlling whether the expectedMap is saved to
+	// the configuration or not.
+	overwriteExpected = flag.Bool("overwriteExpected", false, "save test results as the new expected map in config file")
 	// serialSummarize is a flag for controlling whether a summary of the serial numbers
 	// with lint findings (e.g. one or more fatal, error, warning or info level
 	// findings) should be printed at the end of TestCorpus. Defaults to false

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -26,6 +26,10 @@ var (
 	// findings) should be printed at the end of TestCorpus. Defaults to false
 	// because it is very spammy with a large corpus.
 	serialSummarize = flag.Bool("serialSummary", false, "print summary of all serials with lint findings")
+	// lintSummarize is a flag for controlling whether a summary of result types
+	// by lint name is printed at the end of TestCorpus. Defaults to false because
+	// it is very spammy with a large corpus.
+	lintSummarize = flag.Bool("lintSummary", false, "print summary of result type counts by lint name")
 	// outputTick is a flag for controlling the number of certificates that are
 	// linted before a '.' is printed in the console. This controls the mechanism
 	// used to keep Travis from thinking the job is dead because there hasn't been

--- a/integration/result.go
+++ b/integration/result.go
@@ -2,8 +2,14 @@
 
 package integration
 
-import "fmt"
+import (
+	"fmt"
 
+	"github.com/zmap/zlint/lints"
+)
+
+// TODO(@cpu): Rename this to reflect its an overall count of lint results by
+// type.
 type result struct {
 	FatalCount  uint8 `json:",omitempty"`
 	ErrCount    uint8 `json:",omitempty"`
@@ -11,19 +17,24 @@ type result struct {
 	NoticeCount uint8 `json:",omitempty"`
 }
 
+// TODO(@cpu): Accept a threshold argument so that (for e.g. notices could be
+// counted as passing)
 func (r result) fullPass() bool {
 	return r.FatalCount == 0 && r.ErrCount == 0 && r.WarnCount == 0 && r.NoticeCount == 0
 }
 
 func (r result) String() string {
-	return fmt.Sprintf("fatals: %d\terrs: %d\twarns: %d\tinfos: %d",
+	return fmt.Sprintf("fatals: %4d errs: %4d warns: %4d infos: %4d",
 		r.FatalCount, r.ErrCount, r.WarnCount, r.NoticeCount)
 }
 
-// certResult combines a Result with a Fingerprint.
+// certResult combines a Result (overall count of lint results by type) with
+// a LintSummary (map from lint name to a Notice/Warn/Error/Fatal result) for
+// a specific cert Fingerprint.
 type certResult struct {
 	Fingerprint string
 	Result      result
+	LintSummary map[string]lints.LintStatus
 }
 
 func (cr certResult) String() string {

--- a/integration/result.go
+++ b/integration/result.go
@@ -22,8 +22,22 @@ func (r resultCount) fullPass() bool {
 }
 
 func (r resultCount) String() string {
-	return fmt.Sprintf("fatals: %4d errs: %4d warns: %4d infos: %4d",
+	return fmt.Sprintf("fatals: %-4d errs: %-4d warns: %-4d infos: %-4d",
 		r.FatalCount, r.ErrCount, r.WarnCount, r.NoticeCount)
+}
+
+// Inc increases the resultCount count for the given lint status level.
+func (r *resultCount) Inc(status lints.LintStatus) {
+	switch status {
+	case lints.Notice:
+		r.NoticeCount++
+	case lints.Warn:
+		r.WarnCount++
+	case lints.Error:
+		r.ErrCount++
+	case lints.Fatal:
+		r.FatalCount++
+	}
 }
 
 // certResult combines a Result (overall count of lint results by type) with

--- a/integration/result.go
+++ b/integration/result.go
@@ -8,9 +8,7 @@ import (
 	"github.com/zmap/zlint/lints"
 )
 
-// TODO(@cpu): Rename this to reflect its an overall count of lint results by
-// type.
-type result struct {
+type resultCount struct {
 	FatalCount  uint8 `json:",omitempty"`
 	ErrCount    uint8 `json:",omitempty"`
 	WarnCount   uint8 `json:",omitempty"`
@@ -19,11 +17,11 @@ type result struct {
 
 // TODO(@cpu): Accept a threshold argument so that (for e.g. notices could be
 // counted as passing)
-func (r result) fullPass() bool {
+func (r resultCount) fullPass() bool {
 	return r.FatalCount == 0 && r.ErrCount == 0 && r.WarnCount == 0 && r.NoticeCount == 0
 }
 
-func (r result) String() string {
+func (r resultCount) String() string {
 	return fmt.Sprintf("fatals: %4d errs: %4d warns: %4d infos: %4d",
 		r.FatalCount, r.ErrCount, r.WarnCount, r.NoticeCount)
 }
@@ -33,7 +31,7 @@ func (r result) String() string {
 // a specific cert Fingerprint.
 type certResult struct {
 	Fingerprint string
-	Result      result
+	Result      resultCount
 	LintSummary map[string]lints.LintStatus
 }
 

--- a/integration/small.config.json
+++ b/integration/small.config.json
@@ -1,0 +1,21 @@
+{
+  "CacheDir": "../data/",
+  "Files": [
+    {
+      "Name": "xaa.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xaa.bz2"
+    },
+    {
+      "Name": "xab.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xab.bz2"
+    },
+    {
+      "Name": "xac.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xac.bz2"
+    },
+    {
+      "Name": "xad.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xad.bz2"
+    }
+  ]
+}

--- a/integration/small.config.json
+++ b/integration/small.config.json
@@ -6,16 +6,8 @@
       "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xaa.bz2"
     },
     {
-      "Name": "xab.csv",
-      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xab.bz2"
-    },
-    {
-      "Name": "xac.csv",
-      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xac.bz2"
-    },
-    {
-      "Name": "xad.csv",
-      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xad.bz2"
+      "Name": "xch.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xch.bz2"
     }
   ]
 }

--- a/integration/small.config.json
+++ b/integration/small.config.json
@@ -9,5 +9,394 @@
       "Name": "xch.csv",
       "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xch.bz2"
     }
-  ]
+  ],
+  "Expected": {
+    "e_basic_constraints_not_critical": {
+      "ErrCount": 1
+    },
+    "e_ca_common_name_missing": {},
+    "e_ca_country_name_invalid": {},
+    "e_ca_country_name_missing": {
+      "ErrCount": 2
+    },
+    "e_ca_crl_sign_not_set": {},
+    "e_ca_is_ca": {},
+    "e_ca_key_cert_sign_not_set": {},
+    "e_ca_key_usage_missing": {},
+    "e_ca_key_usage_not_critical": {},
+    "e_ca_organization_name_missing": {
+      "ErrCount": 3
+    },
+    "e_ca_subject_field_empty": {},
+    "e_cab_dv_conflicts_with_locality": {},
+    "e_cab_dv_conflicts_with_org": {},
+    "e_cab_dv_conflicts_with_postal": {},
+    "e_cab_dv_conflicts_with_province": {},
+    "e_cab_dv_conflicts_with_street": {},
+    "e_cab_iv_requires_personal_name": {},
+    "e_cab_ov_requires_org": {},
+    "e_cert_contains_unique_identifier": {},
+    "e_cert_extensions_version_not_3": {},
+    "e_cert_policy_iv_requires_country": {},
+    "e_cert_policy_iv_requires_province_or_locality": {},
+    "e_cert_policy_ov_requires_country": {},
+    "e_cert_policy_ov_requires_province_or_locality": {
+      "ErrCount": 6
+    },
+    "e_cert_unique_identifier_version_not_2_or_3": {},
+    "e_distribution_point_incomplete": {},
+    "e_dnsname_bad_character_in_label": {
+      "ErrCount": 4
+    },
+    "e_dnsname_contains_bare_iana_suffix": {},
+    "e_dnsname_empty_label": {},
+    "e_dnsname_hyphen_in_sld": {},
+    "e_dnsname_label_too_long": {},
+    "e_dnsname_left_label_wildcard_correct": {},
+    "e_dnsname_not_valid_tld": {
+      "ErrCount": 5
+    },
+    "e_dnsname_underscore_in_sld": {},
+    "e_dnsname_wildcard_only_in_left_label": {},
+    "e_dsa_correct_order_in_subgroup": {},
+    "e_dsa_improper_modulus_or_divisor_size": {},
+    "e_dsa_params_missing": {},
+    "e_dsa_shorter_than_2048_bits": {},
+    "e_dsa_unique_correct_representation": {},
+    "e_ec_improper_curves": {},
+    "e_ev_business_category_missing": {},
+    "e_ev_country_name_missing": {},
+    "e_ev_organization_name_missing": {},
+    "e_ev_serial_number_missing": {},
+    "e_ev_valid_time_too_long": {},
+    "e_ext_aia_marked_critical": {},
+    "e_ext_authority_key_identifier_critical": {},
+    "e_ext_authority_key_identifier_missing": {
+      "ErrCount": 2
+    },
+    "e_ext_authority_key_identifier_no_key_identifier": {
+      "ErrCount": 3
+    },
+    "e_ext_cert_policy_disallowed_any_policy_qualifier": {},
+    "e_ext_cert_policy_duplicate": {},
+    "e_ext_cert_policy_explicit_text_ia5_string": {},
+    "e_ext_cert_policy_explicit_text_too_long": {
+      "ErrCount": 9
+    },
+    "e_ext_duplicate_extension": {},
+    "e_ext_freshest_crl_marked_critical": {},
+    "e_ext_ian_dns_not_ia5_string": {},
+    "e_ext_ian_empty_name": {},
+    "e_ext_ian_no_entries": {},
+    "e_ext_ian_rfc822_format_invalid": {},
+    "e_ext_ian_space_dns_name": {},
+    "e_ext_ian_uri_format_invalid": {},
+    "e_ext_ian_uri_host_not_fqdn_or_ip": {},
+    "e_ext_ian_uri_not_ia5": {},
+    "e_ext_ian_uri_relative": {},
+    "e_ext_key_usage_cert_sign_without_ca": {},
+    "e_ext_key_usage_without_bits": {},
+    "e_ext_name_constraints_not_critical": {
+      "ErrCount": 7
+    },
+    "e_ext_name_constraints_not_in_ca": {},
+    "e_ext_policy_constraints_empty": {},
+    "e_ext_policy_constraints_not_critical": {},
+    "e_ext_policy_map_any_policy": {},
+    "e_ext_san_contains_reserved_ip": {},
+    "e_ext_san_directory_name_present": {
+      "ErrCount": 21
+    },
+    "e_ext_san_dns_name_too_long": {},
+    "e_ext_san_dns_not_ia5_string": {},
+    "e_ext_san_edi_party_name_present": {},
+    "e_ext_san_empty_name": {},
+    "e_ext_san_missing": {
+      "ErrCount": 2
+    },
+    "e_ext_san_no_entries": {},
+    "e_ext_san_not_critical_without_subject": {},
+    "e_ext_san_other_name_present": {},
+    "e_ext_san_registered_id_present": {},
+    "e_ext_san_rfc822_format_invalid": {},
+    "e_ext_san_rfc822_name_present": {
+      "ErrCount": 3
+    },
+    "e_ext_san_space_dns_name": {},
+    "e_ext_san_uniform_resource_identifier_present": {},
+    "e_ext_san_uri_format_invalid": {},
+    "e_ext_san_uri_host_not_fqdn_or_ip": {},
+    "e_ext_san_uri_not_ia5": {},
+    "e_ext_san_uri_relative": {},
+    "e_ext_subject_directory_attr_critical": {},
+    "e_ext_subject_key_identifier_critical": {},
+    "e_ext_subject_key_identifier_missing_ca": {},
+    "e_ext_tor_service_descriptor_hash_invalid": {},
+    "e_generalized_time_does_not_include_seconds": {},
+    "e_generalized_time_includes_fraction_seconds": {},
+    "e_generalized_time_not_in_zulu": {},
+    "e_ian_bare_wildcard": {},
+    "e_ian_dns_name_includes_null_char": {},
+    "e_ian_dns_name_starts_with_period": {},
+    "e_ian_wildcard_not_first": {},
+    "e_inhibit_any_policy_not_critical": {},
+    "e_international_dns_name_not_nfc": {},
+    "e_international_dns_name_not_unicode": {},
+    "e_invalid_certificate_version": {},
+    "e_issuer_dn_country_not_printable_string": {},
+    "e_issuer_field_empty": {},
+    "e_name_constraint_empty": {},
+    "e_name_constraint_maximum_not_absent": {},
+    "e_name_constraint_minimum_non_zero": {},
+    "e_old_root_ca_rsa_mod_less_than_2048_bits": {},
+    "e_old_sub_ca_rsa_mod_less_than_1024_bits": {},
+    "e_old_sub_cert_rsa_mod_less_than_1024_bits": {},
+    "e_onion_subject_validity_time_too_large": {},
+    "e_path_len_constraint_improperly_included": {},
+    "e_path_len_constraint_zero_or_less": {},
+    "e_public_key_type_not_allowed": {},
+    "e_qcstatem_etsi_present_qcs_critical": {},
+    "e_qcstatem_etsi_type_as_statem": {
+      "ErrCount": 9
+    },
+    "e_qcstatem_mandatory_etsi_statems": {
+      "ErrCount": 62
+    },
+    "e_qcstatem_qccompliance_valid": {},
+    "e_qcstatem_qclimitvalue_valid": {},
+    "e_qcstatem_qcpds_valid": {},
+    "e_qcstatem_qcretentionperiod_valid": {},
+    "e_qcstatem_qcsscd_valid": {},
+    "e_qcstatem_qctype_valid": {},
+    "e_root_ca_extended_key_usage_present": {},
+    "e_root_ca_key_usage_must_be_critical": {},
+    "e_root_ca_key_usage_present": {},
+    "e_rsa_exp_negative": {},
+    "e_rsa_mod_less_than_2048_bits": {
+      "ErrCount": 1
+    },
+    "e_rsa_no_public_key": {},
+    "e_rsa_public_exponent_not_odd": {},
+    "e_rsa_public_exponent_too_small": {},
+    "e_san_bare_wildcard": {},
+    "e_san_dns_name_includes_null_char": {},
+    "e_san_dns_name_onion_not_ev_cert": {},
+    "e_san_dns_name_starts_with_period": {},
+    "e_san_wildcard_not_first": {},
+    "e_serial_number_longer_than_20_octets": {},
+    "e_serial_number_not_positive": {},
+    "e_signature_algorithm_not_supported": {},
+    "e_spki_rsa_encryption_parameter_not_null": {},
+    "e_sub_ca_aia_does_not_contain_ocsp_url": {
+      "ErrCount": 7
+    },
+    "e_sub_ca_aia_marked_critical": {},
+    "e_sub_ca_aia_missing": {
+      "ErrCount": 5
+    },
+    "e_sub_ca_certificate_policies_missing": {
+      "ErrCount": 1
+    },
+    "e_sub_ca_crl_distribution_points_does_not_contain_url": {},
+    "e_sub_ca_crl_distribution_points_marked_critical": {},
+    "e_sub_ca_crl_distribution_points_missing": {},
+    "e_sub_cert_aia_does_not_contain_ocsp_url": {
+      "ErrCount": 1
+    },
+    "e_sub_cert_aia_marked_critical": {},
+    "e_sub_cert_aia_missing": {
+      "ErrCount": 1
+    },
+    "e_sub_cert_cert_policy_empty": {
+      "ErrCount": 2
+    },
+    "e_sub_cert_certificate_policies_missing": {
+      "ErrCount": 2
+    },
+    "e_sub_cert_country_name_must_appear": {},
+    "e_sub_cert_crl_distribution_points_does_not_contain_url": {
+      "ErrCount": 2
+    },
+    "e_sub_cert_crl_distribution_points_marked_critical": {},
+    "e_sub_cert_eku_missing": {
+      "ErrCount": 2
+    },
+    "e_sub_cert_eku_server_auth_client_auth_missing": {},
+    "e_sub_cert_given_name_surname_contains_correct_policy": {},
+    "e_sub_cert_key_usage_cert_sign_bit_set": {},
+    "e_sub_cert_key_usage_crl_sign_bit_set": {},
+    "e_sub_cert_locality_name_must_appear": {
+      "ErrCount": 15
+    },
+    "e_sub_cert_locality_name_must_not_appear": {
+      "ErrCount": 1
+    },
+    "e_sub_cert_not_is_ca": {},
+    "e_sub_cert_or_sub_ca_using_sha1": {
+      "ErrCount": 1
+    },
+    "e_sub_cert_postal_code_must_not_appear": {
+      "ErrCount": 1
+    },
+    "e_sub_cert_province_must_appear": {
+      "ErrCount": 15
+    },
+    "e_sub_cert_province_must_not_appear": {
+      "ErrCount": 1
+    },
+    "e_sub_cert_street_address_should_not_exist": {
+      "ErrCount": 1
+    },
+    "e_sub_cert_valid_time_longer_than_39_months": {
+      "ErrCount": 8
+    },
+    "e_sub_cert_valid_time_longer_than_825_days": {
+      "ErrCount": 2
+    },
+    "e_subject_common_name_max_length": {},
+    "e_subject_common_name_not_from_san": {
+      "ErrCount": 5
+    },
+    "e_subject_contains_noninformational_value": {
+      "ErrCount": 13
+    },
+    "e_subject_contains_reserved_arpa_ip": {},
+    "e_subject_contains_reserved_ip": {},
+    "e_subject_country_not_iso": {},
+    "e_subject_dn_country_not_printable_string": {},
+    "e_subject_dn_not_printable_characters": {
+      "ErrCount": 3
+    },
+    "e_subject_dn_serial_number_max_length": {},
+    "e_subject_dn_serial_number_not_printable_string": {
+      "ErrCount": 1
+    },
+    "e_subject_email_max_length": {},
+    "e_subject_empty_without_san": {},
+    "e_subject_given_name_max_length": {
+      "ErrCount": 1
+    },
+    "e_subject_info_access_marked_critical": {},
+    "e_subject_locality_name_max_length": {},
+    "e_subject_not_dn": {},
+    "e_subject_organization_name_max_length": {
+      "ErrCount": 4
+    },
+    "e_subject_organizational_unit_name_max_length": {
+      "ErrCount": 4
+    },
+    "e_subject_postal_code_max_length": {
+      "ErrCount": 1
+    },
+    "e_subject_printable_string_badalpha": {},
+    "e_subject_state_name_max_length": {},
+    "e_subject_street_address_max_length": {},
+    "e_subject_surname_max_length": {},
+    "e_tbs_signature_rsa_encryption_parameter_not_null": {
+      "ErrCount": 4
+    },
+    "e_utc_time_does_not_include_seconds": {},
+    "e_utc_time_not_in_zulu": {},
+    "e_validity_time_not_positive": {},
+    "e_wrong_time_format_pre2050": {},
+    "n_ca_digital_signature_not_set": {
+      "NoticeCount": 29
+    },
+    "n_contains_redacted_dnsname": {
+      "NoticeCount": 8
+    },
+    "n_ecdsa_ee_invalid_ku": {
+      "NoticeCount": 3
+    },
+    "n_multiple_subject_rdn": {},
+    "n_san_dns_name_duplicate": {
+      "NoticeCount": 23
+    },
+    "n_sub_ca_eku_missing": {
+      "NoticeCount": 29
+    },
+    "n_sub_ca_eku_not_technically_constrained": {},
+    "n_subject_common_name_included": {
+      "NoticeCount": 64
+    },
+    "w_ct_sct_policy_count_unsatisfied": {
+      "NoticeCount": 176
+    },
+    "w_distribution_point_missing_ldap_or_uri": {
+      "WarnCount": 1
+    },
+    "w_dnsname_underscore_in_trd": {
+      "WarnCount": 13
+    },
+    "w_dnsname_wildcard_left_of_public_suffix": {},
+    "w_eku_critical_improperly": {},
+    "w_ext_aia_access_location_missing": {
+      "WarnCount": 11
+    },
+    "w_ext_cert_policy_contains_noticeref": {
+      "WarnCount": 232
+    },
+    "w_ext_cert_policy_explicit_text_includes_control": {},
+    "w_ext_cert_policy_explicit_text_not_nfc": {},
+    "w_ext_cert_policy_explicit_text_not_utf8": {
+      "WarnCount": 73
+    },
+    "w_ext_crl_distribution_marked_critical": {},
+    "w_ext_ian_critical": {},
+    "w_ext_key_usage_not_critical": {
+      "WarnCount": 40
+    },
+    "w_ext_policy_map_not_critical": {
+      "WarnCount": 1
+    },
+    "w_ext_policy_map_not_in_cert_policy": {
+      "WarnCount": 1
+    },
+    "w_ext_san_critical_with_subject_dn": {
+      "WarnCount": 1
+    },
+    "w_ext_subject_key_identifier_missing_sub_cert": {
+      "WarnCount": 152
+    },
+    "w_ian_iana_pub_suffix_empty": {},
+    "w_issuer_dn_leading_whitespace": {},
+    "w_issuer_dn_trailing_whitespace": {},
+    "w_multiple_issuer_rdn": {},
+    "w_name_constraint_on_edi_party_name": {},
+    "w_name_constraint_on_registered_id": {},
+    "w_name_constraint_on_x400": {},
+    "w_qcstatem_qcpds_lang_case": {
+      "WarnCount": 25
+    },
+    "w_qcstatem_qctype_web": {},
+    "w_root_ca_basic_constraints_path_len_constraint_field_present": {},
+    "w_root_ca_contains_cert_policy": {},
+    "w_rsa_mod_factors_smaller_than_752": {},
+    "w_rsa_mod_not_odd": {},
+    "w_rsa_public_exponent_not_in_range": {},
+    "w_san_iana_pub_suffix_empty": {
+      "WarnCount": 1
+    },
+    "w_sub_ca_aia_does_not_contain_issuing_ca_url": {
+      "WarnCount": 23
+    },
+    "w_sub_ca_certificate_policies_marked_critical": {},
+    "w_sub_ca_eku_critical": {},
+    "w_sub_ca_name_constraints_not_critical": {
+      "WarnCount": 6
+    },
+    "w_sub_cert_aia_does_not_contain_issuing_ca_url": {
+      "WarnCount": 98
+    },
+    "w_sub_cert_certificate_policies_marked_critical": {},
+    "w_sub_cert_eku_extra_values": {
+      "WarnCount": 77
+    },
+    "w_sub_cert_sha1_expiration_too_long": {},
+    "w_subject_contains_malformed_arpa_ip": {},
+    "w_subject_dn_leading_whitespace": {},
+    "w_subject_dn_trailing_whitespace": {
+      "WarnCount": 4
+    }
+  }
 }

--- a/makefile
+++ b/makefile
@@ -1,7 +1,9 @@
 SHELL := /bin/bash
 # Number of linting Go routines to use in integration tests
 PARALLELISM := 5
-# Additional integration test flags (e.g. -forceDownload, -serialSummary, -outputTick)
+# Additional integration test flags. Example usage:
+#   make integration PARALLELISM=99 INT_FLAGS="-serialSummary -forceDownload"
+#   make integration INT_FLAGS="-overwriteExpected -config custom.config.json"
 INT_FLAGS :=
 
 CMDS = zlint zlint-gtld-update

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 # Number of linting Go routines to use in integration tests
 PARALLELISM := 5
-# Additional integration test flags (e.g. -force, -serialSummary, -outputTick)
+# Additional integration test flags (e.g. -forceDownload, -serialSummary, -outputTick)
 INT_FLAGS :=
 
 CMDS = zlint zlint-gtld-update

--- a/makefile
+++ b/makefile
@@ -2,8 +2,9 @@ SHELL := /bin/bash
 # Number of linting Go routines to use in integration tests
 PARALLELISM := 5
 # Additional integration test flags. Example usage:
-#   make integration PARALLELISM=99 INT_FLAGS="-serialSummary -forceDownload"
+#   make integration PARALLELISM=99 INT_FLAGS="-fingerprintSummary -forceDownload"
 #   make integration INT_FLAGS="-overwriteExpected -config custom.config.json"
+#   make integration INT_FLAGS="-fingerprintSummary -lintSummary -fingerprintFilter='^[ea]' -lintFilter='^w_ext_cert_policy_explicit_text_not_utf8' -config small.config.json"
 INT_FLAGS :=
 
 CMDS = zlint zlint-gtld-update

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 # Number of linting Go routines to use in integration tests
 PARALLELISM := 5
-# Additional integration test flags (e.g. -force, -summary, -outputTick)
+# Additional integration test flags (e.g. -force, -serialSummary, -outputTick)
 INT_FLAGS :=
 
 CMDS = zlint zlint-gtld-update

--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@ PARALLELISM := 5
 #   make integration PARALLELISM=99 INT_FLAGS="-fingerprintSummary -forceDownload"
 #   make integration INT_FLAGS="-overwriteExpected -config custom.config.json"
 #   make integration INT_FLAGS="-fingerprintSummary -lintSummary -fingerprintFilter='^[ea]' -lintFilter='^w_ext_cert_policy_explicit_text_not_utf8' -config small.config.json"
+#   make integration INT_FLAGS="-lintSummary -fingerprintSummary -lintFilter='^e_' -config small.config.json"
 INT_FLAGS :=
 
 CMDS = zlint zlint-gtld-update

--- a/zlint.go
+++ b/zlint.go
@@ -19,6 +19,7 @@ package zlint
 import (
 	"encoding/json"
 	"io"
+	"regexp"
 	"time"
 
 	"github.com/zmap/zcrypto/x509"
@@ -38,9 +39,12 @@ type ResultSet struct {
 	FatalsPresent   bool                         `json:"fatals_present"`
 }
 
-func (z *ResultSet) execute(cert *x509.Certificate) {
+func (z *ResultSet) execute(cert *x509.Certificate, filter *regexp.Regexp) {
 	z.Results = make(map[string]*lints.LintResult, len(lints.Lints))
 	for name, l := range lints.Lints {
+		if filter != nil && !filter.MatchString(name) {
+			continue
+		}
 		res := l.Execute(cert)
 		z.Results[name] = res
 		z.updateErrorStatePresent(res)
@@ -79,8 +83,19 @@ func LintCertificate(c *x509.Certificate) *ResultSet {
 	}
 
 	// Run all tests
+	return LintCertificateFiltered(c, nil)
+}
+
+// LintCertificateFiltered runs all lints with names matching the provided
+// regexp on c, producing a ResultSet.
+func LintCertificateFiltered(c *x509.Certificate, filter *regexp.Regexp) *ResultSet {
+	if c == nil {
+		return nil
+	}
+
+	// Run tests with provided filter
 	res := new(ResultSet)
-	res.execute(c)
+	res.execute(c, filter)
 	res.Version = Version
 	res.Timestamp = time.Now().Unix()
 	return res


### PR DESCRIPTION
To limit the size of the data required to be kept in the zlint repo as "golden state" for integration tests it makes more sense to structure the results around per-lint results instead of per-certificate-fingerprint results. This change drops the `integration/config.json` file from ~50mb to 24kb.

This branch adds some other improvements to the integration test tooling that makes the process of investigating integration test failures a better experience. I've done my best to document the high level test process, the tooling and options, and a sample debugging experience in `integration/README.md`.

Resolves https://github.com/zmap/zlint/issues/322