### PR TITLE
CI: Add golangci-lint, enforce Go best practices

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,30 @@
+linters-settings:
+  gocyclo:
+    min-complexity: 25
+  govet:
+    check-shadowing: false
+  misspell:
+    locale: "US"
+
+linters:
+  enable-all: true
+  disable:
+    - stylecheck
+    - gosec
+    - dupl
+    - maligned
+    - depguard
+    - lll
+    - prealloc
+    - scopelint
+    - gocritic
+    - gochecknoinits
+    - gochecknoglobals
+    - godox
+    - funlen
+    - wsl
+    - whitespace
+    - gocognit
+    # TODO(@cpu): Uncomment goconst/golint once findings resolved.
+    - goconst
+    - golint

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,17 @@ dist: trusty
 go:
   - "1.13.x"
 
+install:
+  # Install `golangci-lint` using the installer script
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+
 script:
   # Fast-fail on non-zero exit codes
   - set -e
   # Build commands
   - make
-  # Verify that all files have been gofmt'd with simplification
-  - make format-check
+  # Verify that all files pass the golangci-lint code lints
+  - make code-lint
   # Run unit tests
   - make test
   # Run integration tests

--- a/cmd/zlint/main.go
+++ b/cmd/zlint/main.go
@@ -180,7 +180,7 @@ func includeLints() {
 		includesMap[includeName] = struct{}{}
 	}
 
