### PR TITLE
ci: try and fix goreleaser for v2 structure (round 2)

### DIFF
--- a/v2/.goreleaser.yml
+++ b/v2/.goreleaser.yml
@@ -4,7 +4,7 @@ before:
     - go mod tidy
 builds:
   -
-    main: ./v2/cmd/zlint/main.go
+    main: ./cmd/zlint/main.go
     binary: zlint
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
Getting closer (love 2 iterate in CI):

[Failed build](https://travis-ci.org/zmap/zlint/builds/650550396) found the config:
```
   • releasing using goreleaser 0.126.0...
   • loading config file       file=.goreleaser.yml
```

but had the wrong path for the binary:

```
   ⨯ release failed after 0.28s error=stat v2/cmd/zlint/main.go: no such file or directory
```