### PR TITLE
docs: fix template to use v2 package import.

### DIFF
--- a/v2/template
+++ b/v2/template
@@ -16,7 +16,7 @@ package PACKAGE
 
 import (
 	"github.com/zmap/zcrypto/x509"
-	"github.com/zmap/zlint/lint"
+	"github.com/zmap/zlint/v2/lint"
 )
 
 type SUBST struct{}


### PR DESCRIPTION
The `template` file used by `v2/newLint.sh` needs to use the ZLint 2.0.0 import path for the `lint` package or building a lint created with the utility will fail.