-	// clear all initialised lints except for includes
+	// clear all initialized lints except for includes
 	for lintName := range lints.Lints {
 		if _, ok := includesMap[lintName]; !ok {
 			delete(lints.Lints, lintName)

--- a/gofmt_test.go
+++ b/gofmt_test.go
@@ -32,7 +32,7 @@ func TestGofmt(t *testing.T) {
 		cmd := exec.Command("/bin/sh", "-c", gofmtCmd)
 		var out bytes.Buffer
 		cmd.Stdout = &out
-		cmd.Run()
+		_ = cmd.Run()
 		if out.String() != "" {
 			t.Errorf("glob %s not gofmt'ed", glob)
 		}

--- a/lints/lint_ca_is_ca.go
+++ b/lints/lint_ca_is_ca.go
@@ -43,7 +43,7 @@ func (l *caIsCA) Execute(c *x509.Certificate) *LintResult {
 	if err != nil {
 		return &LintResult{Status: Fatal}
 	}
-	if constraints.IsCA == true {
+	if constraints.IsCA {
 		return &LintResult{Status: Pass}
 	} else {
 		return &LintResult{Status: Error}

--- a/lints/lint_distribution_point_incomplete_test.go
+++ b/lints/lint_distribution_point_incomplete_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 )
 
-func crlCompleteDp(t *testing.T) {
+func TestCRLCompleteDp(t *testing.T) {
 	inputPath := "../testlint/testCerts/crlComlepteDp.pem"
 	expected := Pass
 	out := Lints["e_distribution_point_incomplete"].Execute(ReadCertificate(inputPath))
@@ -27,7 +27,7 @@ func crlCompleteDp(t *testing.T) {
 	}
 }
 
-func crlIncompleteDp(t *testing.T) {
+func TestCRLIncompleteDp(t *testing.T) {
 	inputPath := "../testlint/testCerts/crlIncomlepteDp.pem"
 	expected := Error
 	out := Lints["e_distribution_point_incomplete"].Execute(ReadCertificate(inputPath))

--- a/lints/lint_ec_improper_curves.go
+++ b/lints/lint_ec_improper_curves.go
@@ -41,12 +41,11 @@ func (l *ecImproperCurves) Execute(c *x509.Certificate) *LintResult {
 	/* Declare theKey to be a ECDSA Public Key */
 	var theKey *ecdsa.PublicKey
 	/* Need to do different things based on what c.PublicKey is */
-	switch c.PublicKey.(type) {
+	switch keyType := c.PublicKey.(type) {
 	case *x509.AugmentedECDSA:
-		temp := c.PublicKey.(*x509.AugmentedECDSA)
-		theKey = temp.Pub
+		theKey = keyType.Pub
 	case *ecdsa.PublicKey:
-		theKey = c.PublicKey.(*ecdsa.PublicKey)
+		theKey = keyType
 	}
 	/* Now can actually check the params */
 	theParams := theKey.Curve.Params()

--- a/lints/lint_ext_crl_distribution_marked_critical.go
+++ b/lints/lint_ext_crl_distribution_marked_critical.go
@@ -35,7 +35,7 @@ func (l *ExtCrlDistributionMarkedCritical) CheckApplies(cert *x509.Certificate) 
 
 func (l *ExtCrlDistributionMarkedCritical) Execute(cert *x509.Certificate) *LintResult {
 	if e := util.GetExtFromCert(cert, util.CrlDistOID); e != nil {
-		if e.Critical == false {
+		if !e.Critical {
 			return &LintResult{Status: Pass}
 		} else {
 			return &LintResult{Status: Warn}

--- a/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
+++ b/lints/lint_ext_san_uri_host_not_fqdn_or_ip.go
@@ -27,9 +27,10 @@ Section 7.4.
 *********************************************************************/
 
 import (
+	"net/url"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"net/url"
 )
 
 type SANURIHost struct{}

--- a/lints/lint_name_constraint_maximum_not_absent.go
+++ b/lints/lint_name_constraint_maximum_not_absent.go
@@ -40,6 +40,7 @@ func (l *nameConstraintMax) CheckApplies(c *x509.Certificate) bool {
 	return util.IsExtInCert(c, util.NameConstOID)
 }
 
+//nolint:gocyclo
 func (l *nameConstraintMax) Execute(c *x509.Certificate) *LintResult {
 	for _, i := range c.PermittedDNSNames {
 		if i.Max != 0 {

--- a/lints/lint_name_constraint_minimum_non_zero.go
+++ b/lints/lint_name_constraint_minimum_non_zero.go
@@ -40,6 +40,7 @@ func (l *nameConstMin) CheckApplies(c *x509.Certificate) bool {
 	return util.IsExtInCert(c, util.NameConstOID)
 }
 
+//nolint:gocyclo
 func (l *nameConstMin) Execute(c *x509.Certificate) *LintResult {
 	for _, i := range c.PermittedDNSNames {
 		if i.Min != 0 {

--- a/lints/lint_qcstatem_etsi_present_qcs_critical.go
+++ b/lints/lint_qcstatem_etsi_present_qcs_critical.go
@@ -15,16 +15,11 @@
 package lints
 
 import (
-	"encoding/asn1"
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )
 
 type qcStatemQcEtsiPresentQcsCritical struct{}
-
-func (this *qcStatemQcEtsiPresentQcsCritical) getStatementOid() *asn1.ObjectIdentifier {
-	return &util.IdEtsiQcsQcCompliance
-}
 
 func (l *qcStatemQcEtsiPresentQcsCritical) Initialize() error {
 	return nil

--- a/lints/lint_qcstatem_etsi_type_as_statem.go
+++ b/lints/lint_qcstatem_etsi_type_as_statem.go
@@ -17,6 +17,7 @@ package lints
 import (
 	"encoding/asn1"
 	"fmt"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_qcstatem_mandatory_etsi_statems.go
+++ b/lints/lint_qcstatem_mandatory_etsi_statems.go
@@ -16,6 +16,7 @@ package lints
 
 import (
 	"encoding/asn1"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_qcstatem_qccompliance_valid.go
+++ b/lints/lint_qcstatem_qccompliance_valid.go
@@ -16,6 +16,7 @@ package lints
 
 import (
 	"encoding/asn1"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_qcstatem_qcpds_lang_case.go
+++ b/lints/lint_qcstatem_qcpds_lang_case.go
@@ -17,9 +17,10 @@ package lints
 import (
 	"encoding/asn1"
 	"fmt"
+	"unicode"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"unicode"
 )
 
 type qcStatemQcPdsLangCase struct{}

--- a/lints/lint_qcstatem_qcpds_valid.go
+++ b/lints/lint_qcstatem_qcpds_valid.go
@@ -17,9 +17,10 @@ package lints
 import (
 	"encoding/asn1"
 	"fmt"
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
-	"strings"
 )
 
 type qcStatemQcPdsValid struct{}

--- a/lints/lint_qcstatem_qcretentionperiod_valid.go
+++ b/lints/lint_qcstatem_qcretentionperiod_valid.go
@@ -16,6 +16,7 @@ package lints
 
 import (
 	"encoding/asn1"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_qcstatem_qcsscd_valid.go
+++ b/lints/lint_qcstatem_qcsscd_valid.go
@@ -16,6 +16,7 @@ package lints
 
 import (
 	"encoding/asn1"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_qcstatem_qctype_valid.go
+++ b/lints/lint_qcstatem_qctype_valid.go
@@ -17,6 +17,7 @@ package lints
 import (
 	"encoding/asn1"
 	"fmt"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_qcstatem_qctype_web.go
+++ b/lints/lint_qcstatem_qctype_web.go
@@ -17,6 +17,7 @@ package lints
 import (
 	"encoding/asn1"
 	"fmt"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/util"
 )

--- a/lints/lint_qcstatem_qctype_web.go
+++ b/lints/lint_qcstatem_qctype_web.go
@@ -60,9 +60,8 @@ func (l *qcStatemQctypeWeb) Execute(c *x509.Certificate) *LintResult {
 				found = true
 			}
 		}
-		if found != true {
+		if !found {
 			wrnString += fmt.Sprintf("etsi Type does not indicate certificate as a 'web' certificate")
-
 		}
 	}
 

--- a/lints/lint_sub_cert_certificate_policies_marked_critical.go
+++ b/lints/lint_sub_cert_certificate_policies_marked_critical.go
@@ -37,7 +37,7 @@ func (l *subCertPolicyCrit) CheckApplies(c *x509.Certificate) bool {
 
 func (l *subCertPolicyCrit) Execute(c *x509.Certificate) *LintResult {
 	e := util.GetExtFromCert(c, util.CertPolicyOID)
-	if e.Critical == false {
+	if !e.Critical {
 		return &LintResult{Status: Pass}
 	} else {
 		return &LintResult{Status: Warn}

--- a/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
+++ b/lints/lint_sub_cert_crl_distribution_points_marked_critical.go
@@ -37,9 +37,8 @@ func (l *subCrlDistCrit) CheckApplies(c *x509.Certificate) bool {
 }
 
 func (l *subCrlDistCrit) Execute(c *x509.Certificate) *LintResult {
-	// Add actual lint here
 	e := util.GetExtFromCert(c, util.CrlDistOID)
-	if e.Critical == false {
+	if !e.Critical {
 		return &LintResult{Status: Pass}
 	} else {
 		return &LintResult{Status: Error}

--- a/lints/lint_sub_cert_is_ca.go
+++ b/lints/lint_sub_cert_is_ca.go
@@ -37,7 +37,7 @@ func (l *subCertNotCA) Execute(c *x509.Certificate) *LintResult {
 	if _, err := asn1.Unmarshal(e.Value, &constraints); err != nil {
 		return &LintResult{Status: Fatal}
 	}
-	if constraints.IsCA == true {
+	if constraints.IsCA {
 		return &LintResult{Status: Error}
 	} else {
 		return &LintResult{Status: Pass}

--- a/lints/lint_subject_empty_without_san.go
+++ b/lints/lint_subject_empty_without_san.go
@@ -51,10 +51,7 @@ func (l *emptyWithoutSAN) Execute(cert *x509.Certificate) *LintResult {
 }
 
 func subjectIsEmpty(cert *x509.Certificate) bool {
-	if cert.Subject.Names == nil {
-		return true
-	}
-	return false
+	return len(cert.Subject.Names) == 0
 }
 
 func init() {

--- a/makefile
+++ b/makefile
@@ -32,7 +32,7 @@ test:
 integration:
 	$(INT_TEST)
 
-format-check:
-	diff <(find . -name '*.go' -not -path './vendor/*' -print | xargs -n1 gofmt -l) <(printf "")
+code-lint:
+	golangci-lint run
 
-.PHONY: clean zlint zlint-gtld-update test integration format-check
+.PHONY: clean zlint zlint-gtld-update test integration code-lint

--- a/util/algorithm_identifier.go
+++ b/util/algorithm_identifier.go
@@ -43,7 +43,7 @@ func CheckAlgorithmIDParamNotNULL(algorithmIdentifier []byte, requiredAlgoID asn
 	// byte comparison of algorithm sequence and checking no trailing data is present
 	var algorithmBytes []byte
 	if algorithmSequence.ReadBytes(&algorithmBytes, len(expectedAlgoIDBytes)) {
-		if bytes.Compare(algorithmBytes, expectedAlgoIDBytes) == 0 && algorithmSequence.Empty() {
+		if bytes.Equal(algorithmBytes, expectedAlgoIDBytes) && algorithmSequence.Empty() {
 			return nil
 		}
 	}

--- a/util/fqdn.go
+++ b/util/fqdn.go
@@ -32,10 +32,7 @@ func RemovePrependedQuestionMarks(domain string) string {
 }
 
 func RemovePrependedWildcard(domain string) string {
-	if strings.HasPrefix(domain, "*.") {
-		domain = domain[2:]
-	}
-	return domain
+	return strings.TrimPrefix(domain, "*.")
 }
 
 func IsFQDN(domain string) bool {

--- a/util/gtld.go
+++ b/util/gtld.go
@@ -107,9 +107,7 @@ func IsInTLDMap(label string) bool {
 // return false.
 func CertificateSubjInTLD(c *x509.Certificate, label string) bool {
 	label = strings.ToLower(label)
-	if strings.HasPrefix(label, ".") {
-		label = label[1:]
-	}
+	label = strings.TrimPrefix(label, ".")
 	if !IsInTLDMap(label) {
 		return false
 	}

--- a/util/oid.go
+++ b/util/oid.go
@@ -148,13 +148,13 @@ func GetMappedPolicies(polMap *pkix.Extension) (out [][2]asn1.ObjectIdentifier, 
 	var outSeq, inSeq asn1.RawValue
 
 	empty, err := asn1.Unmarshal(polMap.Value, &outSeq) //strip outer sequence tag/length should be nothing extra
-	if err != nil || len(empty) != 0 || outSeq.Class != 0 || outSeq.Tag != 16 || outSeq.IsCompound == false {
+	if err != nil || len(empty) != 0 || outSeq.Class != 0 || outSeq.Tag != 16 || !outSeq.IsCompound {
 		return nil, errors.New("policyMap: Could not unmarshal outer sequence.")
 	}
 
 	for done := false; !done; { //loop through SEQUENCE OF
 		outSeq.Bytes, err = asn1.Unmarshal(outSeq.Bytes, &inSeq) //extract next inner SEQUENCE (OID pair)
-		if err != nil || inSeq.Class != 0 || inSeq.Tag != 16 || inSeq.IsCompound == false {
+		if err != nil || inSeq.Class != 0 || inSeq.Tag != 16 || !inSeq.IsCompound {
 			err = errors.New("policyMap: Could not unmarshal inner sequence.")
 			return
 		}

--- a/util/oid.go
+++ b/util/oid.go
@@ -109,6 +109,7 @@ func IsExtInCert(cert *x509.Certificate, oid asn1.ObjectIdentifier) bool {
 
 // GetExtFromCert returns the extension with the matching OID, if present. If
 // the extension if not present, it returns nil.
+//nolint:interfacer
 func GetExtFromCert(cert *x509.Certificate, oid asn1.ObjectIdentifier) *pkix.Extension {
 	// Since this function is called by many Lint CheckApplies functions we use
 	// the x509.Certificate.ExtensionsMap field added by zcrypto to check for

--- a/util/qc_stmt.go
+++ b/util/qc_stmt.go
@@ -134,6 +134,7 @@ func IsAnyEtsiQcStatementPresent(extVal []byte) bool {
 	return false
 }
 
+//nolint:gocyclo
 func ParseQcStatem(extVal []byte, sought asn1.ObjectIdentifier) EtsiQcStmtIf {
 	sl := make([]anyContent, 0)
 	rest, err := asn1.Unmarshal(extVal, &sl)

--- a/util/qc_stmt.go
+++ b/util/qc_stmt.go
@@ -21,39 +21,6 @@ import (
 	"reflect"
 )
 
-func etsiOidToDescString(oid asn1.ObjectIdentifier) string {
-	switch {
-	case oid.Equal(IdEtsiQcsQcCompliance):
-		{
-			return "IdEtsiQcsQcCompliance"
-		}
-	case oid.Equal(IdEtsiQcsQcLimitValue):
-		{
-			return "IdEtsiQcsQcLimitValue"
-		}
-	case oid.Equal(IdEtsiQcsQcRetentionPeriod):
-		{
-			return "IdEtsiQcsQcRetentionPeriod"
-		}
-	case oid.Equal(IdEtsiQcsQcSSCD):
-		{
-			return "IdEtsiQcsQcSSCSD"
-		}
-	case oid.Equal(IdEtsiQcsQcEuPDS):
-		{
-			return "IdEtsiQcsQcEuPDS"
-		}
-	case oid.Equal(IdEtsiQcsQcType):
-		{
-			return "IdEtsiQcsQcType"
-		}
-	default:
-		{
-			panic("unresolved ETSI QC Statement OID")
-		}
-	}
-}
-
 type anyContent struct {
 	Raw asn1.RawContent
 }

--- a/zlint.go
+++ b/zlint.go
@@ -70,7 +70,7 @@ func EncodeLintDescriptionsToJSON(w io.Writer) {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 	for _, lint := range lints.Lints {
-		enc.Encode(lint)
+		_ = enc.Encode(lint)
 	}
 }
 


### PR DESCRIPTION
This branch adds [golangci-lint](https://github.com/golangci/golangci-lint) to the CI build/makefile. (_Linters linting linters! :dizzy_face:_)

The configuration I've added (see `.golangci-lint.yml`) **enables** the following lints:
```
bodyclose: checks whether HTTP response body is closed successfully [fast: true, auto-fix: false]
deadcode: Finds unused code [fast: true, auto-fix: false]
dogsled: Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f()) [fast: true, auto-fix: false]
errcheck: Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: true, auto-fix: false]
gocyclo: Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
goimports: Goimports does everything that gofmt does. Additionally it checks unused imports [fast: true, auto-fix: true]
gosimple (megacheck): Linter for Go source code that specializes in simplifying a code [fast: true, auto-fix: false]
govet (vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: true, auto-fix: false]
ineffassign: Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
interfacer: Linter that suggests narrower interface types [fast: true, auto-fix: false]
misspell: Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
nakedret: Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
staticcheck (megacheck): Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: true, auto-fix: false]
structcheck: Finds unused struct fields [fast: true, auto-fix: false]
typecheck: Like the front-end of a Go compiler, parses and type-checks Go code [fast: true, auto-fix: false]
unconvert: Remove unnecessary type conversions [fast: true, auto-fix: false]
unparam: Reports unused function parameters [fast: true, auto-fix: false]
unused (megacheck): Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
varcheck: Finds unused global variables and constants [fast: true, auto-fix: false]
```

I disabled a handful of others. Mostly because they are too opinionated (`gocritic`, `whitespace`, `wsl`, etc), not applicable (`depguard`, `godox`, `gosec`), or produced too many findings to address in this PR (`golint`, `stylecheck`, `goconst`). One day I'd like to come back around to enabling that last category when I can find the time to implement all of the renames/fixes required.

I broke up each commit in this branch based on the lint error that was being fixed. Mostly these are small diffs and a few caught real bugs (e.g. unit tests that were never run, dead code, missed err checking).

The home-spun `make format-check` target can be replaced entirely since it's now subsumed by the `gofmt` linter run by `golangci-lint`.
