### PR TITLE
lints: add more context to `w_subject_contains_malformed_arpa_ip`.

### DIFF
--- a/lints/cabf_br/lint_subject_contains_malformed_arpa_ip.go
+++ b/lints/cabf_br/lint_subject_contains_malformed_arpa_ip.go
@@ -130,9 +130,19 @@ func lintReversedIPAddressLabels(name string, ipv6 bool) error {
 
 func init() {
 	lint.RegisterLint(&lint.Lint{
-		Name:          "w_subject_contains_malformed_arpa_ip",
-		Description:   "Checks no subject domain name contains a rDNS entry in an .arpa zone with the wrong number of labels",
-		Citation:      "BRs: 7.1.4.2.1",
+		Name: "w_subject_contains_malformed_arpa_ip",
+		Description: "Checks no subject domain name contains a rDNS entry in the " +
+			"registry-controlled .arpa zone with the wrong number of labels, or " +
+			"an invalid IP address (RFC 3596, BCP49)",
+		// NOTE(@cpu): 3.2.2.6 is particular to wildcard domain validation for names
+		// in a registry controlled zone (like .arpa), which would be an appropriate
+		// citation for when this lint finds a rDNS entry with the wrong
+		// number of labels/invalid IP because of the presence of a wildcard
+		// character. There is a larger on-going discussion[0] on the BRs stance on
+		// the .arpa zone entries that may produce a better citation to use here.
+		//
+		// [0]: https://github.com/cabforum/documents/issues/153
+		Citation:      "BRs: 3.2.2.6",
 		Source:        lint.CABFBaselineRequirements,
 		EffectiveDate: util.CABEffectiveDate,
 		Lint:          &arpaMalformedIP{},


### PR DESCRIPTION
Section 7.1.4.2.1 of the BRs is a good citation for `e_subject_contains_reserved_arpa_ip` but isn't a great choice for `w_subject_contains_malformed_arpa_ip`.

When the `.arpa` address doesn't have enough labels, or can't be parsed as an IP address it's clear that it isn't an internal IP address and so 7.1.4.2.1 isn't a good citation. Section 3.2.2.6 talks about wildcard domains for "registry controlled" zones, and `.arpa` is one of those (based on BCP49). A wildcard label is one way the `.arpa` domain wouldn't parse as an IP. 

While the larger discussion on how `.arpa` domains that aren't formatted per RFC 3596 unfolds we can ref 3.2.2.6 and add a bit more context to the lint and description. It isn't perfect, but I think less confusing than ref'ing 7.1.4.2.1, which clearly doesn't apply.

See also https://github.com/zmap/zlint/issues/343