### PR TITLE
project: add goreleaser configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ cmd/zlint-gtld-update/zlint-gtld-update
 
 ### Integration test data ###
 data
+
+### Goreleaser builds ###
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,30 @@
+project_name: zlint
+before:
+  hooks:
+    - go mod tidy
+builds:
+  -
+    main: ./cmd/zlint/main.go
+    binary: zlint
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - freebsd
+      - windows
+      - darwin
+    goarch:
+      - amd64
+archives:
+  -
+    wrap_in_directory: true
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
+snapshot:
+  name_template: "{{ .Tag }}-next"
+release:
+  draft: true
+  prerelease: auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,16 @@ script:
   # Run integration tests
   - make integration PARALLELISM=3
 
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: curl -sL https://git.io/goreleaser | bash
+    api_key: $GITHUB_AUTH_TOKEN
+    draft: true
+    on:
+      repo: zmap/zlint
+      tags: true
+
 notifications:
   email:
   - dkumar11@illinois.edu

--- a/cmd/zlint/main.go
+++ b/cmd/zlint/main.go
@@ -39,6 +39,9 @@ var ( // flags
 	format          string
 	include         string
 	exclude         string
+
+	// version is replaced by GoReleaser using an LDFlags option at release time.
+	version = "dev"
 )
 
 func init() {
@@ -50,6 +53,7 @@ func init() {
 
 	flag.BoolVar(&prettyprint, "pretty", false, "Pretty-print output")
 	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "ZLint version %s\n\n", version)
 		fmt.Fprintf(os.Stderr, "Usage: %s [flags] file...\n", os.Args[0])
 		flag.PrintDefaults()
 	}


### PR DESCRIPTION
Adds configuration for [GoReleaser](https://goreleaser.com/) to the project/CI.

Before this will be functional a dedicated Github user with write access to the ZLint repository needs to be created, and an API key saved into the Travis config as a protected env var named `GITHUB_AUTH_TOKEN`.

By default releases are added to the repository in draft status. This gives maintainers a chance to write the release notes/changelog and verify the build artifacts before publishing the release. Tags with "rc" in the name will be marked as pre-release candidates automatically.

Updates https://github.com/zmap/zlint/issues/351