### PR TITLE
remove lisp reserved range since no longer IANA reserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,14 @@ ZLint
 [![Go Report Card](https://goreportcard.com/badge/github.com/zmap/zlint)](https://goreportcard.com/report/github.com/zmap/zlint)
 
 ZLint is a X.509 certificate linter written in Go that checks for consistency
-with standards (e.g. [RFC 5280]) and other relevant PKI requirements (e.g.
-[CA/Browser Forum Baseline Requirements][BR v1.4.8]).
-
-It can be used as a command line tool or as a library integrated into CA
-software.
+with standards (e.g. [RFC 5280]) and PKI requirements (e.g., [CA/Browser Forum
+Baseline Requirements][BR v1.4.8]). It can be used as a command line tool or as
+a library integrated into CA software. [ZLint
+v2.0.0](https://github.com/zmap/zlint/tree/v2.0.0) is the latest stable
+release.
 
 [RFC 5280]: https://www.ietf.org/rfc/rfc5280.txt
 [BR v1.4.8]: https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.4.8.pdf
-
-Requirements
-------------
-
-ZLint requires [Go 1.13.x or newer](https://golang.org/doc/install) be
-installed. The command line setup instructions assume the `go` command is in
-your `$PATH`.
 
 Lint Sources
 ------------
@@ -64,8 +57,12 @@ before finalizing a production ready release tag. We encourage users to test RC
 releases to provide feedback early enough for bugs to be addressed before the
 final release is made available.
 
+Requirements
+------------
 
-Command Line Usage
+ZLint requires [Go 1.13.x or newer](https://golang.org/doc/install) be
+installed. The command line setup instructions assume the `go` command is in
+your `$PATH`.
 ------------------
 
 ZLint can be used on the command-line through a simple bundled executable

--- a/README.md
+++ b/README.md
@@ -5,14 +5,21 @@ ZLint
 [![Go Report Card](https://goreportcard.com/badge/github.com/zmap/zlint)](https://goreportcard.com/report/github.com/zmap/zlint)
 
 ZLint is a X.509 certificate linter written in Go that checks for consistency
-with standards (e.g. [RFC 5280]) and PKI requirements (e.g., [CA/Browser Forum
-Baseline Requirements][BR v1.4.8]). It can be used as a command line tool or as
-a library integrated into CA software. [ZLint
-v2.0.0](https://github.com/zmap/zlint/tree/v2.0.0) is the latest stable
-release.
+with standards (e.g. [RFC 5280]) and other relevant PKI requirements (e.g.
+[CA/Browser Forum Baseline Requirements][BR v1.4.8]).
+
+It can be used as a command line tool or as a library integrated into CA
+software.
 
 [RFC 5280]: https://www.ietf.org/rfc/rfc5280.txt
 [BR v1.4.8]: https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.4.8.pdf
+
+Requirements
+------------
+
+ZLint requires [Go 1.13.x or newer](https://golang.org/doc/install) be
+installed. The command line setup instructions assume the `go` command is in
+your `$PATH`.
 
 Lint Sources
 ------------
@@ -57,12 +64,8 @@ before finalizing a production ready release tag. We encourage users to test RC
 releases to provide feedback early enough for bugs to be addressed before the
 final release is made available.
 
-Requirements
-------------
 
-ZLint requires [Go 1.13.x or newer](https://golang.org/doc/install) be
-installed. The command line setup instructions assume the `go` command is in
-your `$PATH`.
+Command Line Usage
 ------------------
 
 ZLint can be used on the command-line through a simple bundled executable

--- a/v2/util/ip.go
+++ b/v2/util/ip.go
@@ -33,7 +33,7 @@ const (
 	as112
 	amt
 	orchidV2
-	lisp // deprecated
+	_ // deprecated: lisp
 	thisHostOnThisNetwork
 	translatableAddress6to4
 	translatableAddress4to6

--- a/v2/util/ip.go
+++ b/v2/util/ip.go
@@ -33,7 +33,7 @@ const (
 	as112
 	amt
 	orchidV2
-	lisp
+	lisp // deprecated
 	thisHostOnThisNetwork
 	translatableAddress6to4
 	translatableAddress4to6
@@ -84,7 +84,6 @@ func init() {
 		as112:                                {"192.31.196.0/24", "192.175.48.0/24", "2001:4:112::/48", "2620:4f:8000::/48"},
 		amt:                                  {"192.52.193.0/24", "2001:3::/32"},
 		orchidV2:                             {"2001:20::/28"},
-		lisp:                                 {"2001:5::/32"}, // TODO: this could expire at 2019-09. Please check  https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml for updates
 		thisHostOnThisNetwork:                {"0.0.0.0/8"},
 		translatableAddress4to6:              {"2002::/16"},
 		translatableAddress6to4:              {"64:ff9b::/96", "64:ff9b:1::/48"},


### PR DESCRIPTION
lisp range is no longer reserved here: https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml