### PR TITLE
cmd/zlint: fix panic w/ deref of nil registry.

### DIFF
--- a/cmd/zlint/main.go
+++ b/cmd/zlint/main.go
@@ -180,7 +180,7 @@ func trimmedList(raw string) []string {
 func setLints() (lint.Registry, error) {
 	// If there's no filter options set, use the global registry as-is
 	if nameFilter == "" && includeNames == "" && excludeNames == "" && includeSources == "" && excludeSources == "" {
-		return nil, nil
+		return lint.GlobalRegistry(), nil
 	}
 
 	filterOpts := lint.FilterOptions{}


### PR DESCRIPTION
This fixes a panic that can occur when there are no filtering arguments provided to the `zlint` command line tool introduced in 7741587316b5f34b13c0f4849816dd33697f5f19.

This occurs because `setLints` returned a `nil` `Registry` when the intention was to use the global registry: 
https://github.com/zmap/zlint/blob/7741587316b5f34b13c0f4849816dd33697f5f19/cmd/zlint/main.go#L181-L184

Before fix:
```
$ zlint -list-lints-source
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x717bd0]

goroutine 1 [running]:
main.main()
	/home/daniel/go/src/github.com/zmap/zlint/cmd/zlint/main.go:85 +0xe0
```

After fix:
```
$ zlint -list-lints-source
    AWSLabs
    Apple
    CABF_BR
    CABF_EV
    ETSI_ESI
    Mozilla
    RFC5280
    RFC5480
    RFC5891
    ZLint
```