### PR TITLE
util: rewrite test/prepend_testcerts_openssl.sh, update testdata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ script:
   - make
   # Verify that all files pass the golangci-lint code lints
   - make code-lint
+  # Verify that all testdata files are prepended with text
+  - make testdata-lint
   # Run unit tests
   - make test
   # Run integration tests

--- a/v2/makefile
+++ b/v2/makefile
@@ -37,4 +37,7 @@ integration:
 code-lint:
 	golangci-lint run
 
-.PHONY: clean zlint zlint-gtld-update test integration code-lint
+testdata-lint:
+	./test/prepend_testcerts_openssl.sh && git diff --exit-code testdata/
+
+.PHONY: clean zlint zlint-gtld-update test integration code-lint testdata-lint

--- a/v2/test/prepend_testcerts_openssl.sh
+++ b/v2/test/prepend_testcerts_openssl.sh
@@ -34,7 +34,6 @@ for f in "$CERTS_DIR"/*.pem; do
   fi
 
   # Prepend the test cert with its -text OpenSSL output.
-  openssl x509 -in "$f" -text -noout | \
-    cat - "$f" > "$TMP_DIR/$CERT_NAME.new" && \
-    mv "$TMP_DIR/$CERT_NAME.new" "$f"
+  openssl x509 -text -in "$f" -outform PEM -out "$TMP_DIR/$CERT_NAME.new" \
+    && mv "$TMP_DIR/$CERT_NAME.new" "$f"
 done

--- a/v2/test/prepend_testcerts_openssl.sh
+++ b/v2/test/prepend_testcerts_openssl.sh
@@ -1,4 +1,40 @@
 #!/bin/bash
-for f in ../testlint/testCerts/*; do
-    openssl x509 -in $f -text -noout | cat - $f > /tmp/out && mv /tmp/out $f
+
+set -e -o pipefail
+
+BASE_DIR=$(dirname "$0")
+CERTS_DIR="$BASE_DIR/../testdata"
+TMP_DIR=$(mktemp -d -t zlint-XXXX)
+
+# Trap EXIT to cleanup the TMP_DIR
+trap '{ rmdir --ignore-fail-on-non-empty $TMP_DIR; }' EXIT
+
+# For every .pem file in the $CERTS directory, prepend 0penSSL text output if
+# required.
+for f in "$CERTS_DIR"/*.pem; do
+  # Skip any files that don't begin with a PEM header. These are assumed to
+  # already have the OpenSSL text output prepended.
+  if [[ ! $(head -n1 "$f") =~ "-----BEGIN" ]]; then
+    continue
+  fi
+
+  # If an argument is provided only consider filenames that match the provided
+  # argument. This allows only prepending a specific testcert instead of all
+  # unprepended testcerts.
+  CERT_NAME=$(basename "$f")
+  if [[ -n "$1" && ! $CERT_NAME =~ $1 ]]; then
+    continue
+  fi
+
+  # If the certificate has errors parsing with OpenSSL print a warning to stderr
+  # and continue. Sometimes our test data is too weird to parse and that's OK.
+  if ! openssl x509 -in "$f" -noout || false; then
+    echo "error parsing $f with OpenSSL" >&2
+    continue
+  fi
+
+  # Prepend the test cert with its -text OpenSSL output.
+  openssl x509 -in "$f" -text -noout | \
+    cat - "$f" > "$TMP_DIR/$CERT_NAME.new" && \
+    mv "$TMP_DIR/$CERT_NAME.new" "$f"
 done

--- a/v2/testdata/NCReservedIPNet.pem
+++ b/v2/testdata/NCReservedIPNet.pem
@@ -1,3 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: 
+        Validity
+            Not Before: Nov  1 00:00:00 2017 GMT
+            Not After : Nov  1 00:00:00 2017 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:f5:0a:1c:80:44:f6:f2:4d:9a:93:06:18:40:d2:
+                    8e:ae:81:51:19:46:e1:b3:70:47:2f:c9:c9:36:5a:
+                    1e:58:fb:31:f4:eb:68:2b:98:80:a4:fb:34:32:de:
+                    ff:b6:f2:0d:9d:d4:42:72:fa:05:e6:10:ef:30:65:
+                    e8:0f:27:eb:2b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication
+            X509v3 Name Constraints: 
+                Permitted:
+                  IP:192.0.0.0/255.255.0.0
+
+    Signature Algorithm: sha256WithRSAEncryption
+         46:99:a2:e4:6a:96:68:5c:42:bc:fd:c9:0b:21:96:0c:24:4e:
+         1c:ea:b1:e6:a5:52:5c:22:a9:da:d2:f5:07:6f:e1:c6:84:3c:
+         1f:b6:64:9e:21:75:4f:b4:34:4f:2d:8c:8a:fa:5d:9f:58:88:
+         35:74:91:d6:fb:2f:bd:83:fe:03
 -----BEGIN CERTIFICATE-----
 MIIBIDCBy6ADAgECAgEBMA0GCSqGSIb3DQEBCwUAMAAwHhcNMTcxMTAxMDAwMDAw
 WhcNMTcxMTAxMDAwMDAwWjAAMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAPUKHIBE

--- a/v2/testdata/NCValidIPNet.pem
+++ b/v2/testdata/NCValidIPNet.pem
@@ -1,3 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: 
+        Validity
+            Not Before: Nov  1 00:00:00 2017 GMT
+            Not After : Nov  1 00:00:00 2017 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:db:6b:43:17:4e:44:87:33:25:94:78:f3:36:d0:
+                    8b:a4:39:19:43:9c:f7:36:46:49:8a:9f:8e:7a:17:
+                    13:de:8d:f8:21:11:c7:e3:da:62:41:ec:44:23:e5:
+                    66:4a:89:e7:b7:40:7c:46:a8:fe:5d:99:c8:04:77:
+                    d6:39:3c:ca:c1
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication
+            X509v3 Name Constraints: 
+                Permitted:
+                  IP:166.0.0.0/255.255.255.0
+
+    Signature Algorithm: sha256WithRSAEncryption
+         9a:b5:b6:b4:51:d7:81:0c:ce:36:a7:2a:a9:d3:44:67:21:cb:
+         46:10:28:c7:0d:1e:82:ee:24:29:df:aa:d6:f5:8a:ca:cc:f3:
+         98:dc:0f:f1:5f:9e:bb:1c:24:5b:a4:59:9b:43:01:47:fa:68:
+         d1:f1:95:4a:f7:ef:2e:51:ee:51
 -----BEGIN CERTIFICATE-----
 MIIBIDCBy6ADAgECAgEBMA0GCSqGSIb3DQEBCwUAMAAwHhcNMTcxMTAxMDAwMDAw
 WhcNMTcxMTAxMDAwMDAwWjAAMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANtrQxdO

--- a/v2/testdata/QcStmtEtsiEsealValidCert02.pem
+++ b/v2/testdata/QcStmtEtsiEsealValidCert02.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            01:fe:6b:47:c7:09:10:a9:aa:fb:72:3e:37
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:29 2018 GMT
+            Not After : Nov 21 03:21:29 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:bb:4f:7d:3c:11:46:52:c0:fc:4f:b3:00:5e:6f:
+                    d2:7d:dc:3d:58:1c:79:5a:d3:e0:c9:87:62:a8:e4:
+                    75:9f:47:38:ac:02:bb:3d:9a:03:08:e7:13:69:0e:
+                    4c:59:2a:f6:20:c5:60:35:44:51:d3:c2:28:5c:78:
+                    6e:88:59:f7:7a:4a:13:e9:8a:b1:51:68:d2:10:9e:
+                    be:fd:c2:e3:27:60:d2:ab:a4:df:27:b9:9d:df:44:
+                    dc:93:30:40:16:ee:f4:f7:bb:3e:fd:b8:c7:1b:ad:
+                    80:6d:4b:71:cc:82:73:a0:cf:3b:d7:ac:53:a7:f1:
+                    05:68:0d:8a:0c:5d:55:4a:c0:09:71:36:36:ac:03:
+                    49:94:97:ee:7c:cf:21:a3:7b:aa:85:81:e0:ee:c6:
+                    7c:f2:aa:d4:a4:dc:f8:7b:49:fe:b2:b6:5c:af:fd:
+                    ad:92:41:6f:33:18:52:28:51:d0:76:0b:d7:5f:86:
+                    b7:f8:b6:c5:88:fe:fd:e0:81:44:01:75:7e:60:9d:
+                    66:6b:c7:85:08:78:7b:aa:1d:31:77:24:8d:10:d5:
+                    34:d3:63:2b:1c:30:00:02:c3:ad:b2:17:c7:02:36:
+                    0f:98:6e:c4:bb:81:c7:b9:4f:19:d5:38:a7:5e:30:
+                    78:53:9b:b7:00:a6:24:00:c9:4e:53:9d:6c:1a:2c:
+                    02:55
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                FC:90:7C:0F:39:F4:67:D1:E2:89:F2:EE:03:E6:3D:B9:76:C9:42:FA
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0w0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         5d:f9:41:ed:47:62:33:07:2e:9e:77:50:4b:a2:98:29:53:f7:
+         df:2c:e8:23:ef:00:d9:d7:ff:65:d8:92:72:fa:0f:cd:d9:63:
+         e5:29:bd:7a:e9:4d:2c:e5:ca:d7:4c:30:e0:4f:1d:03:82:12:
+         2b:1c:1d:49:44:a9:41:4b:3e:be:20:7c:50:e5:23:2b:5a:06:
+         b1:3b:18:7d:dd:3a:c3:20:0e:b2:b3:e4:f8:91:4b:35:e4:3e:
+         c4:79:32:99:b5:66:b2:be:fb:f1:86:3b:3c:f5:b6:3c:c4:3f:
+         85:ca:05:cf:92:a6:6b:43:dd:af:ca:17:74:0e:7e:ea:8c:64:
+         e4:68:2a:54:d5:25:81:e5:89:8b:83:54:8f:c8:8c:e7:a3:90:
+         44:ca:3e:12:a2:a5:e4:f2:e0:07:6d:e7:42:9e:df:b9:2e:89:
+         6d:24:67:8e:30:7e:e6:33:1a:f5:6f:56:b5:d8:89:9e:b3:1d:
+         46:fa:7d:3f:fd:fb:37:bb:0d:5a:36:66:20:a1:68:79:eb:95:
+         01:b6:9e:84:46:fe:e3:1b:da:ac:1a:57:a9:d3:5c:50:7a:4a:
+         67:58:e0:7c:45:36:90:1d:0b:c1:bf:86:0d:90:00:79:8e:ec:
+         7c:c0:06:0b:96:2f:be:91:20:f9:bc:2e:24:e2:50:19:d3:ee:
+         5d:99:fa:da
 -----BEGIN CERTIFICATE-----
 MIIEzjCCA7agAwIBAgINAf5rR8cJEKmq+3I+NzANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiLangCodeUpperCaseCert23.pem
+++ b/v2/testdata/QcStmtEtsiLangCodeUpperCaseCert23.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0a:e4:f0:40:30:25:65:57:d5:68:eb:40:15
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:34 2018 GMT
+            Not After : Nov 21 03:21:34 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:9b:ea:f5:bd:78:97:77:dd:c5:67:ad:3e:67:50:
+                    a4:ca:77:b4:44:97:4e:d4:67:af:8d:ba:42:05:fa:
+                    41:28:11:18:52:fe:5c:95:e1:f7:57:1f:3e:44:c0:
+                    99:da:9e:22:81:84:1b:98:db:95:bc:d3:49:5a:29:
+                    00:e4:9d:8f:63:5a:b1:00:5e:2a:c4:bf:9d:66:0e:
+                    18:f2:a6:7c:b7:5f:f4:96:e3:8b:27:b8:93:cc:fc:
+                    2b:52:34:5b:fc:8b:ac:76:82:1e:0c:3e:8e:3b:78:
+                    98:6a:35:88:c1:52:26:81:5c:e1:05:a8:e2:65:7c:
+                    c6:d0:d4:00:a4:9d:2c:41:89:f2:45:6d:1d:58:c0:
+                    f3:15:75:5d:b2:c3:ee:ac:c8:0a:73:19:a4:f8:c5:
+                    57:19:91:ed:a7:94:9a:1e:cd:1f:54:aa:db:a3:39:
+                    ab:e7:25:4a:41:f0:92:77:18:fa:ba:ef:63:7d:0b:
+                    65:fe:1c:e1:f9:70:36:f8:42:4e:07:e8:47:a5:7f:
+                    f1:47:16:dd:08:5b:45:e1:cc:8c:26:a8:a1:1d:f4:
+                    8d:6b:5f:74:cb:94:38:4d:a6:78:69:8f:34:9e:e2:
+                    e7:9f:02:06:ec:0f:a6:da:32:65:0a:df:5d:91:c3:
+                    6e:43:7a:16:9b:c9:eb:52:70:ae:c8:48:95:86:3e:
+                    16:27
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                C8:9B:AA:58:F3:56:57:9C:C5:71:3A:64:C1:9D:0B:5E:79:44:96:56
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0w0......F..0V.....F..0L0$..http://example.com/en/test.pdf..EN0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         0a:b7:f5:a8:52:7e:47:f9:bf:e9:f9:c1:50:f1:a6:d3:81:21:
+         46:84:64:fe:14:79:0f:6e:a8:50:5e:37:ab:62:37:c3:51:da:
+         ea:51:aa:4a:9f:6f:60:24:cd:7d:a4:6a:b5:66:61:9d:3b:38:
+         82:2c:14:85:96:b3:0c:23:35:1c:c6:bc:2e:d7:09:71:a3:7b:
+         6b:45:96:d1:e0:c6:89:fb:0a:e1:76:7e:2e:83:cb:2e:d7:91:
+         eb:29:15:a7:1b:da:6b:f1:f7:fc:46:85:a4:30:7a:5a:76:04:
+         5e:e2:b2:f5:4a:9b:c1:54:54:c4:1d:87:9d:35:5a:a5:ec:5f:
+         f6:e5:f9:ad:f3:7f:6d:29:ae:52:03:07:7e:67:ec:0b:a4:f9:
+         98:76:66:f1:9f:85:19:e1:d5:de:cd:35:79:46:b2:61:c5:03:
+         35:24:70:ff:ef:82:84:af:f6:6f:95:dd:31:19:be:cd:aa:f6:
+         d0:41:1b:d6:4e:a8:08:db:ca:f5:fa:d6:47:77:bf:f8:5a:6a:
+         e7:d8:c9:0b:57:91:1e:4d:01:4e:9e:6d:62:dd:b4:b8:b8:05:
+         e9:6a:40:78:4c:c0:26:0c:99:ad:6a:72:1c:42:2b:4d:42:cf:
+         63:9a:d6:b8:cf:d3:ae:11:47:e9:34:73:7e:13:5c:b8:de:c9:
+         42:b7:19:b2
 -----BEGIN CERTIFICATE-----
 MIIEzjCCA7agAwIBAgINCuTwQDAlZVfVaOtAFTANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiMissingEnglishPdsCert04.pem
+++ b/v2/testdata/QcStmtEtsiMissingEnglishPdsCert04.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0b:a7:29:80:c7:a2:24:51:07:50:2a:90:8d
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:29 2018 GMT
+            Not After : Nov 21 03:21:29 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:d2:47:99:12:e5:33:bd:47:eb:a1:ba:d0:b0:21:
+                    75:c5:2b:ad:5d:d1:7a:e2:0a:0e:cd:1f:42:0a:2f:
+                    ff:38:74:96:d6:c1:74:85:16:2d:c1:33:c1:bf:17:
+                    b8:fc:aa:2e:63:20:5d:6c:4b:89:c3:32:87:e6:28:
+                    5a:15:62:58:30:22:41:9e:9c:b5:a4:ee:39:2c:98:
+                    ee:90:2e:c7:e3:4f:9b:ba:d6:a8:87:a6:b3:90:50:
+                    8f:53:8d:53:63:7e:da:36:df:81:10:1e:6d:dd:6d:
+                    45:f8:6f:c7:45:5d:1c:66:b7:68:0d:e9:d7:e1:e0:
+                    68:a6:ef:ef:50:63:18:b3:41:0e:42:9c:17:6d:d9:
+                    da:65:9e:f8:3e:a0:92:d5:59:81:f3:1a:c9:f7:47:
+                    32:01:48:6b:a7:ca:84:c3:a1:3b:a1:3e:d2:d9:4f:
+                    c7:87:c3:08:67:8b:88:ff:87:92:c1:bc:be:48:d9:
+                    cd:a3:00:ee:3d:4c:6b:50:3a:a9:fb:b2:7c:f6:35:
+                    78:e6:c9:f9:9d:d4:c9:1f:63:e0:f3:6e:a2:0c:83:
+                    81:2a:29:65:30:27:a1:fe:74:d8:8d:a3:68:4e:3b:
+                    dd:99:15:7e:55:f4:aa:c0:f4:89:e5:3e:cf:66:ab:
+                    25:69:a9:82:d5:35:08:3f:d2:b5:0c:9e:fe:43:2a:
+                    62:6d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                18:C8:77:53:F8:49:C3:57:53:F6:0D:68:96:D7:F0:A0:D2:D8:56:4B
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0Q0......F..00.....F..0&0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         95:3a:a9:9e:ef:8c:a6:34:8a:08:23:01:01:85:ba:62:4c:6a:
+         80:c2:d7:5e:b7:fa:84:f7:11:a7:65:5f:c5:6b:d0:d7:18:ad:
+         6e:5b:d5:f6:cb:06:62:91:60:de:ed:33:ee:5f:aa:de:75:67:
+         40:bb:e9:7f:a3:11:db:ed:28:b4:c6:93:9e:f6:3d:94:cb:13:
+         d9:56:50:ef:5c:f7:eb:01:b8:a9:28:2e:2f:42:fb:2e:ba:9e:
+         cd:74:a1:1b:dd:e6:72:6d:ef:1a:8d:49:28:6d:9a:b1:8e:e1:
+         7e:6c:6d:5f:ab:26:23:25:71:3f:0f:4a:54:a9:10:7c:46:c2:
+         ba:51:b1:45:82:c9:43:e7:80:af:ba:51:76:9e:2e:e1:6a:01:
+         5f:7c:4a:40:ae:36:41:c0:da:fa:f7:61:ea:39:63:d0:c7:d1:
+         df:82:ef:ca:a7:b3:3e:4b:36:eb:e3:e2:d6:53:71:1f:6d:1a:
+         c9:40:b7:f9:eb:d4:5d:dd:d3:39:bb:a6:d9:db:f8:8a:f9:66:
+         21:e2:c2:44:bf:6d:a1:94:68:d0:5c:5a:76:f1:19:61:78:b5:
+         2c:0c:37:dd:c8:43:48:dd:07:27:88:e6:ac:5b:c3:a1:02:5c:
+         0f:1d:76:b4:47:59:d0:6c:72:9a:bc:b3:01:a6:f1:0b:9d:86:
+         64:6f:d0:9b
 -----BEGIN CERTIFICATE-----
 MIIEpzCCA4+gAwIBAgINC6cpgMeiJFEHUCqQjTANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiMissingMandatoryCert14.pem
+++ b/v2/testdata/QcStmtEtsiMissingMandatoryCert14.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0e:25:29:ab:ca:46:40:44:4a:9a:b2:4d:25
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:32 2018 GMT
+            Not After : Nov 21 03:21:32 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:a1:d8:53:fa:65:88:3e:f1:08:07:4e:ec:62:10:
+                    4a:ae:55:1f:e1:71:3e:7e:9c:d3:0f:0f:20:f6:37:
+                    a0:22:ec:f3:31:71:d5:1e:97:ea:3e:f2:78:4d:e7:
+                    64:8c:ed:53:60:9a:7f:dc:9a:80:2a:18:b7:ef:96:
+                    09:52:99:bb:4b:40:62:58:5b:76:d8:d8:fb:b6:7e:
+                    eb:ff:12:9b:28:9f:23:27:5e:1d:22:b7:03:3d:91:
+                    d9:6a:30:ff:a6:48:e1:0a:ed:75:d8:03:87:6e:10:
+                    a0:b1:0d:6b:f4:07:47:e8:34:e7:87:f0:dd:46:20:
+                    0c:6b:10:e0:56:3a:ee:1d:e0:de:81:4b:58:4a:46:
+                    7f:4e:18:28:9b:ee:b9:8d:fc:16:ba:b3:f1:08:23:
+                    65:de:dd:3b:e0:f8:ba:73:e9:83:41:a4:a8:8d:74:
+                    ed:57:6a:e0:33:5a:8b:5d:ae:b4:45:7a:04:a0:34:
+                    f6:a1:29:d9:86:84:59:75:d9:e8:40:1e:19:80:4d:
+                    91:95:29:87:63:f0:8c:5b:c0:52:9a:88:de:7d:e9:
+                    15:ee:29:b2:5c:5c:87:76:72:7f:39:0c:bc:97:2d:
+                    83:c5:e8:50:d8:5b:6b:3c:03:be:77:6e:92:c2:43:
+                    1c:00:8f:0d:44:3a:9c:c9:7c:9d:fc:74:86:7c:41:
+                    8a:57
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                82:FF:CD:E0:CD:30:08:4C:82:D8:6F:51:85:75:72:15:37:65:1D:C1
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0m0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         5d:42:89:ff:f7:2b:cf:2e:b7:dd:f8:15:39:11:37:98:b9:43:
+         7d:07:af:bb:70:e3:7c:64:93:4d:5b:0b:1b:4d:f4:ee:bb:d5:
+         18:4b:e2:c3:b9:fc:05:14:0e:56:92:74:8f:fe:1b:b9:bd:80:
+         31:f3:be:84:42:ea:1a:e2:b1:b9:cc:5a:c6:7b:ec:2c:fe:2d:
+         21:e8:99:12:8d:5b:74:4e:bd:17:c1:29:e0:1f:0a:e6:14:95:
+         ba:b1:bf:c4:9e:25:59:94:e0:db:27:94:da:b7:c9:91:e8:b3:
+         81:5c:3e:4e:2b:ad:04:d9:6f:14:2b:ef:6e:67:98:13:94:6c:
+         fd:fc:7a:95:f5:b6:98:4c:a3:ed:2b:fa:d8:95:bf:0d:fd:e5:
+         46:f8:50:5f:9b:c6:01:6d:6a:5a:21:be:c0:db:2e:62:d6:12:
+         86:7d:97:e8:1b:de:47:7d:6f:ec:33:82:06:b8:8a:2c:d8:d7:
+         b6:74:01:67:1f:00:04:21:77:e5:10:d3:07:0d:61:10:40:fc:
+         dc:10:da:8e:a6:a4:fe:97:37:f6:e4:cf:fa:a7:3a:9b:11:84:
+         3a:b4:12:72:65:31:53:94:94:e6:ca:0b:94:1e:1f:3c:9c:97:
+         80:b1:00:fd:d4:c8:77:ac:8f:07:b1:ff:e5:24:66:aa:b7:c5:
+         f9:2c:98:ba
 -----BEGIN CERTIFICATE-----
 MIIEwzCCA6ugAwIBAgINDiUpq8pGQERKmrJNJTANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiMissingOidCert09.pem
+++ b/v2/testdata/QcStmtEtsiMissingOidCert09.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            6e:58:90:9b:f3:bd:dd:00:5c:68:e7:9f
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:30 2018 GMT
+            Not After : Nov 21 03:21:30 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:a8:65:13:8e:1a:3c:01:42:e3:ed:36:e7:3c:14:
+                    84:97:a2:b1:ae:4c:ee:37:6d:82:2a:4d:cd:7d:6a:
+                    b2:77:ba:68:69:c4:51:73:3e:24:21:4c:eb:8e:1d:
+                    13:6b:cf:ee:e9:a5:a9:dd:01:1b:54:36:46:7c:68:
+                    27:37:ad:00:a4:88:cc:ba:c3:8c:20:93:27:97:ac:
+                    22:22:12:e2:d4:90:c0:14:43:0b:14:b4:ec:b2:2e:
+                    69:74:bb:b0:b5:66:fd:15:93:f7:a3:21:7e:9f:af:
+                    01:da:c1:33:b2:a6:da:45:5d:06:97:e1:97:d2:91:
+                    94:ef:2b:31:80:c6:6c:fb:25:ca:c6:ee:af:c8:04:
+                    7f:62:0f:3c:cd:7b:b1:d2:60:e3:8d:d5:b6:ad:b9:
+                    86:87:ac:10:42:64:99:e0:8b:65:57:54:a7:db:61:
+                    87:d4:f3:f8:bd:c8:9f:ec:c9:ab:44:d5:72:42:30:
+                    0d:6e:6e:8f:71:12:0f:71:82:20:6d:c3:4b:59:03:
+                    98:71:c5:26:b1:72:56:70:31:17:55:10:20:e2:c6:
+                    e7:d6:d1:6e:67:f0:80:de:19:db:34:32:18:c0:c6:
+                    be:54:90:e0:f9:43:96:17:f8:02:f0:99:fc:f9:ea:
+                    40:cd:7d:0c:83:b7:14:7c:fc:48:77:18:cd:d7:da:
+                    d8:7d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                DB:F3:30:0B:18:1A:94:B6:3D:45:E6:CA:EC:A1:13:82:DC:10:B6:91
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0l0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..
+    Signature Algorithm: sha256WithRSAEncryption
+         5b:31:31:f6:ea:9e:45:25:c7:e5:93:90:43:e3:9c:17:b4:46:
+         48:5f:4c:53:69:a3:ba:c9:ef:77:24:ee:55:d9:f1:10:a6:6e:
+         87:63:80:45:d4:e6:58:ee:06:de:64:67:b6:df:c1:a6:9c:4e:
+         4e:30:22:da:0f:9d:33:45:fd:75:36:f0:2e:5c:cb:6b:b1:1d:
+         bd:29:ec:66:0a:ea:d8:4c:57:f0:d4:5a:7d:73:c9:e9:75:79:
+         67:40:7c:c7:39:cc:e1:50:25:76:a1:72:e0:2e:a8:ee:18:85:
+         90:3e:97:3f:7e:e2:1a:ec:5f:98:0a:96:99:fd:24:f2:42:ed:
+         f3:c0:2d:d9:ae:52:42:bb:29:61:ad:46:30:74:63:8e:77:ef:
+         68:5e:cc:80:da:4b:b2:ca:25:de:85:8f:e5:37:d0:c2:20:d9:
+         78:d4:d5:5d:35:fc:e0:5f:a3:0d:3b:b9:2a:60:a1:0a:34:4c:
+         39:90:94:43:16:45:28:69:c4:f4:52:3d:30:ef:59:57:9a:ea:
+         81:8c:1f:99:80:f0:ef:d5:75:c3:dc:1e:c5:5e:0b:2f:66:96:
+         3c:b7:39:f7:e8:94:10:75:44:ce:25:96:b7:e9:b7:81:e7:f3:
+         9f:2c:2c:ee:e9:2c:4c:e5:3b:52:b1:0d:88:c6:ac:de:b6:ef:
+         a9:d8:3f:d8
 -----BEGIN CERTIFICATE-----
 MIIEwTCCA6mgAwIBAgIMbliQm/O93QBcaOefMA0GCSqGSIb3DQEBCwUAMEAxFDAS
 BgNVBAMMC0xpbnQgU3ViLUNBMQ0wCwYDVQQLDARUZXN0MQwwCgYDVQQKDANNVEcx

--- a/v2/testdata/QcStmtEtsiMissingPDSCert16.pem
+++ b/v2/testdata/QcStmtEtsiMissingPDSCert16.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            04:5e:59:81:f4:6c:54:e6:d0:07:64:3f:83
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:32 2018 GMT
+            Not After : Nov 21 03:21:32 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:99:3d:f7:35:79:33:2b:77:56:27:2e:24:b6:2d:
+                    ec:0d:04:b2:de:07:5c:07:c3:9c:4d:63:0a:4f:9a:
+                    6e:1c:a7:b0:1d:78:f7:38:6f:78:74:ff:f1:de:a8:
+                    75:22:af:a3:43:70:a5:fe:c2:ce:e1:61:75:a9:f3:
+                    63:d6:d7:9e:fc:f3:61:bc:90:dd:67:c1:47:27:50:
+                    8d:0d:17:b4:89:c2:2d:84:f6:71:11:f6:7f:a5:13:
+                    2c:bb:ab:63:27:4a:d1:a6:fb:80:a4:4d:50:4b:50:
+                    34:c1:cc:80:25:c9:cb:a7:4e:8d:81:d9:07:04:a5:
+                    7d:16:f9:9a:55:ac:b6:f3:d4:38:fc:99:34:01:b7:
+                    16:a1:a6:62:2f:d7:3f:3b:e2:24:7c:1e:73:bf:59:
+                    2d:51:b8:69:3c:fc:9d:d3:3b:1a:98:cc:4d:79:3e:
+                    98:67:df:51:66:54:77:b3:e1:a3:75:3a:57:11:65:
+                    cf:6c:c5:71:9c:ca:58:43:ea:68:48:c4:56:aa:ed:
+                    e0:f9:6d:d7:f9:f7:e0:34:9a:44:18:3a:16:2a:8d:
+                    b1:78:d6:8a:ab:aa:93:55:35:68:bf:1f:94:20:bd:
+                    1b:03:bc:e1:df:29:fc:7b:aa:c2:1b:55:1c:08:5f:
+                    88:4c:b8:2c:51:1d:c8:c0:45:6d:c3:c5:1f:db:bc:
+                    f9:3b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                3C:66:67:01:57:A1:DC:46:8C:3D:42:6D:23:94:B5:6E:FF:AD:93:1F
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0.0......F..0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         72:79:f7:87:ff:b3:4b:fd:27:9b:1d:24:37:77:3c:75:c9:e7:
+         bf:8e:f9:ed:7a:66:92:40:98:91:d5:99:a2:5a:f8:a6:28:1a:
+         71:44:88:9a:7c:3c:cb:c3:d4:13:6e:05:18:d5:b6:0f:6d:82:
+         84:04:67:2d:4d:b2:54:de:fd:46:3e:2f:1e:e8:3b:22:1e:e4:
+         72:66:67:82:f7:3b:07:25:bb:b8:2d:61:b3:e7:21:0e:f0:f6:
+         1f:b5:e3:2a:88:32:bc:30:db:a9:20:20:91:6c:4d:28:d0:92:
+         0b:3f:b3:69:9f:e5:6c:24:e6:41:ed:a4:3a:75:0d:92:1b:e4:
+         5c:eb:17:9b:e8:ea:d4:af:61:22:08:95:24:df:30:35:99:15:
+         48:29:5b:c8:da:d5:c5:c4:b7:18:74:eb:b6:a7:63:f5:c0:60:
+         3d:ff:d1:7b:a8:7f:c4:7b:2d:c4:5f:b7:0d:60:8c:4c:4e:92:
+         ec:93:3a:25:46:77:3f:b1:63:e7:2b:17:d8:dc:44:dc:72:ff:
+         da:40:9d:3f:f0:98:69:19:d9:26:e7:73:5e:f9:34:e7:5e:3c:
+         bb:d3:98:50:f8:9d:56:b5:d1:d8:39:15:71:70:a4:3e:00:a1:
+         20:2a:3c:62:24:97:c9:6e:82:25:d3:9d:d7:13:bd:6a:e8:a2:
+         97:71:ba:8f
 -----BEGIN CERTIFICATE-----
 MIIEdTCCA12gAwIBAgINBF5ZgfRsVObQB2Q/gzANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiMissingSeqForQcTypesCert18.pem
+++ b/v2/testdata/QcStmtEtsiMissingSeqForQcTypesCert18.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0e:92:ba:23:65:f0:cf:cd:2d:9b:31:f8:a3
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:33 2018 GMT
+            Not After : Nov 21 03:21:33 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:9d:7e:3d:42:8d:18:fc:05:c6:65:d8:7a:45:2c:
+                    7a:25:a6:7c:83:cb:21:f8:d3:fd:42:41:24:81:53:
+                    eb:59:48:d8:f8:9f:6e:ec:d0:e9:1f:b9:b9:8d:15:
+                    59:96:50:46:ee:27:d9:96:af:6a:4b:c1:f3:89:a2:
+                    93:be:51:ec:71:14:49:47:ce:9e:86:da:7c:a4:5b:
+                    c1:cd:e3:5d:ad:56:6a:4b:4b:04:be:87:37:71:b8:
+                    f7:e3:01:6d:4f:82:3b:d9:53:cf:2d:7a:58:0b:48:
+                    32:50:7f:25:c1:06:e4:d0:7f:0b:0b:cc:64:18:f3:
+                    fb:98:71:74:c3:33:db:94:92:4a:96:b4:bc:5c:15:
+                    32:82:8d:af:ce:81:ed:37:f1:39:0a:26:4c:f2:4f:
+                    30:23:8b:73:b2:6a:6f:eb:67:8c:5b:36:73:09:04:
+                    19:fa:82:62:8f:0b:ae:5d:cf:11:9a:6c:13:07:43:
+                    b2:e2:62:56:fa:ef:c6:fa:e4:5f:7a:e9:ba:f6:55:
+                    0e:22:d0:6c:71:7d:92:39:67:00:40:f8:49:64:41:
+                    41:7e:0e:b8:cf:40:cb:6d:61:2d:6d:c1:d7:b2:86:
+                    d6:da:dd:98:ed:c7:7f:20:82:a3:03:a7:35:ef:72:
+                    f2:96:fe:26:18:35:76:86:af:db:c6:23:26:fb:d9:
+                    7c:7d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                93:C7:34:F9:C0:AF:BC:EB:FE:90:C9:3E:74:4A:13:36:E0:40:AD:A2
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0u0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F.......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         2c:47:d5:a1:02:08:59:b5:91:6e:bb:e4:c3:24:67:cb:e9:39:
+         81:31:93:8a:74:e1:ec:6c:1e:c7:d4:27:61:99:59:08:19:d8:
+         21:66:9f:0c:4d:2d:2b:a0:cf:1d:02:98:f1:4c:8f:fa:29:b3:
+         45:b5:76:1c:f6:de:48:f3:ac:e6:c1:6f:e7:18:f0:95:56:0a:
+         ab:f9:f7:28:83:ed:a6:f7:f5:04:13:16:2f:7d:51:02:4f:c5:
+         71:80:b9:45:85:1e:92:28:05:75:f0:94:d9:01:c1:b4:9d:c1:
+         3f:c2:42:cc:bc:71:1e:66:04:22:3b:f2:5b:7b:12:07:ee:98:
+         bd:20:d8:18:5b:c2:cf:6e:a5:0f:1b:74:bc:c5:d4:f4:c8:3f:
+         b4:44:26:b0:9e:7c:e2:cf:77:50:65:5e:38:c2:7a:8e:39:d8:
+         5b:5e:73:31:71:83:29:e0:c8:f2:11:5d:83:e9:12:fb:83:d1:
+         ec:ae:ed:2d:f8:be:50:ff:af:fa:f1:e1:71:ba:5a:64:ce:1f:
+         d9:ed:8c:a0:29:ce:1b:61:3e:e7:24:29:d1:c6:a3:13:d4:b9:
+         c2:6c:84:66:be:32:ed:e8:b2:e3:94:47:9c:3a:b7:c1:da:f3:
+         ad:28:19:14:ae:dc:b7:2c:7f:a9:c1:b9:16:cd:46:a0:ea:11:
+         20:64:11:eb
 -----BEGIN CERTIFICATE-----
 MIIEzDCCA7SgAwIBAgINDpK6I2Xwz80tmzH4ozANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiNoQcStatmentsCert22.pem
+++ b/v2/testdata/QcStmtEtsiNoQcStatmentsCert22.pem
@@ -1,3 +1,74 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            04:ea:44:0d:3b:51:aa:72:75:84:67:7b:d9
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:34 2018 GMT
+            Not After : Nov 21 03:21:34 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:81:17:44:61:72:a2:06:83:4e:a4:7d:01:2b:51:
+                    61:ec:ef:40:8f:0b:59:cc:99:20:27:9f:a3:5c:27:
+                    ec:73:02:4c:8d:3a:25:3f:17:b6:5c:e9:f0:aa:3c:
+                    ac:ae:c7:d9:7b:c8:8c:c8:55:9e:e0:10:d7:3d:24:
+                    72:4c:8b:e9:9e:f4:8a:19:76:c0:3a:5e:e5:12:d2:
+                    cd:cf:45:88:8d:ef:c4:97:a8:7f:13:0e:3c:7d:01:
+                    2a:05:0d:5a:e0:50:09:96:3a:c6:c6:45:cc:dd:a7:
+                    60:fc:fb:91:de:de:1c:d4:26:7e:7d:6a:f8:1e:94:
+                    1b:1f:e9:fd:14:7b:08:fc:4b:db:2b:75:64:c7:ad:
+                    63:c5:65:25:64:b8:cb:ee:7a:a5:63:96:5b:2a:03:
+                    cc:a2:a9:0a:31:c5:9a:56:a8:0f:be:c8:d7:ae:a1:
+                    39:d9:2f:59:21:cf:d8:86:06:c0:1b:08:8e:8d:c1:
+                    08:43:ca:d5:c5:3f:5c:ab:fa:51:a2:83:1b:17:71:
+                    08:e5:a4:ec:44:0a:e7:9e:ec:43:64:42:44:1d:81:
+                    50:8d:36:07:da:3a:57:94:b0:2f:33:21:3a:f4:b9:
+                    77:31:dc:19:b4:18:50:c3:e1:87:a1:80:a6:1c:66:
+                    7b:d6:e3:ac:ee:58:7e:9b:e7:a0:16:a2:0a:8c:6f:
+                    57:ff
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                9F:97:0A:A1:7D:D5:B3:07:3A:F4:71:C7:CF:1C:DC:09:B4:2A:41:FA
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+    Signature Algorithm: sha256WithRSAEncryption
+         37:96:32:9d:81:e0:1f:c4:e0:cc:dc:6d:19:a6:3d:84:aa:3e:
+         c3:bf:22:d8:4d:1c:14:2d:68:06:c1:b9:08:6d:c0:63:12:5d:
+         ee:67:8a:cb:8c:cf:b7:22:f8:42:1e:7b:2b:3a:38:f3:4e:eb:
+         e2:14:08:05:8d:01:2e:cb:11:1b:21:c7:7f:ce:9a:5f:f3:8c:
+         84:53:98:5f:6f:73:30:37:38:28:8d:5f:8a:b5:fe:f9:c4:9f:
+         20:db:37:a9:6f:6d:7d:d6:3c:c0:4d:da:e9:7a:12:75:70:64:
+         fd:2e:22:2b:51:93:a3:ba:f4:1d:32:73:77:c0:44:b2:b1:11:
+         64:18:95:3c:6f:f1:fa:8c:2e:8b:d2:b9:72:23:e2:5d:12:4d:
+         14:b6:5b:86:35:c5:23:6f:e2:c1:68:b5:7c:51:a6:68:91:b8:
+         56:39:11:88:fa:95:41:d9:d4:a8:7d:be:70:a4:62:0b:92:a8:
+         63:65:0c:78:70:25:cd:91:68:1c:94:da:04:eb:c1:36:50:7d:
+         6c:01:fa:4a:12:86:da:40:35:37:75:15:da:26:35:2a:df:8c:
+         d1:7f:81:5b:4b:01:a7:41:88:dc:45:c1:5b:d8:91:07:46:98:
+         3e:a7:88:0d:5d:b9:57:3b:a8:7c:69:fb:3e:b8:95:52:d1:56:
+         98:46:62:df
 -----BEGIN CERTIFICATE-----
 MIIERjCCAy6gAwIBAgINBOpEDTtRqnJ1hGd72TANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiNumberInLangCodeCert21.pem
+++ b/v2/testdata/QcStmtEtsiNumberInLangCodeCert21.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            09:68:4b:c8:c3:e3:6a:6e:4c:19:16:9a:70
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:33 2018 GMT
+            Not After : Nov 21 03:21:33 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:b9:2b:a6:b1:95:81:d6:86:3e:f3:b4:8a:49:f1:
+                    4b:ad:af:ba:f1:5f:87:a0:ff:ec:84:f0:f3:62:90:
+                    52:2d:1e:4e:a7:a7:a8:08:2d:ea:34:2e:5c:62:e7:
+                    72:6f:1b:e5:87:8f:85:79:31:be:c3:c2:11:2c:44:
+                    8a:20:2f:ca:fb:53:19:78:69:c9:18:3a:cc:49:1c:
+                    18:e0:e1:67:af:c1:45:1b:f0:70:ce:9c:cd:76:c1:
+                    d1:0a:c1:9e:c1:4c:5c:4b:d0:b4:3c:c3:ad:20:3a:
+                    7b:c2:da:eb:d8:d4:8b:93:b0:46:34:44:08:21:68:
+                    28:3e:5e:c9:ba:96:f8:9e:01:53:30:b6:4d:34:47:
+                    c1:9c:80:df:ce:e0:72:a9:56:4b:6b:a4:de:30:2b:
+                    fd:97:33:c8:b9:7f:b2:c7:54:c7:88:4c:f4:52:9c:
+                    cd:a1:b2:bd:f1:f4:5c:4d:04:82:af:e9:6b:6d:d3:
+                    0e:ed:a9:37:63:da:6b:54:f3:96:67:b1:b9:78:c1:
+                    57:9f:53:17:c2:91:1b:5f:7e:ee:16:4d:8b:2a:fc:
+                    d5:f8:88:56:ef:01:78:fd:fe:4f:1b:7d:e0:57:b4:
+                    5a:78:e4:e7:cc:93:03:e2:b9:94:ed:38:c7:2e:cd:
+                    e2:e8:15:29:4a:5d:9e:3f:c0:7c:5b:4b:02:fc:b0:
+                    df:17
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                AD:FB:9F:0F:3F:1B:CD:9D:8A:5B:13:92:B4:4A:F0:26:DE:3E:00:04
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0w0......F..0V.....F..0L0$..http://example.com/en/test.pdf..n30$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         25:8f:76:e6:21:9e:03:8c:6b:8b:08:9b:b8:00:78:d8:d1:96:
+         50:2e:ef:20:2e:d2:64:c8:21:36:b3:f7:3e:84:36:da:52:a1:
+         2f:f3:4f:83:83:a7:bd:a4:80:32:55:40:4b:5f:f1:6a:de:cf:
+         fe:03:a9:3f:27:e1:6a:45:6c:1c:c4:0a:d5:f3:1f:d9:99:23:
+         4f:80:91:e6:97:90:3c:22:0f:c4:c7:08:e1:53:8c:7e:55:91:
+         3d:5d:e4:d2:57:49:f5:e9:36:a9:02:80:cd:f2:9b:42:06:e6:
+         66:6c:38:f7:ed:02:2c:ea:e6:c9:9b:a0:4f:07:62:45:b2:5e:
+         ef:81:d8:f2:87:b3:b7:ed:60:63:6c:8f:5d:e3:95:37:59:4e:
+         da:05:7b:37:10:32:70:fe:aa:14:22:cc:d9:9f:b4:0e:93:3b:
+         fc:52:e8:1b:e5:ea:93:f9:aa:b8:82:f4:14:f0:11:ab:95:45:
+         d7:77:7a:2a:5d:6a:0e:03:91:1d:3c:07:9f:f4:7c:21:30:44:
+         22:c1:78:33:bc:3b:f7:8e:b2:90:41:06:fe:4c:14:eb:d2:3e:
+         73:41:2e:93:ce:de:1e:77:ca:d3:27:a9:44:7d:27:8a:16:94:
+         e6:66:ac:15:3c:9e:33:fa:6f:bd:eb:00:41:73:fc:a2:2f:ad:
+         27:80:84:4b
 -----BEGIN CERTIFICATE-----
 MIIEzjCCA7agAwIBAgINCWhLyMPjam5MGRaacDANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiQcComplWithNonEmptyStmtInfoCert19.pem
+++ b/v2/testdata/QcStmtEtsiQcComplWithNonEmptyStmtInfoCert19.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            08:78:3d:db:ab:92:a9:da:7f:21:f8:b5:c9
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:33 2018 GMT
+            Not After : Nov 21 03:21:33 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:a4:67:f9:93:03:19:6c:da:4d:4b:0c:d3:9b:e8:
+                    43:19:d9:f0:fc:b1:65:52:9f:87:41:90:42:36:40:
+                    b2:61:f0:ca:0a:10:d2:be:f6:8a:76:59:85:f7:2a:
+                    c1:9b:75:c3:f5:81:78:7e:05:bf:1f:f1:3b:40:55:
+                    c8:c6:02:e8:5f:9d:3f:cd:09:0e:58:61:ee:31:f0:
+                    e8:91:b2:dc:a9:9c:62:15:2d:73:57:53:57:2f:44:
+                    74:7b:bb:bc:36:f5:e6:22:bc:85:ac:54:0e:9a:d3:
+                    22:f6:b1:7a:74:1b:19:54:2a:d3:ff:25:b4:6a:be:
+                    bd:77:94:52:de:e8:95:14:8b:f2:44:b4:97:8c:fa:
+                    7c:8a:47:51:0c:c1:8b:28:ed:9b:ad:92:d0:9b:80:
+                    12:f4:4d:ca:23:4b:e4:85:40:2b:63:41:39:23:35:
+                    72:03:a6:0b:75:77:3e:0b:24:52:d5:4e:52:d8:84:
+                    e2:b2:26:f0:ec:c9:40:ff:4a:a2:92:75:e5:62:70:
+                    a8:f6:8b:c1:1e:f1:59:e6:13:2d:2f:32:0c:26:79:
+                    9e:08:bc:14:01:da:d4:74:e4:41:0c:d3:cc:56:1a:
+                    0a:6b:2a:44:2a:43:79:48:1c:3c:c2:0e:8d:0f:f2:
+                    a3:6f:37:67:01:a1:67:b2:d0:ba:6e:4d:53:4e:22:
+                    ea:d5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                6C:ED:36:B9:B2:01:77:DC:12:4A:93:DA:90:9C:66:E1:20:C5:13:AC
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0.0......F.......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         6b:a1:1a:50:64:2b:e2:e4:11:d0:81:dc:f3:96:db:75:09:4b:
+         30:23:df:9d:f8:b3:4d:ef:4c:a5:75:0f:71:13:02:4d:73:57:
+         cb:49:13:bc:52:fc:e2:0b:8a:6c:99:e7:0e:89:79:42:40:6e:
+         68:bb:c9:bf:f2:18:97:7f:eb:de:fa:53:3e:ec:6b:1d:2e:46:
+         c1:0b:cd:b6:8f:02:3f:0f:d2:de:e5:09:e2:52:a4:6e:e1:e1:
+         c8:69:3f:98:f8:94:27:5a:c0:0f:37:c4:2c:d5:94:24:d7:62:
+         ca:19:da:45:0b:f0:42:12:14:70:ab:1f:2e:69:78:80:65:ef:
+         d2:bc:13:7a:4f:28:fa:e4:7b:b9:af:a9:91:24:a4:88:ab:3d:
+         fb:96:e7:fb:93:20:bd:cd:bd:e5:5a:5f:83:ab:ac:05:79:f7:
+         bc:de:20:82:0c:66:4b:6b:f5:33:76:7a:b6:50:d4:d5:55:a8:
+         1a:62:85:25:ec:ff:54:de:87:fe:42:8d:aa:5a:24:a2:26:44:
+         9f:d6:82:bd:c9:68:09:cb:d6:87:1b:e5:d1:2e:4c:a5:ea:22:
+         f4:80:a7:aa:60:1b:0c:ad:5e:1c:86:49:78:2c:f9:0d:74:7f:
+         ce:a1:20:77:0b:98:6f:65:66:31:82:74:39:3d:46:29:b7:6a:
+         8d:8c:93:f6
 -----BEGIN CERTIFICATE-----
 MIIE1zCCA7+gAwIBAgINCHg926uSqdp/Ifi1yTANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiQcTypeAsQcStmtCert10.pem
+++ b/v2/testdata/QcStmtEtsiQcTypeAsQcStmtCert10.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            08:7f:28:a7:36:ab:27:3a:c3:8f:96:43:2e
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:30 2018 GMT
+            Not After : Nov 21 03:21:30 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:ab:22:d5:29:63:de:f9:76:0a:2b:79:43:44:06:
+                    1f:59:11:50:03:52:78:5c:cc:d4:31:37:4c:0b:ab:
+                    1c:d0:11:b8:e2:80:96:03:c1:5d:8a:69:53:c0:d4:
+                    40:04:8d:60:dd:c2:a1:e3:1f:15:f4:24:d3:59:85:
+                    c0:67:18:64:d1:71:0a:c5:7a:1a:4e:54:e3:18:86:
+                    74:29:a1:94:ec:21:be:27:8b:98:44:74:8b:40:84:
+                    4c:ed:d2:81:84:f4:e6:07:24:67:e7:a4:02:b2:82:
+                    75:b3:34:42:2e:bb:e2:c2:d8:65:89:e5:da:0b:00:
+                    f9:30:1a:96:02:cc:8a:bc:9c:d9:54:0a:b9:a2:76:
+                    ce:88:3c:87:7a:01:5d:34:09:cd:bd:02:bb:4e:d1:
+                    96:9c:15:4a:74:41:50:b6:86:6d:5f:1d:3f:4c:c2:
+                    2a:3a:0e:39:bb:a5:75:69:e0:95:71:a7:ec:ce:84:
+                    5f:9f:08:33:e3:d5:ea:04:12:3f:4e:1c:6b:05:5a:
+                    ed:f2:65:fc:bd:d7:80:72:23:1a:1d:ca:52:f6:1b:
+                    7a:75:51:0a:4b:69:a1:95:f4:c9:dc:1a:e6:7a:a9:
+                    0e:e4:d2:ed:39:43:20:08:ce:23:86:9b:3e:4c:8f:
+                    66:6c:88:5e:c8:19:09:9a:00:12:11:e6:6a:51:5d:
+                    49:a1
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                A7:C6:14:07:3C:47:2F:B9:B9:CC:CF:17:74:5A:A3:23:15:56:A4:9D
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0m0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         32:c2:20:06:2a:33:2c:0f:97:e2:cc:e7:dc:53:1f:43:05:31:
+         d2:d4:9c:72:e9:78:7f:76:cc:b2:c0:be:2e:85:dd:f4:d3:42:
+         7a:dd:b8:d2:d3:f0:57:39:98:86:af:79:65:12:fd:48:fe:c4:
+         ba:71:01:b8:04:fb:f9:2e:20:a6:27:94:be:3b:46:44:87:46:
+         89:4e:02:41:01:99:a0:58:f8:cf:70:3f:94:a4:39:54:77:62:
+         ee:17:3f:27:52:cf:ed:06:68:cd:c5:a1:2a:ef:ae:8a:97:4b:
+         2a:5d:81:f4:18:0f:38:76:0a:14:fc:4b:2a:a2:67:a7:39:ef:
+         90:36:e4:23:65:1c:eb:8c:de:27:5a:23:17:40:b7:12:4e:b9:
+         91:db:2a:8e:e1:8a:ee:63:fc:07:c1:b2:45:1f:aa:bb:8f:48:
+         6b:c9:e1:06:2d:c7:44:b5:cf:52:a6:cb:7f:d8:ef:e4:60:54:
+         69:ec:eb:96:86:be:a3:93:8c:15:ca:db:dd:aa:47:a9:02:ad:
+         2a:f4:fa:a1:83:3a:3b:43:d2:96:bc:12:b0:db:e2:dc:b7:15:
+         fd:01:56:14:5e:3a:0c:7a:62:02:9b:87:f3:b3:30:c6:3d:52:
+         b2:fb:80:00:5c:50:6e:99:ed:12:c9:56:b4:e4:14:96:d5:83:
+         8e:b5:e3:e0
 -----BEGIN CERTIFICATE-----
 MIIEwzCCA6ugAwIBAgINCH8opzarJzrDj5ZDLjANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiTaggedValueCert20.pem
+++ b/v2/testdata/QcStmtEtsiTaggedValueCert20.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0e:48:53:dc:1f:ac:d7:db:f0:bc:da:45:12
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:33 2018 GMT
+            Not After : Nov 21 03:21:33 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:95:21:db:46:5a:0f:c7:d4:f8:20:b6:44:33:b8:
+                    96:2a:16:56:28:ee:b4:41:f0:3b:26:32:f8:ec:5e:
+                    23:80:be:b9:a2:a1:65:c8:4a:c3:07:d5:39:82:80:
+                    40:0b:a2:2b:aa:0e:6a:54:2a:6e:2e:56:8f:4d:e5:
+                    cd:dd:d7:57:8d:38:c9:58:b2:ef:6c:ee:54:c1:59:
+                    e6:a6:46:c1:fc:0d:19:31:68:cb:3f:92:c4:72:31:
+                    32:1f:4f:02:5e:fa:60:d5:0b:06:86:ab:be:fb:7c:
+                    6a:1d:18:ec:a1:73:ab:56:d2:3a:21:d2:33:19:de:
+                    79:21:25:e7:d7:d3:c0:c4:1c:1a:70:21:6f:5f:1a:
+                    e0:a9:c1:72:b4:91:d8:f9:b4:ea:67:fd:39:9e:58:
+                    8e:3a:1e:8b:69:5a:36:6a:78:e4:36:08:fa:d5:3e:
+                    84:f6:f5:94:e0:33:59:bc:fc:e6:e6:38:4c:27:a0:
+                    47:a2:09:00:33:d7:45:b6:79:ba:40:0c:09:48:aa:
+                    b5:be:47:10:7f:f1:78:1a:63:40:f5:f1:8d:57:7f:
+                    f5:34:7e:42:d1:0d:05:77:9e:3e:31:0c:51:9b:9e:
+                    fb:54:ad:a0:ca:f6:16:e7:01:ae:99:c3:59:55:32:
+                    24:f7:91:df:1a:00:7e:50:86:d3:e4:cf:27:8f:c8:
+                    40:95
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                55:F9:9A:11:F8:2D:A8:F3:73:83:B7:1D:03:BB:C4:43:10:B1:2D:90
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0w0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         4e:27:fe:10:d2:79:70:f4:bf:96:fd:76:f2:df:e3:7e:f1:d7:
+         23:f2:36:0d:e4:56:b6:b1:80:7d:6d:1f:f3:b4:e3:9a:f9:ca:
+         74:b6:6c:45:9c:49:c7:2d:3d:ba:1d:7c:99:e4:8b:f4:b6:24:
+         74:50:fa:29:85:fd:e1:ca:6d:cb:7f:b1:d7:49:12:69:b1:d0:
+         c3:91:1f:c4:fe:53:b1:96:55:f6:23:de:0a:d9:f1:bc:d1:ab:
+         8c:a5:1d:4f:ac:ab:39:05:7f:c3:9e:be:8e:31:d3:eb:0c:95:
+         6b:a5:48:f0:7a:51:46:3d:04:74:a9:5a:8f:3e:dd:95:74:68:
+         c6:d1:a9:34:99:34:c7:ab:eb:ba:c0:d5:8a:86:7a:4c:31:ce:
+         a4:c6:6c:aa:8f:be:d3:cc:43:25:ec:8f:94:55:d3:a0:96:51:
+         0a:c3:26:f9:6e:a6:73:f8:92:fd:ba:25:e9:a2:a6:25:74:cc:
+         e3:14:0f:6d:0b:ae:c4:62:36:5f:e2:03:ca:a4:be:bc:32:4a:
+         65:12:4a:6b:67:d6:8b:04:48:a7:e4:02:09:be:63:89:10:49:
+         3f:1c:2c:8a:99:2e:0b:dc:c8:f7:9b:15:11:a1:72:9d:97:ab:
+         6c:2c:e0:13:09:d9:dd:66:77:db:23:a4:52:a5:62:cc:66:0c:
+         c1:04:1d:6e
 -----BEGIN CERTIFICATE-----
 MIIEzjCCA7agAwIBAgINDkhT3B+s19vwvNpFEjANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiTwoEnglPdsCert12.pem
+++ b/v2/testdata/QcStmtEtsiTwoEnglPdsCert12.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0f:80:26:50:61:46:19:e4:0d:b7:97:a0:4e
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:31 2018 GMT
+            Not After : Nov 21 03:21:31 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:bc:6d:e2:cd:64:8f:fb:af:61:08:3f:1d:8b:ca:
+                    6b:be:e0:cf:38:aa:96:5a:5f:e1:08:08:1b:14:89:
+                    0e:5f:38:f7:28:93:ed:65:2f:2f:03:9e:7c:e2:b5:
+                    1f:f6:e3:8e:d9:68:d7:29:92:90:3e:43:c6:7a:46:
+                    e9:85:b3:55:e6:ea:b8:0f:65:aa:87:fc:56:f9:18:
+                    c7:4b:e8:bd:d5:e2:be:0b:f7:41:07:51:e2:80:fe:
+                    85:8a:3c:e3:19:59:dc:5e:91:5e:b2:43:d8:ac:b6:
+                    b5:1e:bb:13:57:67:f8:3e:0d:fa:55:9d:4b:0a:82:
+                    4f:c8:dc:37:4b:b4:4a:46:ac:2a:68:eb:a4:b4:7a:
+                    c2:09:f2:af:e3:d2:62:b5:b1:ea:1a:2c:18:74:e0:
+                    16:3d:ec:05:82:de:73:50:a1:91:3f:49:02:ee:ea:
+                    af:e3:fa:13:ae:a3:ed:ed:a9:2a:18:69:5d:42:7e:
+                    65:d3:c7:b7:5e:de:da:56:99:48:90:a0:34:7b:cf:
+                    6a:74:ca:b3:b4:ef:34:74:8e:e8:24:d7:14:cc:81:
+                    0a:77:03:45:5f:7d:b6:9b:38:bc:ef:56:5c:44:b0:
+                    a1:b4:6c:6b:5d:82:af:7b:5e:26:18:7a:ce:c8:c0:
+                    de:17:5a:ec:b2:06:dd:8f:d8:05:2b:6f:87:72:30:
+                    ad:4b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                3A:8F:8B:B7:F2:ED:CC:79:45:0F:D4:6B:F8:8C:1B:DF:85:D1:02:91
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0..0......F..0|.....F..0r0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0$..http://example.com/en/test.pdf..en0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         3c:ed:22:93:62:54:ed:b1:e6:5e:4b:71:e9:cd:77:96:c3:c4:
+         70:da:53:12:d5:38:27:05:1d:41:b2:4f:28:bf:a0:c7:70:45:
+         31:7f:c8:98:ca:9d:7d:f6:6a:fb:1d:4a:ba:62:1c:07:3b:c5:
+         36:e2:34:4e:a2:ef:1a:17:d8:28:0d:40:31:ba:93:1a:ba:96:
+         0c:52:24:48:c0:8b:30:62:ec:e4:99:8f:18:1d:c1:4b:f9:08:
+         d1:aa:50:f4:1e:4d:17:35:b4:e5:1f:1e:d8:0e:51:4e:67:13:
+         7d:a7:c7:33:17:24:86:30:e4:18:f9:d3:86:1d:eb:11:38:d1:
+         69:af:34:1d:2f:6b:26:42:3e:0c:49:b0:a3:8d:b0:dc:3b:50:
+         c5:c9:28:97:a8:90:06:ea:25:7a:7c:2f:4e:9b:94:7c:8e:4f:
+         e8:0c:aa:b0:26:6e:4f:07:74:cc:73:b2:20:1c:40:15:b9:e0:
+         9f:a3:81:f7:ea:31:ed:08:5c:02:03:9f:da:9b:2d:7d:1b:f4:
+         23:0e:76:aa:33:d1:fb:84:81:83:60:dc:89:b9:2d:61:c6:0b:
+         65:e4:90:12:ad:05:e3:e2:10:3d:61:5b:0f:b5:17:d2:54:0f:
+         be:76:0a:f4:18:d1:01:89:04:1c:da:82:68:94:dc:9b:9c:74:
+         cf:b7:5c:33
 -----BEGIN CERTIFICATE-----
 MIIE9jCCA96gAwIBAgIND4AmUGFGGeQNt5egTjANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiTwoLangCodesCert17.pem
+++ b/v2/testdata/QcStmtEtsiTwoLangCodesCert17.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0f:64:7d:bf:34:24:c4:3a:61:ea:9f:1a:92
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:33 2018 GMT
+            Not After : Nov 21 03:21:33 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:bd:8f:c8:75:d0:13:8c:2f:a7:ad:fa:fa:47:42:
+                    64:82:22:c8:33:5e:09:3a:3b:54:2c:90:3c:f4:00:
+                    85:5e:2c:c6:cb:bc:24:2c:77:63:eb:36:16:80:16:
+                    a4:11:31:e7:9b:e8:ee:d8:72:75:d1:77:09:99:84:
+                    f0:7b:ad:a5:47:1b:8b:9b:84:8d:8f:c3:05:33:df:
+                    ec:3c:bd:a0:8a:d5:20:5c:d0:5d:82:58:12:0e:48:
+                    ed:d7:c3:0d:a3:7b:20:e9:5e:05:e6:dd:37:14:44:
+                    1e:60:4d:0c:2b:c5:30:b3:79:58:72:9f:8c:88:4c:
+                    5c:a7:78:e4:2b:05:55:d9:e3:55:00:bc:3b:47:93:
+                    ce:e6:ee:86:6e:c7:03:87:fc:96:73:86:a0:23:71:
+                    04:00:9d:1d:4c:47:e4:5e:5e:a7:2e:30:25:0e:7d:
+                    4b:05:ef:b9:b8:98:10:13:0a:5a:03:51:ca:34:d7:
+                    9a:85:d1:91:36:cb:90:50:bc:ac:9d:4e:45:e6:19:
+                    fe:57:18:ad:44:de:5f:f9:3a:98:42:c2:b3:08:fb:
+                    fb:53:cb:f4:5c:d8:2b:d7:68:af:cc:bb:03:ed:9a:
+                    11:92:43:f2:90:7a:e4:4e:b8:40:1e:0a:32:85:dd:
+                    05:60:0b:3b:c0:b1:b7:85:31:4d:af:a9:6b:da:16:
+                    b5:35
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                04:36:41:A6:60:74:A0:70:8E:D6:03:D3:29:8F:CE:CB:92:28:BD:56
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0{0......F..0Z.....F..0P0(..http://example.com/en/test.pdf..en..gr0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         97:4b:6c:dd:47:78:d2:72:99:d1:b0:65:5b:8a:df:05:dc:94:
+         26:98:72:0f:69:0c:3b:86:4f:24:20:62:7b:0e:1d:ca:95:b1:
+         6d:8b:e5:07:6f:c6:f4:48:8d:7a:ec:bd:d4:5f:86:62:b1:7a:
+         f1:30:10:2b:48:47:e1:e2:49:06:88:fb:d8:e9:6e:7b:b4:fa:
+         cc:9a:7f:6b:b7:b8:45:0c:95:40:af:07:5f:33:e8:08:d7:b0:
+         ac:2c:63:17:64:b7:c8:72:8d:76:28:d0:72:6b:f9:b3:e0:57:
+         37:7b:15:f3:fb:61:b5:2b:31:32:81:99:ae:11:83:53:54:ff:
+         de:99:08:33:51:31:59:84:06:7d:7a:ca:90:fb:d6:d1:85:66:
+         6c:44:94:79:38:78:7b:2e:fd:38:33:73:9d:e3:a6:a0:9d:60:
+         57:cd:fc:cf:36:b3:95:ca:9e:a2:66:40:7f:c6:84:2d:a6:1e:
+         e8:c3:ac:fc:b2:48:5e:1e:50:8a:40:4d:68:44:45:12:6d:70:
+         ec:0d:e8:ec:1d:68:46:6c:65:51:b8:ac:ea:7e:0f:89:de:91:
+         c2:6d:ae:09:3a:1d:e2:70:1a:26:60:e2:5b:fa:ba:88:4f:08:
+         bb:d6:b7:0a:eb:c2:2f:8c:f0:17:4b:c7:5a:6c:9f:fa:d4:4c:
+         8b:e9:2a:db
 -----BEGIN CERTIFICATE-----
 MIIE0jCCA7qgAwIBAgIND2R9vzQkxDph6p8akjANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiTwoQcTypesCert15.pem
+++ b/v2/testdata/QcStmtEtsiTwoQcTypesCert15.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            04:16:88:35:d8:07:ce:d1:14:65:d3:46:d2
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:32 2018 GMT
+            Not After : Nov 21 03:21:32 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:8d:95:2c:33:d9:da:21:90:d1:3b:4e:bd:5c:fc:
+                    10:9b:35:d8:1c:02:d7:f7:9d:f1:4f:4f:21:74:ad:
+                    0d:a9:4b:8f:a9:27:5d:e5:0a:41:1e:5c:df:ff:60:
+                    8d:51:07:37:a5:f9:1d:c1:e4:32:cd:88:57:a7:90:
+                    09:bb:11:cf:94:94:eb:20:ad:0a:b2:1f:62:78:c9:
+                    bb:d1:7c:7c:5b:63:07:23:03:df:12:dd:4c:b6:ba:
+                    09:70:fb:04:fb:9b:38:55:d9:e8:6b:3f:bf:39:13:
+                    11:cb:b8:b7:dc:b8:03:5f:ff:f9:fb:62:63:dc:18:
+                    7c:7b:50:39:aa:7d:58:fd:3c:25:fb:e3:4c:54:52:
+                    49:53:bb:a3:8a:24:73:a3:51:58:2f:73:f5:2d:92:
+                    e9:da:24:47:7c:61:ba:0c:ee:cc:bb:28:cd:de:3c:
+                    5f:2f:5a:29:1c:86:c8:aa:11:3d:ff:55:ca:31:6f:
+                    3b:fb:6b:3a:97:46:c1:ca:22:93:d8:18:03:6d:0a:
+                    0a:d2:e1:a4:f8:57:41:16:f9:4f:db:50:32:72:23:
+                    37:1b:32:36:a2:fc:69:cb:3c:38:31:dc:16:94:ee:
+                    33:3a:96:11:68:cc:9a:16:1d:f4:95:f9:77:8e:e0:
+                    4f:5c:b3:b3:c0:7b:d7:eb:cb:21:16:85:54:9f:36:
+                    29:bd
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                7A:FD:90:65:F8:0C:FC:B7:13:61:3A:DE:55:31:E0:32:B5:3E:4B:AB
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0..0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..0......F........F...
+    Signature Algorithm: sha256WithRSAEncryption
+         a5:1e:6e:3d:12:c9:37:6c:76:5f:d4:11:cf:f5:59:0f:d1:1e:
+         08:a9:8c:84:89:7c:9d:86:2d:14:ad:cc:22:b9:38:70:49:f2:
+         12:bf:75:09:63:6c:85:b7:a5:3a:a7:41:34:a4:34:6e:00:a8:
+         2f:fc:ef:f4:fa:1a:7c:10:7b:e6:cd:aa:73:05:dc:19:ea:c8:
+         07:55:cb:0d:34:d0:0d:ae:61:d1:ab:9c:71:c1:61:29:6c:ae:
+         32:3f:09:a2:72:ba:0d:d4:77:a5:0e:4a:97:3f:db:56:13:36:
+         67:cc:9d:02:42:8f:e8:4f:d9:d5:d4:86:f4:e0:11:98:93:d3:
+         c0:e7:9d:0f:72:e0:5c:48:8f:d1:53:cc:af:03:b8:38:74:8d:
+         db:6b:b6:42:b1:66:e3:17:44:44:31:b7:34:46:08:3c:cd:67:
+         f5:d2:e2:61:16:4d:9d:90:29:c1:81:ab:89:3d:b2:35:b7:70:
+         7a:49:0a:ee:f3:f0:97:60:e6:6e:92:07:d9:a2:b2:a5:e0:86:
+         2f:dd:f9:f3:de:6e:89:c7:e9:4d:af:d9:87:c1:49:0c:9e:65:
+         41:0c:b7:8a:73:98:2a:1d:2c:38:48:04:c3:c1:ed:4d:4f:60:
+         81:69:a9:a0:42:0c:91:8a:de:07:09:a8:70:75:80:9a:56:29:
+         60:58:23:da
 -----BEGIN CERTIFICATE-----
 MIIE2TCCA8GgAwIBAgINBBaINdgHztEUZdNG0jANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiValidAddLangCert13.pem
+++ b/v2/testdata/QcStmtEtsiValidAddLangCert13.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            02:12:ec:a1:2d:d7:ce:30:e1:a5:33:41:f4
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:31 2018 GMT
+            Not After : Nov 21 03:21:31 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:90:df:66:25:e1:eb:f6:f5:ba:86:96:9b:39:12:
+                    38:74:95:e7:64:10:6e:2e:02:96:26:0e:da:aa:0f:
+                    11:31:d9:dd:ed:c0:3d:ce:25:67:94:57:3e:62:9b:
+                    c4:08:2f:e3:3c:2a:ee:64:f5:3b:24:cf:81:cc:e5:
+                    f2:3f:91:00:1a:bb:17:e4:75:fa:84:3a:0f:54:28:
+                    11:a3:5d:55:c7:78:85:36:be:33:ad:95:53:7d:82:
+                    28:23:d4:9b:54:c4:c9:9c:48:2d:7d:3e:f9:87:38:
+                    44:4c:29:14:fd:31:e5:a0:21:51:75:c3:44:e4:46:
+                    df:16:34:43:26:ef:4e:e9:02:a3:16:e8:f2:99:8a:
+                    c9:43:5d:ea:4f:b5:2e:5d:4b:6c:5a:20:64:b2:e7:
+                    c8:02:c7:dd:8f:e3:9d:2d:6a:c0:8e:ef:5f:87:d1:
+                    7d:86:98:a8:a3:78:83:ca:93:37:40:ce:57:6c:27:
+                    54:b0:56:fa:64:24:a5:cc:e5:0c:ac:0f:e7:a8:bf:
+                    04:14:1f:bb:94:a5:d8:32:f0:49:ec:bf:86:00:cb:
+                    38:20:66:62:58:ee:71:41:1a:72:ad:6f:e7:2a:9f:
+                    a2:bf:61:5a:ee:06:b4:be:74:3b:03:af:ed:f6:0b:
+                    ca:0d:7a:ec:9f:7a:08:80:c4:d5:ce:91:2a:a5:6e:
+                    cf:1f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                78:36:48:EE:EA:D2:D8:66:DF:E3:B6:B3:81:0F:E7:17:FD:D9:90:71
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0..0......F..0|.....F..0r0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0$..http://example.com/gr/test.pdf..gr0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         23:e2:f7:7f:e7:6c:e4:c7:fa:74:f8:58:86:58:6b:3b:33:4a:
+         c1:70:3c:91:9d:c7:37:14:14:dc:aa:54:ce:6b:5a:94:30:ec:
+         1d:93:29:d8:64:35:83:1a:66:3b:24:d0:de:03:62:47:a1:ce:
+         17:4a:6d:b9:ec:4e:b2:e0:1c:a7:d5:5c:b2:b9:ed:c3:f0:62:
+         26:07:bc:90:da:7a:17:75:71:f0:bb:35:d0:6d:07:d8:72:9b:
+         29:fc:15:d7:e9:35:65:4b:0f:76:c4:65:8a:01:c4:80:d2:a9:
+         54:4f:f0:4b:71:c5:c8:c8:d3:c6:78:f6:52:78:8b:0e:73:4a:
+         d2:a9:d0:85:d5:75:48:b8:18:de:e2:3f:ab:3d:ba:40:26:96:
+         b6:b6:9b:18:93:db:80:d8:39:59:fc:a1:e6:44:8b:f0:f0:57:
+         25:a1:3c:4b:3f:09:02:a8:f7:b9:25:83:7e:3c:13:9e:75:56:
+         fa:87:ba:47:3e:9c:e3:21:7d:a1:b6:04:c7:66:99:53:03:05:
+         0a:bf:dd:e8:9f:2a:72:f2:60:4d:dd:b2:68:ee:3e:d4:34:a0:
+         04:7b:d6:71:10:32:68:93:82:e6:0a:11:86:92:20:52:4a:71:
+         d4:87:b2:5b:c6:2d:bd:3b:33:59:39:2b:e5:dd:10:13:74:8a:
+         c1:43:22:ca
 -----BEGIN CERTIFICATE-----
 MIIE9jCCA96gAwIBAgINAhLsoS3XzjDhpTNB9DANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiValidCert03.pem
+++ b/v2/testdata/QcStmtEtsiValidCert03.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            09:5e:77:d0:1c:3f:f2:13:28:52:4b:73:05
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:29 2018 GMT
+            Not After : Nov 21 03:21:29 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:d5:b4:45:92:89:1f:03:e8:a6:3f:95:f4:01:5a:
+                    57:b8:d8:cc:09:dd:0a:10:60:bf:6c:86:cd:1f:94:
+                    be:f0:91:27:24:b6:d3:ba:47:72:88:a9:91:3f:2c:
+                    d7:19:38:72:c7:1d:d7:31:69:69:d2:65:01:8c:74:
+                    1d:77:82:9d:87:35:f8:21:0f:0b:14:2d:19:9d:18:
+                    00:fd:93:65:04:bb:24:d3:8d:61:0e:d6:85:e0:b6:
+                    0d:f8:5f:19:4c:3f:b7:b0:b8:88:21:56:62:09:de:
+                    12:70:e1:ff:ba:93:2d:da:0c:29:83:83:82:9a:c9:
+                    7a:7e:00:2a:63:b0:b6:b8:1c:b2:b9:2a:41:8d:59:
+                    aa:57:39:e8:46:ef:ef:9a:d8:70:6c:1e:81:af:7a:
+                    1d:d2:2b:e6:c3:2f:4c:f2:51:7f:64:f7:09:ab:d1:
+                    22:f0:8c:1e:05:e4:44:cd:14:15:45:ce:60:30:70:
+                    8b:20:3a:5a:6a:66:37:5a:04:fa:ec:42:6a:a3:77:
+                    84:9d:e9:de:2b:d8:89:5d:d3:94:d0:9f:fe:77:6b:
+                    85:3a:e9:b2:4e:22:11:ea:5c:d1:99:81:65:b1:1a:
+                    63:9f:c8:75:f5:83:33:35:13:d5:40:7e:a7:78:cd:
+                    9f:ad:3e:af:b3:a9:8c:77:6c:ca:67:00:1e:c7:9b:
+                    71:5f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                F4:9A:6B:96:8C:7B:4B:6C:63:B6:D1:69:75:6E:3A:87:9F:A7:99:BD
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0w0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         83:70:76:50:a1:11:8e:7b:00:27:45:1e:13:d3:f3:e2:97:9c:
+         5f:da:45:db:8b:cf:d3:a0:c5:b7:04:ab:ae:8b:3c:0b:d5:c9:
+         62:f6:3d:61:26:c6:35:4f:31:7b:97:a6:a0:ac:ea:bc:a9:a8:
+         76:80:0d:28:17:88:4a:0b:f1:7b:f7:2d:5a:22:4c:72:9e:75:
+         50:16:6a:c1:c0:f4:e4:5e:fc:35:95:1c:29:89:f1:fc:92:1a:
+         1b:e7:55:d8:47:cb:c7:be:1e:df:d2:e4:71:10:4b:88:44:7e:
+         72:bb:1c:cd:ab:f1:62:c9:d2:ba:15:58:fa:f7:aa:f1:59:94:
+         80:a5:d1:73:71:ce:a5:b7:8b:99:5e:84:af:73:d4:ed:ca:c7:
+         62:66:80:6b:e2:66:e3:29:b2:05:7e:b5:7e:72:2c:d7:1c:50:
+         9c:e7:56:dc:28:5e:44:d0:c3:b4:db:ca:80:e4:77:5d:7b:5b:
+         23:f1:90:c1:ed:b1:4b:f2:0c:9a:5c:c5:40:a1:77:36:94:92:
+         74:c8:36:e0:f2:27:73:40:65:c4:d4:eb:75:ad:ff:98:11:34:
+         79:6e:95:31:30:ae:60:3c:75:72:81:72:d9:b2:da:79:49:34:
+         69:41:02:9f:45:0a:7d:bd:35:52:1d:97:60:44:8b:55:49:2b:
+         31:4e:95:a3
 -----BEGIN CERTIFICATE-----
 MIIEzjCCA7agAwIBAgINCV530Bw/8hMoUktzBTANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiValidCert11.pem
+++ b/v2/testdata/QcStmtEtsiValidCert11.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            01:9e:f9:8e:fc:78:13:c9:8e:bd:80:52:25
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:31 2018 GMT
+            Not After : Nov 21 03:21:31 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:b0:ae:36:22:ac:7c:e0:f7:13:c8:71:45:7e:59:
+                    d0:f7:c2:8b:6c:a9:96:99:b0:94:5e:b1:6b:71:63:
+                    5a:0e:35:b1:83:b3:b1:7b:bd:b3:56:6f:93:91:c0:
+                    94:3c:cd:3d:0f:be:40:39:cf:bd:2a:3e:63:6c:42:
+                    c0:cc:2a:24:b5:f0:b1:78:d0:55:ac:c1:99:e3:ae:
+                    cc:74:02:0a:38:96:8e:da:47:fe:c1:19:77:f2:41:
+                    dd:6b:ce:af:df:ed:32:38:32:61:4d:20:23:a7:df:
+                    20:92:8a:f7:dd:b5:7c:29:e6:e3:c5:ad:b5:0b:f4:
+                    d4:6d:34:a7:18:93:a7:6e:10:c6:8b:3e:8c:b3:68:
+                    c1:72:72:2f:38:a1:a8:f9:70:06:f4:28:cf:20:64:
+                    dc:1a:c0:16:e8:37:76:96:b0:d5:ad:76:54:08:64:
+                    ea:48:25:cc:79:5b:4e:9d:f1:63:e0:33:7d:df:d5:
+                    6b:d0:39:1b:fb:20:48:d4:93:37:47:f5:3c:09:04:
+                    65:7d:62:3c:05:62:67:b5:3b:fe:13:26:25:bb:4b:
+                    90:2a:8b:cb:1a:66:12:d7:45:b7:7d:49:68:45:3a:
+                    f6:97:3a:37:f6:13:8d:3f:8f:32:bf:54:f3:33:cd:
+                    24:d1:81:84:fb:29:d5:6d:67:ae:10:54:9b:33:68:
+                    4b:9d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                48:1B:E9:55:E2:6B:B9:89:55:B8:BD:9B:88:E9:44:D6:A4:5F:AA:76
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0w0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         3a:30:b0:0b:e5:62:e2:e2:55:1b:20:81:38:8d:65:91:d5:48:
+         64:63:d1:ce:93:63:e1:59:48:1e:91:eb:51:90:80:24:d5:71:
+         28:dd:ce:71:a7:e4:4e:d5:b0:1f:e3:c4:2a:c0:ce:93:3a:51:
+         f1:db:ab:f8:e0:a8:e5:bb:d2:97:47:e3:26:2b:22:fe:4c:3a:
+         d0:e1:6d:d2:f4:a9:3b:b7:9a:59:e2:24:06:79:6e:a5:6c:c4:
+         ef:c5:68:d5:ef:c6:71:a0:48:66:48:8b:26:71:1d:7a:fb:8c:
+         af:fe:7a:d2:58:f6:d1:22:65:b6:5b:d5:37:82:69:c6:ce:bd:
+         bf:3b:65:cf:00:1f:76:ca:61:0a:6f:35:61:20:67:06:95:d9:
+         75:35:de:ba:3a:15:83:2e:cb:db:a9:9e:78:40:b1:c1:9a:42:
+         b4:18:4b:f6:d2:c8:05:1f:6f:44:42:85:0c:82:8b:db:63:f3:
+         c1:d8:3e:7e:cd:3c:a3:69:12:18:f2:25:32:03:e3:88:17:bb:
+         70:38:20:38:55:1e:b5:dc:7c:93:3b:90:42:7a:eb:5f:2c:1f:
+         a5:01:67:59:1f:63:e6:62:21:2a:25:11:40:d7:a3:7c:ab:01:
+         b6:98:52:40:a3:e1:24:65:e9:d4:dd:7e:d9:29:8d:58:1e:48:
+         1c:ec:a3:5f
 -----BEGIN CERTIFICATE-----
 MIIEzjCCA7agAwIBAgINAZ75jvx4E8mOvYBSJTANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiValidCert24.pem
+++ b/v2/testdata/QcStmtEtsiValidCert24.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0b:bd:16:31:94:47:b4:20:52:6d:2e:04:06
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: May 16 03:20:30 2019 GMT
+            Not After : May 16 03:20:30 2049 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:9b:f1:47:63:f7:d9:70:cb:1e:49:15:ce:23:8c:
+                    97:57:a6:d2:36:3a:f5:cb:86:ae:c3:29:1e:11:15:
+                    5f:a5:bf:75:5b:d5:fc:2b:56:7d:c0:58:42:ab:e4:
+                    20:f3:7a:31:d2:20:b2:18:a9:84:67:bf:81:a5:ce:
+                    84:75:f2:19:d5:60:d9:8c:94:8d:23:ff:db:e3:88:
+                    2e:52:39:20:79:6d:14:fa:c3:64:40:89:56:fd:6e:
+                    cb:20:21:0b:06:bb:4b:53:d0:01:7a:1b:a4:9a:bf:
+                    ae:d9:26:ad:d0:29:0e:7e:70:9d:f2:69:09:54:af:
+                    38:4f:85:65:65:62:c8:e4:e6:52:0d:23:72:25:97:
+                    a8:b8:44:17:1b:35:e0:1b:e2:66:98:1f:7a:c1:86:
+                    be:b3:77:0c:2d:f7:89:17:94:b1:06:13:42:4e:3b:
+                    99:68:df:a0:c7:06:2f:44:ae:df:bb:e4:01:2a:6f:
+                    05:64:f4:5c:c8:15:74:52:e8:b6:83:fc:ed:5c:de:
+                    a8:5b:76:38:92:5d:02:08:c2:cf:14:35:db:31:b1:
+                    18:98:bd:62:ab:3f:84:08:b5:c5:da:8d:f1:47:c4:
+                    f3:51:01:d7:fe:db:f4:af:0a:bb:29:a2:5f:60:0f:
+                    40:62:d1:a6:2b:91:5e:9e:0b:61:be:7c:b0:ef:8d:
+                    6e:53
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:54:8F:12:03:16:C7:B3:FD:35:6D:2F:F7:2C:BD:24:73:57:85:81:8C
+
+            X509v3 Subject Key Identifier: 
+                0C:52:49:BB:A4:CA:5C:2A:DF:E0:24:3F:CE:E6:B9:86:3D:EF:F8:04
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0..0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..0......F...0......F....*
+    Signature Algorithm: sha256WithRSAEncryption
+         0a:4b:e4:54:bc:cf:da:c7:c0:05:1d:e6:72:d4:bd:c8:af:63:
+         53:f2:95:bb:8d:d2:5e:3e:9c:e4:bf:57:96:65:02:d6:2d:f4:
+         48:09:9f:0c:84:da:5d:87:0b:2f:92:8d:3d:1f:5e:73:5c:bb:
+         c3:a4:f4:49:1a:96:3c:f6:f2:c7:96:b8:44:20:37:fc:db:19:
+         83:1a:44:45:df:60:42:3c:de:12:f8:30:09:07:d9:22:5c:a4:
+         55:90:72:cb:20:c2:ce:3b:be:65:a5:33:0d:de:66:67:6a:71:
+         c4:df:43:d6:24:88:2e:c3:fa:c8:a9:81:36:85:bc:43:60:04:
+         69:b5:ca:d7:32:2c:e6:9d:fe:07:e4:3c:11:e7:29:fa:18:a6:
+         42:c6:d3:d5:1a:43:b3:c9:60:56:fa:83:83:27:4d:0c:c8:b2:
+         df:a8:bc:6c:7e:ac:62:90:d5:1a:80:21:ad:80:2a:aa:c4:7d:
+         3d:9e:c6:93:d7:ab:b1:ec:07:4d:0c:d1:a9:aa:16:1a:39:5c:
+         f6:c0:8b:86:fb:4f:92:f3:94:7b:4b:67:47:31:fd:6d:07:f5:
+         a7:24:85:63:77:e6:5c:e8:b6:55:55:4d:33:8f:c0:f2:8e:cb:
+         14:1b:23:a8:ab:b2:12:ce:a1:25:84:77:9a:5e:c1:6c:58:56:
+         8f:7d:86:61
 -----BEGIN CERTIFICATE-----
 MIIE3TCCA8WgAwIBAgINC70WMZRHtCBSbS4EBjANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiWrongCriticalityCert06.pem
+++ b/v2/testdata/QcStmtEtsiWrongCriticalityCert06.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            04:f2:ed:70:46:be:49:5c:b7:89:56:3f:00
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:29 2018 GMT
+            Not After : Nov 21 03:21:29 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:94:31:9e:3b:de:a9:2e:fc:b1:9f:48:fd:40:30:
+                    8e:70:cd:ab:fd:24:82:57:37:40:0c:5b:7b:40:81:
+                    94:ee:26:16:c0:96:ea:3b:85:4c:42:21:2d:60:9c:
+                    e1:d9:9a:bf:5d:a8:60:7d:01:c7:c9:b2:cb:33:0b:
+                    58:cb:75:41:de:12:e0:5f:d5:9c:16:da:f9:d7:0f:
+                    fa:05:71:59:29:79:dd:e6:f1:e5:d7:ca:98:ee:8d:
+                    8d:1c:10:8c:6a:6d:48:af:9b:23:8a:4b:9b:aa:87:
+                    ce:bd:96:f6:74:9a:10:8c:e6:7f:4b:aa:c9:e1:c9:
+                    31:a5:54:c7:f3:37:b5:9d:91:78:fe:3b:1c:9d:4a:
+                    91:ef:1d:97:34:24:6f:19:41:bd:36:28:70:59:57:
+                    07:79:9d:59:a0:a0:ba:9c:b1:2a:fa:ce:c6:7f:86:
+                    c4:68:8c:94:d9:f0:03:91:84:15:be:0b:96:71:37:
+                    49:97:2d:23:58:63:9f:23:d3:08:1f:e8:fa:e1:d6:
+                    23:3e:09:5e:a0:14:35:b8:c0:31:e5:2e:7a:07:35:
+                    bc:4d:90:a7:ff:ad:2c:b0:81:fa:79:a9:b2:d7:f3:
+                    d6:20:8c:65:0d:76:70:e7:37:88:e4:ed:e3:6b:73:
+                    45:6b:40:7f:17:8e:7d:46:28:c4:88:ee:53:56:7d:
+                    33:a1
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                0E:89:E0:BC:14:3A:FD:FE:6D:8D:2B:F8:BF:6B:AB:03:FF:4C:EB:B3
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: critical
+                0w0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         03:61:65:17:19:d9:e8:6a:e0:e8:97:bf:17:1e:a0:cc:97:ad:
+         b7:b4:8a:9a:bf:cc:cc:7b:fb:ad:f8:23:c0:29:f1:ad:c0:0c:
+         dd:73:b1:1a:d8:5e:6b:c8:ed:b3:20:dc:85:60:82:da:ce:b2:
+         70:75:61:7c:a8:01:b8:ce:55:b5:5a:0e:49:de:40:4f:64:22:
+         6b:73:72:b8:52:40:ee:21:83:dd:19:6c:6f:48:e1:21:32:3b:
+         dd:b1:8e:a1:8d:c8:5e:2e:4c:ea:f2:40:64:9e:53:0f:a3:9a:
+         74:e9:2e:ba:a2:d3:ef:3c:68:d5:66:3e:2a:4d:d7:fd:1e:eb:
+         50:df:f5:59:76:d3:96:bf:a7:a6:b1:e2:24:a6:1a:56:31:5c:
+         d1:32:c9:2d:54:0c:11:0d:ef:36:69:c7:4b:25:a7:1f:13:74:
+         1f:52:f1:73:ad:46:9c:0d:2b:eb:3a:ff:ec:7b:12:2d:77:02:
+         63:0b:5a:75:00:fc:cd:c7:a0:b1:94:6c:6f:b6:c5:52:21:b0:
+         c8:3d:a5:fc:63:78:ff:8e:82:93:8f:b8:fd:62:8f:5f:95:e8:
+         70:ac:7e:e2:7b:be:93:9f:1b:c1:2a:f1:27:66:33:0b:1f:bf:
+         6c:0b:e9:22:fd:30:6a:24:6b:73:bb:a3:a4:05:6a:15:19:73:
+         9a:9e:eb:bf
 -----BEGIN CERTIFICATE-----
 MIIE0TCCA7mgAwIBAgINBPLtcEa+SVy3iVY/ADANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiWrongEncodingCert01.pem
+++ b/v2/testdata/QcStmtEtsiWrongEncodingCert01.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0b:07:02:70:d9:62:61:4f:cc:57:00:ae:11
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:28 2018 GMT
+            Not After : Nov 21 03:21:28 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:80:f7:08:6a:e3:85:65:47:b6:77:10:53:65:d8:
+                    ba:a1:44:3b:ff:2b:0c:a9:23:69:e5:3c:dc:bc:7d:
+                    94:18:d7:f1:33:48:fa:1d:3f:49:81:d9:bf:c4:77:
+                    b1:5d:da:c3:b9:d0:7d:96:77:00:82:e3:76:0a:b0:
+                    4e:22:e6:af:64:84:a5:0f:3e:b3:9e:04:67:d5:88:
+                    b0:76:e4:80:46:c5:2b:4f:2e:03:d3:7d:cb:d0:45:
+                    d2:70:9b:fa:26:0a:fb:5d:79:6a:23:70:04:0f:9f:
+                    75:49:ae:47:f1:50:2c:4e:66:60:12:83:9e:9d:70:
+                    4b:1f:5e:23:35:4a:a8:19:ca:a2:f0:ef:74:b0:4e:
+                    6f:94:c3:50:7b:29:d5:93:8c:bb:1d:78:5f:05:2f:
+                    a4:0a:ad:ba:aa:11:81:19:0c:9f:b8:33:9a:6f:97:
+                    cc:31:a6:2f:c5:6b:7b:c6:6d:5b:bd:5f:77:46:41:
+                    73:ed:36:70:28:8d:bf:a2:fc:31:2a:bc:26:bd:46:
+                    36:6d:4b:77:d0:2a:e4:f0:10:84:59:17:98:ec:5a:
+                    64:1e:d4:58:84:45:e1:62:85:11:19:c9:0b:b2:8e:
+                    4d:17:ce:17:a2:e5:00:4c:9a:a4:39:23:20:eb:cc:
+                    2c:59:63:69:f4:5d:18:c1:e5:ac:d9:71:cc:7e:72:
+                    f0:a5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                DF:19:8C:1A:30:02:E8:96:B3:E2:10:E5:A9:A1:92:69:7A:DB:9F:05
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0.......
+    Signature Algorithm: sha256WithRSAEncryption
+         80:38:b7:c5:18:b9:df:c2:2d:4b:b8:fa:d5:c2:97:df:86:8f:
+         2c:2b:e5:f5:f3:b8:d6:80:f3:e0:26:20:ba:08:a0:5a:55:88:
+         2b:bc:ef:8b:09:24:f9:a3:65:77:6d:24:ae:7e:10:8a:b3:05:
+         37:ae:0d:b2:01:71:b6:d8:34:fd:80:cc:f5:60:f1:c1:56:54:
+         18:6c:c9:96:b2:e7:6b:27:3d:26:9c:64:76:66:89:f5:3a:51:
+         36:9e:ed:41:0e:1a:e7:76:35:37:3f:d1:e0:21:14:92:bd:17:
+         2d:23:6a:31:3b:ed:46:9a:7a:07:f2:60:9d:54:cf:e5:ad:c7:
+         08:41:df:ce:45:7f:e6:63:3c:b4:6d:2e:b8:94:ce:74:f8:0c:
+         88:01:e0:ce:8d:ca:80:98:3e:00:be:be:c5:ac:a0:86:7e:b5:
+         1c:9c:c9:fe:a5:92:38:96:aa:5f:a4:6e:49:d9:f5:85:0b:93:
+         0a:40:69:02:ef:ba:a8:6e:63:e9:95:b9:54:e9:e4:e6:4f:5e:
+         c3:cd:1b:b6:9a:4b:07:ad:cd:bc:48:84:07:ae:19:d5:19:98:
+         aa:3c:79:37:fb:d1:8c:80:63:7a:3c:3e:dc:77:3c:17:f5:0e:
+         73:23:7d:eb:70:b8:f7:a8:f4:7e:cf:19:2c:63:5e:88:f5:f7:
+         5a:56:58:f1
 -----BEGIN CERTIFICATE-----
 MIIEXDCCA0SgAwIBAgINCwcCcNliYU/MVwCuETANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiWrongEncodingLangCodeCert07.pem
+++ b/v2/testdata/QcStmtEtsiWrongEncodingLangCodeCert07.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            05:d8:ca:5e:c3:85:b1:b2:4b:4d:6f:81:c4
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:30 2018 GMT
+            Not After : Nov 21 03:21:30 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:85:cb:42:f4:ff:97:89:90:cf:99:7f:d7:57:c6:
+                    6d:9a:2a:00:e1:54:c4:c6:38:f3:a7:af:50:f5:67:
+                    52:76:25:9d:27:8b:cf:fa:d5:21:3a:08:c2:94:78:
+                    65:93:cb:99:1d:4c:68:f2:46:a5:f8:bc:11:91:7d:
+                    93:27:8a:ba:d1:66:43:ce:67:b4:a8:97:c3:c5:84:
+                    a1:cb:e0:a0:fd:33:f1:3d:ae:32:9c:fa:89:86:6d:
+                    fe:54:97:c9:c9:15:55:3e:a6:73:07:b8:4d:29:5a:
+                    61:db:e8:84:41:74:28:7f:55:d6:c4:01:6b:58:e6:
+                    13:18:af:8c:11:7c:be:bd:e5:db:8e:4b:dd:62:68:
+                    fe:6c:64:28:dd:f0:e6:4d:9f:ed:bd:60:a5:aa:04:
+                    d8:8e:99:53:0f:b2:74:b4:40:72:9b:0f:a1:d4:1a:
+                    d5:bf:ac:f6:38:ab:5e:0b:a9:9e:cc:ae:ae:96:9f:
+                    b1:5c:57:53:68:e4:d0:e5:2d:97:7f:74:8e:e5:bf:
+                    7b:79:b2:3b:35:95:84:56:ee:21:f2:1a:e6:1b:11:
+                    0c:c4:d6:a5:9b:99:9b:ca:ad:6e:4f:e3:d4:39:c2:
+                    15:91:66:a1:2f:e8:d5:98:62:a3:79:1f:43:c3:93:
+                    86:19:2c:f3:a0:5d:0d:50:c1:da:37:05:25:75:2a:
+                    0c:0d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                3C:E8:C1:40:29:82:E7:F0:3C:9A:D5:3F:48:96:1C:0B:AF:4A:2B:F8
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0w0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         a6:91:15:61:1c:36:1f:a6:79:11:3a:58:10:bc:57:77:5f:bc:
+         6e:2d:87:9f:0e:15:fd:ae:8a:cf:bf:95:d6:35:ae:71:ba:86:
+         dc:8d:68:c0:c3:34:3f:d5:2d:e4:a1:66:9c:70:6c:d0:ea:66:
+         aa:fe:aa:ba:c8:76:ef:3c:d2:92:ea:d3:8e:9a:d4:84:1c:45:
+         40:a8:8c:67:cc:af:ab:61:93:c2:85:ba:3b:b1:92:d3:bf:24:
+         1a:24:a3:44:4f:07:2a:04:61:d3:9b:07:11:43:d2:0e:df:65:
+         70:5a:40:10:6a:a0:81:40:2d:50:18:0e:49:6f:e1:d3:97:27:
+         04:de:be:77:8b:f3:fa:75:d7:87:a8:0a:45:26:0b:3a:46:f4:
+         15:c0:cf:92:14:28:49:67:42:69:ba:1c:d3:b7:7f:71:40:ff:
+         8b:2a:bd:a5:bf:97:91:7b:de:91:11:12:41:08:e4:a9:cb:4b:
+         0a:36:a1:8b:94:35:b2:4a:60:aa:31:ef:9a:a2:4b:74:67:2e:
+         fd:41:fe:0a:5c:8d:4f:5a:15:59:5f:58:e9:45:3d:78:da:6c:
+         31:4b:07:84:22:2b:82:36:e6:aa:88:53:4c:e9:ae:be:89:ec:
+         17:e1:d1:6e:07:38:1a:a0:b5:17:39:36:30:9d:ad:c7:31:ba:
+         ce:6e:21:9b
 -----BEGIN CERTIFICATE-----
 MIIEzjCCA7agAwIBAgINBdjKXsOFsbJLTW+BxDANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiWrongEncodingUrlCert08.pem
+++ b/v2/testdata/QcStmtEtsiWrongEncodingUrlCert08.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0f:03:01:fc:79:42:c0:3a:ed:cf:db:80:a6
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:30 2018 GMT
+            Not After : Nov 21 03:21:30 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:90:af:0b:6b:95:28:e1:21:fd:fa:90:5f:e2:ab:
+                    2c:7e:1b:c0:1f:87:b3:cd:c5:87:83:77:98:f7:d8:
+                    32:55:52:68:d8:64:04:21:ed:c1:1e:59:cc:8e:fc:
+                    4f:dc:b8:1e:45:fc:ae:22:dc:8f:74:5b:7a:3b:69:
+                    95:c3:5b:dc:47:32:75:4a:fa:82:74:f3:f2:15:74:
+                    32:8c:d8:4e:da:b8:49:ca:3d:2f:a9:57:a6:1a:6f:
+                    d5:2f:1f:32:af:7b:c5:2c:0a:d1:4f:d3:70:b1:cd:
+                    ce:fe:9d:27:f7:e8:bd:fa:09:ff:8f:fd:e8:26:c4:
+                    b8:8c:7d:19:c8:be:ea:8a:a9:d5:25:66:2c:ed:66:
+                    31:a6:fc:8c:a5:12:d8:2b:bf:92:a8:d4:71:f0:18:
+                    1b:b3:47:83:19:f5:2a:e9:a7:9e:b2:2b:de:5e:7a:
+                    19:16:ce:73:4d:16:5c:a1:4e:e2:ea:4f:3e:e0:68:
+                    fa:cf:a5:98:32:e9:af:e1:91:89:6b:c2:fe:f7:32:
+                    54:24:2f:14:1f:32:ef:8c:03:7c:ac:8d:24:62:21:
+                    0c:39:f4:7e:4b:eb:82:63:d3:43:16:1e:44:de:d5:
+                    21:5c:55:5d:3e:02:2d:af:ec:8f:d1:e4:c3:15:1a:
+                    87:ea:5b:54:f2:b0:3c:f6:54:d8:1e:d0:42:c7:5c:
+                    b6:cd
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                47:CB:5C:6F:3A:1E:53:30:05:17:EA:F7:7F:45:30:01:62:57:A4:07
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0w0......F..0V.....F..0L0$..http://example.com/en/test.pdf..en0$..http://example.com/de/test.pdf..de0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         55:da:8e:2d:b9:6f:b2:c8:47:c6:cf:25:c9:ea:bc:5e:0b:c7:
+         4a:7b:53:06:77:e0:b6:9d:2c:2c:14:19:d2:ca:2e:70:1f:1a:
+         49:83:72:33:f1:3a:35:8f:15:e4:2c:2c:36:16:2d:85:78:1a:
+         67:4e:c2:5e:27:23:5c:b1:0e:c3:47:c7:4c:85:ca:c3:f3:9b:
+         03:cf:90:64:66:45:02:b4:b8:34:c1:c5:1b:8e:ba:96:67:9a:
+         06:9b:83:05:dd:d5:c7:e2:8d:e3:93:0c:f6:e5:7b:91:36:e4:
+         4c:9f:ea:6f:33:bd:3c:6b:28:ea:a3:93:a3:ff:ff:41:7c:61:
+         35:73:85:f1:87:43:8f:3b:98:0d:f4:4d:85:cc:54:bb:a5:87:
+         c2:5c:a5:bb:a2:8f:3e:13:a4:be:e0:7e:23:38:ba:c1:87:fa:
+         0f:67:bd:1a:45:cb:ab:f2:ed:89:1d:e7:e5:11:dd:3b:e3:e3:
+         33:08:15:8f:92:96:57:dc:28:14:98:8c:86:ff:c2:e7:d5:ad:
+         d5:78:b3:fb:62:c3:33:ee:ce:00:e0:c4:37:61:03:1c:89:e4:
+         35:ea:c4:2d:29:6f:c1:17:9f:eb:a4:c4:a8:26:f7:5d:12:75:
+         4e:d7:d3:a1:f7:da:66:f6:db:e6:63:fd:b6:99:74:5f:6a:85:
+         8d:59:49:76
 -----BEGIN CERTIFICATE-----
 MIIEzjCCA7agAwIBAgINDwMB/HlCwDrtz9uApjANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtEtsiWrongLangCodeCert05.pem
+++ b/v2/testdata/QcStmtEtsiWrongLangCodeCert05.pem
@@ -1,3 +1,76 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            02:14:cd:c4:50:13:16:32:2a:bb:cc:e2:ce
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Lint Sub-CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Nov 21 03:21:29 2018 GMT
+            Not After : Nov 21 03:21:29 2048 GMT
+        Subject: CN = www.example.com, OU = Test, O = MTG, L = Darmstadt, ST = Hessen, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:92:9e:74:92:e6:42:3b:3b:75:29:a1:44:6c:39:
+                    76:1f:97:cf:f4:e6:c1:bc:ee:59:15:bd:c3:59:87:
+                    1b:fa:ae:32:59:a8:96:a7:84:0e:61:34:19:35:a1:
+                    20:16:f7:08:7e:a1:8e:45:04:ee:3c:ea:1f:34:25:
+                    02:d8:c3:46:0c:b7:46:8d:f1:a6:4f:ae:71:6b:2e:
+                    b7:da:d0:73:74:53:f3:db:dd:42:32:57:8f:58:d3:
+                    1a:d2:8f:5e:1b:91:90:67:b7:90:27:94:af:3e:8b:
+                    fd:0f:eb:b9:a5:11:d3:f2:cf:57:1e:3e:85:55:d9:
+                    11:95:ed:d5:81:39:05:6f:fd:cc:81:2a:30:0f:8d:
+                    69:ba:7a:6c:37:94:44:fa:e0:d4:3d:55:dc:23:49:
+                    e0:f2:61:70:d2:70:c3:d6:24:22:9e:fc:70:5e:31:
+                    75:ea:cc:e1:1b:ed:59:c3:2c:eb:99:90:14:8d:7a:
+                    3d:46:c1:82:68:4b:3a:9d:40:2c:db:c9:6d:fa:9f:
+                    dd:13:97:f1:1f:6f:58:55:f9:9c:81:52:e1:64:24:
+                    0a:79:24:90:cb:8b:e4:72:17:9f:0c:84:63:e9:3d:
+                    2a:d6:a3:9d:13:6e:09:b6:7a:7f:f4:6d:61:24:c8:
+                    69:54:67:30:87:b0:d1:9d:9e:f2:93:33:11:d9:5e:
+                    12:79
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:E2:0F:66:4C:20:2C:78:21:2A:8F:29:DB:F9:99:F6:00:86:C4:AF:E1
+
+            X509v3 Subject Key Identifier: 
+                D9:44:CD:C3:89:1D:7C:27:73:04:60:88:31:92:C5:27:A4:61:31:F4
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com
+            Authority Information Access: 
+                CA Issuers - URI:http://ca.example.com/ca.crt
+                OCSP - URI:http://ocsp.example.com/ocsp
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3.4.5
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            qcStatements: 
+                0x0......F..0W.....F..0M0$..http://example.com/en/test.pdf..en0%..http://example.com/de/test.pdf..ded0......F..0......F...
+    Signature Algorithm: sha256WithRSAEncryption
+         48:dd:a5:c7:5b:2a:eb:1b:e0:91:64:9b:75:18:ec:f9:45:23:
+         6b:83:04:54:df:a1:66:b7:26:db:e7:68:8c:fb:a6:01:97:16:
+         64:0c:37:9e:79:d1:5e:45:8b:6c:a4:4e:27:4a:e5:dc:e3:cc:
+         8f:5f:d5:da:0a:0a:4f:f3:8f:67:7c:f4:79:b7:3e:b5:3f:71:
+         ea:b7:b7:cc:44:cc:34:22:44:fe:c1:bc:ef:ea:a6:4c:47:31:
+         1c:0f:30:96:fa:b8:15:65:c9:7e:4e:2d:0e:4c:8e:0e:d5:0e:
+         55:94:ef:41:9d:e8:d6:c5:11:c8:5c:0f:6e:98:e0:4f:4a:05:
+         03:3f:cb:ec:49:10:fc:16:ef:ef:d4:48:de:34:72:e7:ef:c3:
+         11:be:58:70:25:fa:02:e9:97:76:e1:09:10:93:a9:45:3c:6a:
+         ec:4c:77:b1:28:a0:2f:aa:04:3a:bf:07:3b:dd:66:e7:0d:66:
+         86:19:f1:24:79:69:f3:d9:42:56:17:16:5a:31:c4:fe:58:14:
+         f2:47:03:53:45:d5:90:9f:a6:56:61:08:34:d7:14:37:e3:54:
+         ff:43:f1:d6:2f:0d:a0:a4:f9:0f:5b:d1:f0:ef:87:e5:0d:66:
+         02:c1:6f:a1:8f:6f:fb:6f:74:78:78:d5:da:40:25:3a:65:4f:
+         de:01:98:4e
 -----BEGIN CERTIFICATE-----
 MIIEzzCCA7egAwIBAgINAhTNxFATFjIqu8zizjANBgkqhkiG9w0BAQsFADBAMRQw
 EgYDVQQDDAtMaW50IFN1Yi1DQTENMAsGA1UECwwEVGVzdDEMMAoGA1UECgwDTVRH

--- a/v2/testdata/QcStmtInvalidLimitValue.pem
+++ b/v2/testdata/QcStmtInvalidLimitValue.pem
@@ -1,3 +1,84 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            1e:fd:a7:3c:4f:16:eb:57:af:70:b9:4f
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = PK, O = Development, CN = Development Sub CA
+        Validity
+            Not Before: Sep 25 09:37:57 2019 GMT
+            Not After : Oct 26 09:37:57 2029 GMT
+        Subject: C = PK, O = Development, serialNumber = 578611675, GN = Muhammad Bilal, SN = Ashraf, CN = Muhammad Bilal Ashraf
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:d8:73:d5:a2:53:6f:03:4a:95:bb:05:cf:71:72:
+                    1d:ad:af:d6:fd:53:8b:cf:1e:51:c9:18:c0:1d:40:
+                    bc:b2:c6:0a:3c:b2:79:ac:d8:d4:70:01:6b:20:c4:
+                    41:10:b5:70:d4:1f:92:af:7f:fa:ef:57:03:b2:1d:
+                    76:9c:59:0e:e0:a7:c2:a6:9a:ef:1b:d8:29:57:6c:
+                    8b:64:f3:61:a5:43:ea:c6:96:d7:6b:a1:fa:55:0b:
+                    f8:3d:83:47:b9:fe:f9:90:f2:73:ca:7d:9d:92:1c:
+                    3f:44:63:5f:88:df:5b:fe:a3:38:2d:2c:47:ce:5a:
+                    ce:7b:e8:23:37:bb:92:68:b1:1c:b6:bd:7a:bf:b9:
+                    6e:eb:9d:25:6c:d0:b6:f5:77:c6:f4:5b:91:29:e1:
+                    c0:07:4e:16:a0:5b:60:7b:a3:f7:5f:0b:d1:90:74:
+                    d5:bd:c5:23:c7:45:d2:44:3d:c5:6d:cb:e2:fd:2a:
+                    8a:65:2b:45:2c:dd:fc:d9:7a:7f:b8:0e:d2:fa:45:
+                    f4:79:51:c7:c8:88:10:c8:4c:9d:3a:ae:65:23:59:
+                    93:44:2b:09:9f:4b:ce:5d:ab:f6:62:06:62:1c:6b:
+                    e9:0c:cc:d7:3f:3f:e3:fe:20:05:6e:52:e6:19:e3:
+                    45:45:44:03:22:bc:13:61:41:1f:74:68:c1:18:e0:
+                    25:57
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Non Repudiation
+            X509v3 Extended Key Usage: 
+                E-mail Protection
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                5E:3B:7F:1D:E8:D5:58:7E:EE:26:B3:C7:92:E6:5A:C1:0E:5F:BB:9D
+            X509v3 Authority Key Identifier: 
+                keyid:30:CD:83:A7:36:AC:A5:35:FF:21:1B:37:40:6E:B2:CF:5F:1C:03:2F
+
+            Authority Information Access: 
+                OCSP - URI:http://dev.com/ocsp
+                CA Issuers - URI:http://dev.com/ca.crt
+
+            X509v3 Subject Alternative Name: 
+                email:bilal.ashraf@gmail.com
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://dev.com/ca.crl
+
+            X509v3 Certificate Policies: 
+                Policy: 1.3.7.8.9
+                  CPS: https://www.dev.com/repository/
+
+            qcStatements: 
+                0..0......F..0......F....
+0......F..0...EURO..
+...0......F..00.....F..0&0$..https://dev.com/pds/en/pds.pdf..en0%.....F..0......F........F........F...
+    Signature Algorithm: sha256WithRSAEncryption
+         0f:25:98:4c:8c:ef:19:bc:c8:6d:46:df:7b:49:87:48:dc:63:
+         a1:a7:2e:85:65:90:2e:1c:97:fd:47:c7:67:98:5d:60:be:e8:
+         b0:8b:f0:bd:6b:bc:d6:11:a2:18:af:44:a3:4d:bb:f5:6d:18:
+         7b:12:78:aa:9f:74:60:8c:c6:f2:48:ca:bc:ae:d7:21:b1:4b:
+         99:89:c2:7f:bf:bc:b1:71:dc:bc:7f:70:fd:bf:16:d7:57:13:
+         5a:60:b6:fb:1b:98:83:10:96:bc:79:06:c1:65:69:12:96:65:
+         90:37:3e:61:88:e2:95:45:50:ef:02:1c:8a:78:29:4f:df:13:
+         7a:4d:fa:44:86:7c:99:c3:6a:91:75:13:ac:26:96:b7:d4:5a:
+         e2:1e:f7:d8:9f:3b:31:25:b2:76:27:c4:31:85:22:f9:f4:8a:
+         b6:dc:3b:72:30:73:7f:a4:39:5c:59:16:63:4b:90:b5:8d:3c:
+         ec:42:11:95:d7:b3:c1:af:42:64:04:92:b5:a1:15:cd:0e:d4:
+         4e:c3:b3:2d:26:e6:60:44:33:28:af:2c:88:ee:99:f9:18:d5:
+         f3:a6:54:e3:bb:92:67:67:02:fb:ef:d2:40:1b:9f:01:0d:02:
+         87:fb:67:37:63:b7:bc:00:9f:03:7d:10:85:06:e5:58:77:bd:
+         59:de:2d:68
 -----BEGIN CERTIFICATE-----
 MIIFRzCCBC+gAwIBAgIMHv2nPE8W61evcLlPMA0GCSqGSIb3DQEBCwUAMEAxCzAJ
 BgNVBAYTAlBLMRQwEgYDVQQKEwtEZXZlbG9wbWVudDEbMBkGA1UEAxMSRGV2ZWxv

--- a/v2/testdata/QcStmtValidLimitValue.pem
+++ b/v2/testdata/QcStmtValidLimitValue.pem
@@ -1,3 +1,84 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            1e:fd:a7:3c:4f:16:eb:57:af:70:b9:4f
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = PK, O = Development, CN = Development Sub CA
+        Validity
+            Not Before: Sep 25 09:31:18 2019 GMT
+            Not After : Oct 26 09:31:18 2029 GMT
+        Subject: C = PK, O = Development, serialNumber = 578611675, GN = Muhammad Bilal, SN = Ashraf, CN = Muhammad Bilal Ashraf
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:fe:68:4a:13:03:61:d5:0c:0f:5a:fe:6a:da:af:
+                    0f:b1:e5:5c:a3:13:21:c5:a2:8c:8a:94:94:9a:16:
+                    50:9c:8c:9a:c8:d7:41:11:fc:10:aa:f9:fc:4f:62:
+                    6b:3d:54:25:87:eb:f2:04:0b:d9:ff:18:fc:e7:16:
+                    a3:0b:be:85:46:bc:ee:64:cc:c2:df:8f:fd:de:cd:
+                    16:74:c5:f6:5f:5b:68:cf:0d:03:3e:01:2d:1b:b5:
+                    71:1a:7b:8b:75:f6:6d:45:04:f0:e0:a3:9d:2f:74:
+                    0e:ad:27:88:4a:62:ae:b0:5a:81:3c:5b:1e:35:0f:
+                    81:74:e2:70:68:f7:fe:d9:c9:95:cb:7c:1f:97:52:
+                    6a:50:2c:f9:76:8c:66:89:91:fa:ae:4c:61:2d:c7:
+                    9a:8c:fb:0f:e9:62:3d:33:a1:28:1a:bc:b0:55:e9:
+                    c3:e5:0d:25:ac:b4:57:62:86:13:c3:33:ed:97:9a:
+                    10:cf:49:b0:89:83:5b:46:e6:80:a6:22:4b:ba:78:
+                    0e:8f:26:2e:f5:67:5f:d5:28:c9:0e:62:97:0c:61:
+                    e4:0c:c7:ee:f5:b1:80:9a:73:3c:6c:de:50:c0:38:
+                    d1:4b:15:c9:a9:fa:64:41:a7:1f:b3:b8:9e:df:a7:
+                    d7:b6:20:c5:15:b8:42:cf:b3:48:58:2f:ed:f3:0d:
+                    4b:43
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Non Repudiation
+            X509v3 Extended Key Usage: 
+                E-mail Protection
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                3B:98:64:CA:C0:14:92:2B:AA:F9:E5:1D:71:F7:43:6B:C9:F6:F7:29
+            X509v3 Authority Key Identifier: 
+                keyid:30:CD:83:A7:36:AC:A5:35:FF:21:1B:37:40:6E:B2:CF:5F:1C:03:2F
+
+            Authority Information Access: 
+                OCSP - URI:http://dev.com/ocsp
+                CA Issuers - URI:http://dev.com/ca.crt
+
+            X509v3 Subject Alternative Name: 
+                email:bilal.ashraf@gmail.com
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://dev.com/ca.crl
+
+            X509v3 Certificate Policies: 
+                Policy: 1.3.7.8.9
+                  CPS: https://www.dev.com/repository/
+
+            qcStatements: 
+                0..0......F..0......F....
+0......F..0...EUR..
+...0......F..00.....F..0&0$..https://dev.com/pds/en/pds.pdf..en0%.....F..0......F........F........F...
+    Signature Algorithm: sha256WithRSAEncryption
+         77:9c:08:f7:f4:0b:16:93:3a:f1:cf:fe:c6:48:12:1b:85:ac:
+         db:d6:8e:7b:34:8c:c5:2a:62:9c:64:dc:27:9e:79:12:6b:4f:
+         94:ea:b5:0c:bd:ab:ea:80:b7:e3:5c:9f:d7:c3:5c:a0:cf:3b:
+         76:a4:93:11:0d:3b:87:ac:30:45:84:67:4f:f2:08:44:d1:6a:
+         d6:f2:5f:63:95:e1:bb:38:7e:a3:3a:73:1c:a6:41:1a:f7:4a:
+         36:b4:10:a1:00:c1:b2:01:5f:28:77:6b:c0:49:62:34:55:72:
+         3b:f7:7c:96:6d:2c:c1:77:ed:1b:37:68:67:f0:13:c0:85:ed:
+         c4:0b:19:68:42:20:dc:29:16:ae:3b:af:4a:20:dc:3d:85:38:
+         b1:1f:f4:a2:96:30:e2:a0:34:10:05:87:39:60:09:1f:ba:8b:
+         58:3e:34:ec:4a:1b:0e:e9:a9:ce:5e:7f:04:c5:14:6b:81:fc:
+         9f:45:17:55:9d:51:ed:33:6c:25:a6:4a:6d:07:f5:09:7c:82:
+         67:da:6a:30:ef:39:85:48:21:0a:91:46:fc:b2:a5:48:bd:a7:
+         01:7f:c0:04:16:98:70:9c:f8:5d:aa:04:ac:90:73:9d:12:59:
+         6d:2d:9c:51:b6:b1:59:53:01:50:be:02:d9:b4:17:1d:4d:f0:
+         ea:1d:3b:d2
 -----BEGIN CERTIFICATE-----
 MIIFRjCCBC6gAwIBAgIMHv2nPE8W61evcLlPMA0GCSqGSIb3DQEBCwUAMEAxCzAJ
 BgNVBAYTAlBLMRQwEgYDVQQKEwtEZXZlbG9wbWVudDEbMBkGA1UEAxMSRGV2ZWxv

--- a/v2/testdata/ct18mo2SCTs.pem
+++ b/v2/testdata/ct18mo2SCTs.pem
@@ -1,3 +1,56 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3286978188447131116 (0x2d9db13f4ad925ec)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = lint_ct_sct_policy_count_unsatisified_test CA
+        Validity
+            Not Before: Apr  6 16:35:24 2019 GMT
+            Not After : Oct  6 16:35:24 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:b9:8d:fb:20:5b:0a:8a:9b:c5:21:07:18:f4:b7:
+                    d0:62:ee:86:dd:f8:a4:f1:d6:5f:2c:fd:7e:22:b3:
+                    d9:d1:8a:43:1d:c2:e2:ad:bd:e5:b7:77:74:94:2b:
+                    58:19:47:3e:3c:f3:3e:b0:f5:18:99:47:1e:6a:ab:
+                    84:9b:8b:ef:b7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:F7:5E:C5:4A:CD:04:C3:BD:7F:D5:F2:25:DD:EE:E2:
+                                37:40:D2:58:0E:C2:25:CA:28:0C:5B:A9:12:BA:B8:D1
+                    Timestamp : Apr  6 16:35:24.705 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:FD:62:36:8A:2C:C8:F5:45:90:5D:7A:7A:9E:34:ED:
+                                B8:F6:86:9C:B3:FE:8C:1B:07:B4:FD:3E:A8:7F:88:1C
+                    Timestamp : Apr  6 16:35:24.705 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+    Signature Algorithm: sha256WithRSAEncryption
+         88:b1:a9:38:1b:ff:0f:eb:d8:40:09:37:2b:f5:8e:57:fb:51:
+         d6:1d:b7:2d:a4:7b:c1:b2:10:92:5d:c1:70:bd:5a:90:15:f2:
+         52:69:34:79:80:26:d5:27:05:f7:2c:fb:37:18:2a:df:68:34:
+         21:e8:6a:3c:f4:4b:b2:be:59:a3
 -----BEGIN CERTIFICATE-----
 MIICUjCCAfygAwIBAgIILZ2xP0rZJewwDQYJKoZIhvcNAQELBQAwODE2MDQGA1UE
 AwwtbGludF9jdF9zY3RfcG9saWN5X2NvdW50X3Vuc2F0aXNpZmllZF90ZXN0IENB

--- a/v2/testdata/ct18mo3SCTs.pem
+++ b/v2/testdata/ct18mo3SCTs.pem
@@ -1,3 +1,65 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2504317466764564129 (0x22c11f77b34ed6a1)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = lint_ct_sct_policy_count_unsatisified_test CA
+        Validity
+            Not Before: Apr  6 16:37:24 2019 GMT
+            Not After : Oct  6 16:37:24 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:b3:1c:79:c5:0c:f1:39:ab:73:e2:b6:73:c3:0f:
+                    3f:3c:0c:d0:55:b0:62:7a:fe:f0:5d:41:f0:6d:8f:
+                    80:4e:62:a3:be:54:a8:8e:71:7e:f4:de:09:6e:32:
+                    b9:28:f0:e6:28:b9:e3:5b:93:5f:c1:88:b5:83:c1:
+                    13:d5:20:c8:ab
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:F7:5E:C5:4A:CD:04:C3:BD:7F:D5:F2:25:DD:EE:E2:
+                                37:40:D2:58:0E:C2:25:CA:28:0C:5B:A9:12:BA:B8:D1
+                    Timestamp : Apr  6 16:37:24.264 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:FD:62:36:8A:2C:C8:F5:45:90:5D:7A:7A:9E:34:ED:
+                                B8:F6:86:9C:B3:FE:8C:1B:07:B4:FD:3E:A8:7F:88:1C
+                    Timestamp : Apr  6 16:37:24.264 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 38:73:45:D5:C8:B8:56:76:82:F2:AA:21:18:AB:36:9A:
+                                98:C0:EA:3F:45:3E:AD:35:28:0A:29:2A:EE:96:7B:E8
+                    Timestamp : Apr  6 16:37:24.264 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+    Signature Algorithm: sha256WithRSAEncryption
+         93:09:20:54:97:eb:90:7e:40:1a:93:ce:29:0e:35:ef:c1:89:
+         45:d0:c9:0e:94:d0:a2:77:96:e5:f2:9e:16:81:33:fb:89:8f:
+         64:b2:f5:f4:e5:fc:c8:37:7f:39:14:c4:fd:54:5c:98:c7:79:
+         6e:40:6a:3d:84:bc:66:ca:77:ad
 -----BEGIN CERTIFICATE-----
 MIICpDCCAk6gAwIBAgIIIsEfd7NO1qEwDQYJKoZIhvcNAQELBQAwODE2MDQGA1UE
 AwwtbGludF9jdF9zY3RfcG9saWN5X2NvdW50X3Vuc2F0aXNpZmllZF90ZXN0IENB

--- a/v2/testdata/ct38mo3SCTs.pem
+++ b/v2/testdata/ct38mo3SCTs.pem
@@ -1,3 +1,65 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 141448948552955724 (0x1f68711bc59f74c)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = lint_ct_sct_policy_count_unsatisified_test CA
+        Validity
+            Not Before: Apr  6 16:38:29 2019 GMT
+            Not After : Jun  6 16:38:29 2022 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:96:ed:ec:1a:9a:1b:db:6d:f7:11:55:c4:ea:a4:
+                    1f:7c:11:ce:e8:15:56:a0:d7:b9:65:39:52:5c:75:
+                    94:aa:88:e7:11:3c:88:3a:38:e0:16:1d:38:f7:f4:
+                    8f:9c:e4:9e:b0:44:1b:03:87:5e:40:a6:e9:2f:a4:
+                    c6:34:39:2f:89
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:F7:5E:C5:4A:CD:04:C3:BD:7F:D5:F2:25:DD:EE:E2:
+                                37:40:D2:58:0E:C2:25:CA:28:0C:5B:A9:12:BA:B8:D1
+                    Timestamp : Apr  6 16:38:29.978 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:FD:62:36:8A:2C:C8:F5:45:90:5D:7A:7A:9E:34:ED:
+                                B8:F6:86:9C:B3:FE:8C:1B:07:B4:FD:3E:A8:7F:88:1C
+                    Timestamp : Apr  6 16:38:29.978 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 38:73:45:D5:C8:B8:56:76:82:F2:AA:21:18:AB:36:9A:
+                                98:C0:EA:3F:45:3E:AD:35:28:0A:29:2A:EE:96:7B:E8
+                    Timestamp : Apr  6 16:38:29.978 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+    Signature Algorithm: sha256WithRSAEncryption
+         f1:d1:7c:33:f3:bd:d9:12:d2:ec:55:ab:92:9a:80:07:9a:4a:
+         06:ce:85:db:79:67:3e:76:94:ea:58:ae:61:9c:b2:05:88:63:
+         e5:9e:ff:b7:a2:6d:75:fc:1a:45:a7:be:51:cb:c1:be:c7:38:
+         bd:75:42:e8:fd:fb:40:59:b8:a6
 -----BEGIN CERTIFICATE-----
 MIICpDCCAk6gAwIBAgIIAfaHEbxZ90wwDQYJKoZIhvcNAQELBQAwODE2MDQGA1UE
 AwwtbGludF9jdF9zY3RfcG9saWN5X2NvdW50X3Vuc2F0aXNpZmllZF90ZXN0IENB

--- a/v2/testdata/ct38mo4SCTs.pem
+++ b/v2/testdata/ct38mo4SCTs.pem
@@ -1,3 +1,74 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 68826212176208159 (0xf4851347ffa11f)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = lint_ct_sct_policy_count_unsatisified_test CA
+        Validity
+            Not Before: Apr  6 16:39:07 2019 GMT
+            Not After : Jun  6 16:39:07 2022 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:ab:61:01:e2:bf:b5:76:15:7f:4a:25:5b:4b:08:
+                    3a:60:19:79:25:b4:35:a8:08:20:5e:f8:a9:ee:a1:
+                    1b:99:6b:5d:ff:bf:3c:7a:9e:fe:5d:f6:fd:9e:8c:
+                    36:11:f7:b4:f6:50:f7:29:59:42:ec:07:34:60:fa:
+                    7b:4e:9f:0f:cf
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:F7:5E:C5:4A:CD:04:C3:BD:7F:D5:F2:25:DD:EE:E2:
+                                37:40:D2:58:0E:C2:25:CA:28:0C:5B:A9:12:BA:B8:D1
+                    Timestamp : Apr  6 16:39:07.763 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:FD:62:36:8A:2C:C8:F5:45:90:5D:7A:7A:9E:34:ED:
+                                B8:F6:86:9C:B3:FE:8C:1B:07:B4:FD:3E:A8:7F:88:1C
+                    Timestamp : Apr  6 16:39:07.763 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 38:73:45:D5:C8:B8:56:76:82:F2:AA:21:18:AB:36:9A:
+                                98:C0:EA:3F:45:3E:AD:35:28:0A:29:2A:EE:96:7B:E8
+                    Timestamp : Apr  6 16:39:07.763 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 6F:38:2E:1E:1B:FA:35:39:36:3C:2A:F5:17:EC:60:2C:
+                                1B:B0:43:47:92:8C:19:AD:E7:A4:79:FB:7D:88:08:E0
+                    Timestamp : Apr  6 16:39:07.763 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+    Signature Algorithm: sha256WithRSAEncryption
+         5c:28:fd:27:6b:8e:a6:bb:42:a9:8d:db:bf:62:cb:c8:95:9a:
+         41:63:ae:38:38:ee:9d:6c:54:6b:31:23:a7:1f:01:98:d2:04:
+         59:a1:65:d8:94:c5:9b:3d:cd:8b:91:12:42:7f:41:f8:2e:ca:
+         0d:da:ef:f5:c7:22:6a:1e:0c:ce
 -----BEGIN CERTIFICATE-----
 MIIC9zCCAqGgAwIBAgIIAPSFE0f/oR8wDQYJKoZIhvcNAQELBQAwODE2MDQGA1UE
 AwwtbGludF9jdF9zY3RfcG9saWN5X2NvdW50X3Vuc2F0aXNpZmllZF90ZXN0IENB

--- a/v2/testdata/ct3mo1SCTs.pem
+++ b/v2/testdata/ct3mo1SCTs.pem
@@ -1,3 +1,47 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 4726752801992504291 (0x4198cca147d873e3)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = lint_ct_sct_policy_count_unsatisified_test CA
+        Validity
+            Not Before: Apr  6 16:21:46 2019 GMT
+            Not After : Jul  6 16:21:46 2019 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:9d:74:f0:26:72:2d:ca:fe:92:e6:b0:c9:ae:22:
+                    12:28:ef:3b:58:31:ab:fc:e6:09:35:71:cc:69:2d:
+                    ca:9a:43:16:0d:06:b0:75:e4:af:06:0d:79:f1:26:
+                    79:3f:5d:8d:17:93:d0:dd:7c:83:a2:ed:d2:e9:6a:
+                    4d:6d:d3:cf:61
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:F7:5E:C5:4A:CD:04:C3:BD:7F:D5:F2:25:DD:EE:E2:
+                                37:40:D2:58:0E:C2:25:CA:28:0C:5B:A9:12:BA:B8:D1
+                    Timestamp : Apr  6 16:21:46.382 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+    Signature Algorithm: sha256WithRSAEncryption
+         a1:a9:3f:3a:12:a2:08:69:e1:34:46:b6:c1:ab:2b:9a:8e:98:
+         3b:7a:be:1f:1b:5e:3a:47:52:4f:06:6e:51:fd:cd:5e:35:75:
+         75:ab:25:21:1c:f0:12:a5:ae:b9:e8:42:47:1f:9b:08:ff:1e:
+         0e:bc:af:4c:4a:98:14:1c:df:cc
 -----BEGIN CERTIFICATE-----
 MIIB/DCCAaagAwIBAgIIQZjMoUfYc+MwDQYJKoZIhvcNAQELBQAwODE2MDQGA1UE
 AwwtbGludF9jdF9zY3RfcG9saWN5X2NvdW50X3Vuc2F0aXNpZmllZF90ZXN0IENB

--- a/v2/testdata/ct3mo2DupeSCTs.pem
+++ b/v2/testdata/ct3mo2DupeSCTs.pem
@@ -1,3 +1,56 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 4052089272115185075 (0x383be9b95e98c5b3)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = lint_ct_sct_policy_count_unsatisified_test CA
+        Validity
+            Not Before: Apr  6 16:53:35 2019 GMT
+            Not After : Jul  6 16:53:35 2019 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:d9:1b:d0:e2:a5:4a:17:f0:03:32:03:ae:d5:55:
+                    69:8b:f7:b8:d3:c0:71:a2:39:06:d8:cd:b7:09:6e:
+                    d9:f5:60:db:be:64:4b:97:25:83:b6:8f:e7:f0:97:
+                    ab:a0:16:86:87:1d:9e:c6:56:fe:4c:69:32:64:89:
+                    70:a5:f8:2a:ef
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:F7:5E:C5:4A:CD:04:C3:BD:7F:D5:F2:25:DD:EE:E2:
+                                37:40:D2:58:0E:C2:25:CA:28:0C:5B:A9:12:BA:B8:D1
+                    Timestamp : Apr  6 16:53:35.778 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:F7:5E:C5:4A:CD:04:C3:BD:7F:D5:F2:25:DD:EE:E2:
+                                37:40:D2:58:0E:C2:25:CA:28:0C:5B:A9:12:BA:B8:D1
+                    Timestamp : Apr  6 16:53:35.778 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+    Signature Algorithm: sha256WithRSAEncryption
+         1b:b3:b1:73:ef:13:f7:c9:7c:cc:1c:7f:79:e5:78:1b:fe:4c:
+         0a:6a:58:c1:89:7e:fe:86:8f:84:ff:df:f0:6c:34:69:ce:df:
+         a1:16:ed:2b:c3:78:25:26:70:02:de:88:e6:9d:7e:b5:21:4d:
+         16:59:e4:b9:46:2e:71:f2:35:9d
 -----BEGIN CERTIFICATE-----
 MIICUjCCAfygAwIBAgIIODvpuV6YxbMwDQYJKoZIhvcNAQELBQAwODE2MDQGA1UE
 AwwtbGludF9jdF9zY3RfcG9saWN5X2NvdW50X3Vuc2F0aXNpZmllZF90ZXN0IENB

--- a/v2/testdata/ct3mo2SCTs.pem
+++ b/v2/testdata/ct3mo2SCTs.pem
@@ -1,3 +1,56 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 6825578583704583247 (0x5eb9538ef439bc4f)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = lint_ct_sct_policy_count_unsatisified_test CA
+        Validity
+            Not Before: Apr  6 16:25:05 2019 GMT
+            Not After : Jul  6 16:25:05 2019 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:d8:34:fb:ea:85:5e:08:a8:f7:8d:78:1a:0b:df:
+                    24:6a:da:ca:3f:f7:5d:27:50:32:40:2e:5b:5e:65:
+                    80:29:9f:41:e4:78:40:b7:f9:fa:2e:5b:a4:a9:d8:
+                    87:47:74:58:78:d8:a8:aa:c3:57:0b:2b:f4:1e:86:
+                    fb:a7:53:fc:af
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:F7:5E:C5:4A:CD:04:C3:BD:7F:D5:F2:25:DD:EE:E2:
+                                37:40:D2:58:0E:C2:25:CA:28:0C:5B:A9:12:BA:B8:D1
+                    Timestamp : Apr  6 16:25:05.431 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:FD:62:36:8A:2C:C8:F5:45:90:5D:7A:7A:9E:34:ED:
+                                B8:F6:86:9C:B3:FE:8C:1B:07:B4:FD:3E:A8:7F:88:1C
+                    Timestamp : Apr  6 16:25:05.431 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+    Signature Algorithm: sha256WithRSAEncryption
+         14:14:d2:45:b2:ec:57:15:9f:73:13:be:27:b9:18:21:c2:62:
+         0d:21:0b:33:a2:dc:46:ef:35:6b:e2:de:58:c5:bd:3e:4b:85:
+         5f:9b:33:55:54:ff:f9:ea:0c:10:83:0d:cb:17:1c:fb:8a:98:
+         52:e1:14:f2:a9:40:42:6d:6e:5e
 -----BEGIN CERTIFICATE-----
 MIICUjCCAfygAwIBAgIIXrlTjvQ5vE8wDQYJKoZIhvcNAQELBQAwODE2MDQGA1UE
 AwwtbGludF9jdF9zY3RfcG9saWN5X2NvdW50X3Vuc2F0aXNpZmllZF90ZXN0IENB

--- a/v2/testdata/ct666mo4SCTs.pem
+++ b/v2/testdata/ct666mo4SCTs.pem
@@ -1,3 +1,74 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 8421146558524395128 (0x74ddec2d86598e78)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = lint_ct_sct_policy_count_unsatisified_test CA
+        Validity
+            Not Before: Apr  6 16:40:07 2019 GMT
+            Not After : Oct  6 17:40:07 2074 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:f0:65:71:6e:0e:5d:2c:06:0f:4f:2b:8c:f0:42:
+                    3f:db:9b:e7:59:0a:4d:d6:f7:b8:ed:42:a9:9c:5a:
+                    b6:f1:8a:7d:69:98:4d:b0:e7:5e:1e:d5:29:8e:cd:
+                    21:7b:70:97:68:55:af:e1:ac:37:22:ef:3c:67:58:
+                    60:f0:57:4b:47
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:F7:5E:C5:4A:CD:04:C3:BD:7F:D5:F2:25:DD:EE:E2:
+                                37:40:D2:58:0E:C2:25:CA:28:0C:5B:A9:12:BA:B8:D1
+                    Timestamp : Apr  6 16:40:07.531 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:FD:62:36:8A:2C:C8:F5:45:90:5D:7A:7A:9E:34:ED:
+                                B8:F6:86:9C:B3:FE:8C:1B:07:B4:FD:3E:A8:7F:88:1C
+                    Timestamp : Apr  6 16:40:07.531 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 38:73:45:D5:C8:B8:56:76:82:F2:AA:21:18:AB:36:9A:
+                                98:C0:EA:3F:45:3E:AD:35:28:0A:29:2A:EE:96:7B:E8
+                    Timestamp : Apr  6 16:40:07.531 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 6F:38:2E:1E:1B:FA:35:39:36:3C:2A:F5:17:EC:60:2C:
+                                1B:B0:43:47:92:8C:19:AD:E7:A4:79:FB:7D:88:08:E0
+                    Timestamp : Apr  6 16:40:07.531 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+    Signature Algorithm: sha256WithRSAEncryption
+         95:09:65:57:55:aa:d5:f6:01:e7:e6:1d:07:f5:c5:b5:a3:c2:
+         6a:42:41:e5:6b:a8:75:e6:e7:7e:c2:02:45:c7:68:df:74:b6:
+         54:d2:a0:10:cc:39:5e:5b:95:a6:ab:2a:04:b7:cf:a2:18:4c:
+         bb:16:6e:bf:5e:c3:64:31:83:0e
 -----BEGIN CERTIFICATE-----
 MIIC+TCCAqOgAwIBAgIIdN3sLYZZjngwDQYJKoZIhvcNAQELBQAwODE2MDQGA1UE
 AwwtbGludF9jdF9zY3RfcG9saWN5X2NvdW50X3Vuc2F0aXNpZmllZF90ZXN0IENB

--- a/v2/testdata/ct666mo5SCTs.pem
+++ b/v2/testdata/ct666mo5SCTs.pem
@@ -1,3 +1,83 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 6101906947973781316 (0x54ae540a36771744)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = lint_ct_sct_policy_count_unsatisified_test CA
+        Validity
+            Not Before: Apr  6 16:41:48 2019 GMT
+            Not After : Oct  6 17:41:48 2074 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:a6:f5:40:8a:31:c8:9e:07:86:90:fd:44:36:1f:
+                    16:59:90:28:f5:fa:e8:c2:66:75:1e:c3:66:1c:eb:
+                    a0:80:dd:c3:4e:c0:a7:57:7c:d6:80:6f:6b:dc:6d:
+                    85:29:9e:95:62:47:52:0b:fc:b3:25:59:8a:13:16:
+                    5a:e9:4c:5a:d9
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:F7:5E:C5:4A:CD:04:C3:BD:7F:D5:F2:25:DD:EE:E2:
+                                37:40:D2:58:0E:C2:25:CA:28:0C:5B:A9:12:BA:B8:D1
+                    Timestamp : Apr  6 16:41:48.574 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : B0:FD:62:36:8A:2C:C8:F5:45:90:5D:7A:7A:9E:34:ED:
+                                B8:F6:86:9C:B3:FE:8C:1B:07:B4:FD:3E:A8:7F:88:1C
+                    Timestamp : Apr  6 16:41:48.574 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 38:73:45:D5:C8:B8:56:76:82:F2:AA:21:18:AB:36:9A:
+                                98:C0:EA:3F:45:3E:AD:35:28:0A:29:2A:EE:96:7B:E8
+                    Timestamp : Apr  6 16:41:48.574 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 6F:38:2E:1E:1B:FA:35:39:36:3C:2A:F5:17:EC:60:2C:
+                                1B:B0:43:47:92:8C:19:AD:E7:A4:79:FB:7D:88:08:E0
+                    Timestamp : Apr  6 16:41:48.574 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : FB:05:8A:CF:28:A6:45:12:66:1B:6A:8A:85:B2:84:D9:
+                                E9:4B:CE:05:5A:48:92:A8:17:CD:BC:8C:BC:C7:85:CE
+                    Timestamp : Apr  6 16:41:48.574 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                F3:86:8F:1F:A2:02:B2:3B:82:0D:82:CD:7A:39:24:97:
+                                EB:2A:E0:DA:0E:97:79:85:66:8A:AF:F9:D2:37:7B:A7
+    Signature Algorithm: sha256WithRSAEncryption
+         49:cf:bf:c2:09:bf:2b:92:c3:cc:56:78:88:37:f8:3b:a0:26:
+         fc:fd:da:27:e4:4d:09:85:86:d6:b7:5d:23:da:60:14:aa:4d:
+         bb:a5:b7:8d:9c:21:1e:9c:27:3d:e9:e6:eb:f1:a9:16:8a:43:
+         1e:9e:73:99:ec:0a:be:82:e6:b8
 -----BEGIN CERTIFICATE-----
 MIIDSjCCAvSgAwIBAgIIVK5UCjZ3F0QwDQYJKoZIhvcNAQELBQAwODE2MDQGA1UE
 AwwtbGludF9jdF9zY3RfcG9saWN5X2NvdW50X3Vuc2F0aXNpZmllZF90ZXN0IENB

--- a/v2/testdata/ctNoSCTs.pem
+++ b/v2/testdata/ctNoSCTs.pem
@@ -1,3 +1,37 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 8139484093773701995 (0x70f541a89052e36b)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = lint_ct_sct_policy_count_unsatisified_test CA
+        Validity
+            Not Before: Apr  6 15:18:21 2019 GMT
+            Not After : Jul  6 15:18:21 2019 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:bc:f2:3e:12:6d:a3:88:41:60:fe:4b:c8:e6:4f:
+                    fe:cb:58:92:93:42:66:ff:d0:48:eb:0f:d0:ba:09:
+                    8b:8b:ba:91:a2:e0:bd:34:bb:da:8d:73:15:da:cb:
+                    c0:25:c8:53:99:69:cf:28:25:37:3f:9b:95:ca:a4:
+                    e7:4f:94:95:45
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io
+    Signature Algorithm: sha256WithRSAEncryption
+         66:28:05:5b:5b:ee:fa:79:43:82:2a:dc:6e:1b:e8:26:e5:0f:
+         02:c5:2e:92:fa:12:13:63:17:bb:31:ae:b9:3c:72:bf:80:4a:
+         9a:be:2c:34:05:fd:9c:95:8e:ea:81:4a:ca:5a:5e:c1:8d:03:
+         7f:fe:f9:30:b6:a8:93:cb:db:f1
 -----BEGIN CERTIFICATE-----
 MIIBlTCCAT+gAwIBAgIIcPVBqJBS42swDQYJKoZIhvcNAQELBQAwODE2MDQGA1UE
 AwwtbGludF9jdF9zY3RfcG9saWN5X2NvdW50X3Vuc2F0aXNpZmllZF90ZXN0IENB

--- a/v2/testdata/ctNoSCTsPoisoned.pem
+++ b/v2/testdata/ctNoSCTsPoisoned.pem
@@ -1,3 +1,39 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 8496361007976834640 (0x75e9235233f06650)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = lint_ct_sct_policy_count_unsatisified_test CA
+        Validity
+            Not Before: Aug  1 15:12:58 2019 GMT
+            Not After : Nov  1 15:12:58 2019 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:bf:ec:e7:95:e6:14:0c:77:d6:c7:61:b6:cc:6b:
+                    d6:6d:bb:9e:84:10:de:2a:a6:9a:34:bc:3c:db:36:
+                    76:7a:2c:ea:a6:5f:7c:27:94:eb:68:5c:1a:66:78:
+                    0e:90:52:20:42:e4:3b:fa:05:c1:1a:b7:54:0a:ff:
+                    13:df:62:7f:2f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io
+            CT Precertificate Poison: critical
+                NULL
+    Signature Algorithm: sha256WithRSAEncryption
+         ad:0f:6c:0f:34:df:99:39:db:8b:54:14:ee:ed:1e:e3:97:2c:
+         10:5e:fa:82:7c:17:96:78:93:b2:85:3e:63:29:10:eb:5a:ff:
+         67:dd:a8:dd:43:5b:24:64:ee:d8:d2:85:f5:aa:0e:86:c0:3f:
+         43:32:b7:e4:e9:bc:cb:dd:0c:6c
 -----BEGIN CERTIFICATE-----
 MIIBqjCCAVSgAwIBAgIIdekjUjPwZlAwDQYJKoZIhvcNAQELBQAwODE2MDQGA1UE
 AwwtbGludF9jdF9zY3RfcG9saWN5X2NvdW50X3Vuc2F0aXNpZmllZF90ZXN0IENB

--- a/v2/testdata/dnsNameNoEmptyLabel.pem
+++ b/v2/testdata/dnsNameNoEmptyLabel.pem
@@ -1,3 +1,71 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Mother Nature, OU = Everything, O = Mother Nature, postalCode = postalcode, C = US, GN = givenname, SN = surname
+        Validity
+            Not Before: Aug 28 16:00:32 2017 GMT
+            Not After : Nov  9 17:00:32 2017 GMT
+        Subject: CN = gov.us, OU = Chaos, O = org, street = 3210 Holly Mill Run, ST = province, postalCode = 30062, GN = hello, SN = surname
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:b6:23:37:03:4a:0f:6d:2a:62:d1:4b:8c:f8:3c:
+                    3e:86:15:6f:c2:a9:a7:f1:42:ec:e0:36:09:27:58:
+                    ae:86:75:ce:df:61:e8:5d:f3:c3:5a:8b:df:86:78:
+                    1c:5c:bc:19:4e:f6:55:a6:4e:c7:ea:9b:eb:68:c0:
+                    bd:fd:26:b2:31:9a:97:79:8e:2f:5c:e0:49:40:a7:
+                    5f:d6:17:3c:4b:5d:ee:2b:ce:8e:45:5a:62:f1:71:
+                    3e:35:6b:d6:81:e5:08:d8:39:66:9b:ff:ac:f5:2e:
+                    de:3d:02:b1:51:b8:90:60:3c:43:a1:54:90:44:48:
+                    aa:4e:6f:24:82:c3:d0:46:ce:06:a5:04:8d:88:b5:
+                    09:e7:44:c6:00:73:e6:ec:e9:45:b1:96:f1:e2:8b:
+                    22:a3:17:fb:63:03:e5:a0:72:57:47:31:9e:fe:46:
+                    4d:22:e7:ec:f7:d3:ac:38:e7:5e:3d:45:62:ad:0f:
+                    3a:1c:e6:b8:44:6f:ab:6e:40:29:ef:b7:73:02:d6:
+                    7e:d2:1f:17:85:8a:b5:31:58:28:87:eb:cc:fa:9f:
+                    cb:52:af:3e:f4:2a:eb:12:00:0e:49:f1:86:a7:a9:
+                    07:11:25:46:63:f5:a3:07:81:2f:2c:8a:0a:9f:0b:
+                    07:b1:84:1b:ab:b7:c5:5c:e7:e9:25:d2:b4:39:31:
+                    10:3d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                keyid:01:02:03
+
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+
+            X509v3 Subject Alternative Name: 
+                DNS:hi.co.uk
+            X509v3 Certificate Policies: 
+                Policy: X509v3 Any Policy
+
+    Signature Algorithm: sha256WithRSAEncryption
+         79:49:de:bd:53:3f:5b:18:91:72:bc:81:b2:24:41:d7:7f:f2:
+         b8:73:23:5c:e1:b4:74:ba:b0:e6:f9:9e:dc:17:38:dc:e4:dc:
+         d9:2a:aa:1f:09:02:ff:9c:3b:17:06:c0:0c:17:94:b3:45:8d:
+         0d:92:d7:5f:8d:94:06:3c:05:a1:41:3a:22:19:2c:d6:21:1f:
+         6e:84:f7:ff:4d:05:ca:11:08:c1:33:82:26:b6:6f:71:59:c1:
+         38:42:14:a4:8f:6a:cf:98:75:d8:a6:02:35:f6:da:1c:73:a7:
+         d6:96:86:96:c1:e2:16:a1:5e:ce:5a:58:21:dc:14:9a:ec:60:
+         fe:54:0e:79:da:e8:04:90:16:17:f4:b2:ed:fa:5f:e9:ed:6d:
+         82:3b:0d:46:4e:f2:94:da:f1:39:c5:71:7b:e8:1f:cf:ba:5b:
+         92:db:eb:db:e6:09:62:8f:0d:a5:b2:4e:9f:f6:14:bb:3f:0c:
+         e3:9e:92:35:96:78:e5:37:a2:a5:24:03:cf:3f:87:e2:17:bd:
+         0a:db:e4:1d:24:cd:9f:ea:c7:d6:00:10:2c:3d:9f:dd:19:7f:
+         72:a6:42:a6:91:82:1e:72:c1:d5:c5:66:a4:29:e0:23:b3:9c:
+         06:e7:84:fe:24:e7:61:67:05:94:2b:85:f4:81:28:b4:fb:bb:
+         7c:14:c8:c2
 -----BEGIN CERTIFICATE-----
 MIIEeTCCA2OgAwIBAgIBATALBgkqhkiG9w0BAQswgY8xFjAUBgNVBAMTDU1vdGhl
 ciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcxFjAUBgNVBAoTDU1vdGhlciBO

--- a/v2/testdata/dnsNameNoLongerValidTLD.pem
+++ b/v2/testdata/dnsNameNoLongerValidTLD.pem
@@ -1,3 +1,61 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 9222122447971639347 (0x7ffb8f816a816033)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = zlint test 78dd88
+        Validity
+            Not Before: Sep  1 00:00:00 2017 GMT
+            Not After : Sep  1 00:00:00 2018 GMT
+        Subject: CN = zlint.mcdonalds
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:c1:c8:31:f7:28:e1:a6:53:9f:bf:f4:09:66:62:
+                    0d:e0:1e:6b:9e:c1:89:7b:d2:87:2d:f2:99:6e:48:
+                    64:a5:14:bb:be:0c:e3:4e:aa:1c:a2:57:4d:24:cb:
+                    14:09:36:ac:3e:e8:b5:e4:35:2d:30:a9:54:b9:04:
+                    4c:fc:72:d4:8e:30:fa:b3:5b:8e:cc:11:42:73:da:
+                    82:16:f7:7e:29:22:4f:0e:c8:2e:74:d9:f8:46:7a:
+                    69:47:40:3d:78:1d:fd:b2:37:1a:d1:31:f9:c6:37:
+                    7a:de:4c:ae:ab:7e:6a:d2:c6:74:12:9a:b2:94:c8:
+                    c6:c1:b2:cf:08:6f:df:75:7a:80:ea:b9:6e:c6:70:
+                    17:44:58:88:d6:7b:19:99:e3:a3:58:3f:79:9f:ff:
+                    e0:89:3d:d1:2b:ea:b8:a6:8a:87:1b:81:a7:98:0b:
+                    83:18:69:f6:ef:b9:85:64:c3:b8:6a:1a:d8:01:ed:
+                    27:63:fc:1e:17:f8:98:2a:22:d7:9f:d4:f2:53:2e:
+                    fc:36:42:70:52:1b:54:89:15:5f:21:01:91:46:a0:
+                    25:ee:b7:13:c4:ab:80:d8:3d:ba:6d:0d:49:0b:1b:
+                    bd:35:de:83:11:0a:fb:65:26:34:c7:65:2f:30:8e:
+                    6a:68:75:7e:7a:cd:25:ba:c7:96:a7:14:ec:48:54:
+                    59:45
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zlint.mcdonalds
+    Signature Algorithm: sha256WithRSAEncryption
+         11:f0:e5:eb:17:33:1c:b1:72:97:a4:0d:0d:2c:dc:f4:ad:f5:
+         5a:fb:7b:4c:15:3e:03:e1:76:15:40:a5:13:5c:3e:f0:6c:05:
+         84:97:c9:1b:e3:9f:a2:48:ee:0e:92:e8:c3:e7:ad:e5:61:81:
+         d4:23:af:e2:89:ac:94:76:d0:3c:1f:07:41:d0:d7:d4:01:40:
+         23:f5:03:e4:fd:5b:71:21:e9:70:9a:e8:6f:86:5a:08:98:e2:
+         0f:0d:9c:88:63:5a:b1:72:dd:2f:5e:c3:f1:54:15:9a:db:17:
+         9a:44:75:b6:88:a1:46:55:c7:42:4c:5d:2d:f5:3d:04:ba:3b:
+         66:b0:1a:2e:c3:01:ef:1b:c9:a0:88:84:ad:38:56:31:80:d3:
+         fe:b5:0e:be:76:7a:bb:17:dd:88:e8:5d:16:5e:2f:99:c9:ea:
+         b8:b1:b2:8a:ba:29:92:56:64:3a:3a:2b:01:c5:c3:44:ea:b0:
+         04:0c:41:ab:91:25:0a:f3:35:a7:1f:a7:60:ae:43:ec:8a:c3:
+         25:59:9d:32:f8:a5:8c:4e:4a:42:f5:ed:77:4c:f4:b3:4b:b0:
+         57:75:02:5c:1f:25:b1:67:d8:14:a6:cf:b0:74:96:82:12:82:
+         e1:ee:9c:ae:d3:75:b0:5f:bf:cf:35:42:c3:fa:fd:64:d8:9e:
+         8a:51:b0:45
 -----BEGIN CERTIFICATE-----
 MIIDEzCCAfugAwIBAgIIf/uPgWqBYDMwDQYJKoZIhvcNAQELBQAwHDEaMBgGA1UE
 AxMRemxpbnQgdGVzdCA3OGRkODgwHhcNMTcwOTAxMDAwMDAwWhcNMTgwOTAxMDAw

--- a/v2/testdata/dnsNameNotYetValidTLD.pem
+++ b/v2/testdata/dnsNameNotYetValidTLD.pem
@@ -1,3 +1,61 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2232116547796066095 (0x1efa122c88a7df2f)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = zlint test 1b4f23
+        Validity
+            Not Before: Aug  7 00:00:00 2016 GMT
+            Not After : Aug  1 00:00:00 2017 GMT
+        Subject: CN = zlint.mcdonalds
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:e9:16:74:5c:50:fd:ad:36:33:34:86:65:61:40:
+                    bb:eb:da:34:be:64:07:3e:c9:fb:ff:28:7a:ba:0e:
+                    a0:21:dd:86:51:e8:bc:25:0b:0e:df:8f:43:33:26:
+                    b1:a6:dd:fc:e5:89:f2:35:f7:f0:18:df:bb:fb:54:
+                    69:ed:34:d3:76:45:4e:ca:2f:49:9a:93:82:59:63:
+                    ac:46:c2:25:e1:71:f9:f8:4f:4e:17:70:34:2c:ff:
+                    14:d0:f3:0f:79:c6:2e:49:80:33:12:14:96:97:10:
+                    66:3b:5e:89:96:b4:74:d6:92:ad:01:91:90:45:95:
+                    61:4f:56:b6:f3:27:4a:06:8c:5c:d1:69:6f:94:92:
+                    dc:61:cd:2f:4b:d4:69:d3:2e:21:83:cf:9e:d1:fa:
+                    e8:1c:63:5c:92:07:8a:5d:03:b5:ed:5c:df:d1:73:
+                    df:a6:9d:c8:20:68:60:57:c3:fe:7c:0d:64:7f:88:
+                    17:74:e7:a0:8c:f4:eb:1f:58:c1:47:55:60:71:e4:
+                    8b:0a:ba:6f:29:c5:71:59:fa:0f:d1:79:d5:f3:18:
+                    d6:41:14:75:b1:f8:a9:da:a7:d5:ab:c8:0b:51:92:
+                    92:9e:94:72:90:3d:ab:a1:df:d2:4b:a5:50:f9:f8:
+                    8c:9c:29:4b:0f:fe:d1:6f:1b:76:43:6b:93:74:66:
+                    c2:c9
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zlint.mcdonalds
+    Signature Algorithm: sha256WithRSAEncryption
+         3f:f8:a7:1a:b6:0a:86:b8:02:01:15:de:37:f2:7c:5d:c9:df:
+         0e:fe:b6:21:23:89:05:bc:7f:0e:a6:ca:d8:b0:d6:30:75:e0:
+         cd:5f:41:2e:dc:e3:6f:51:c8:3c:ec:1c:a8:41:4d:c0:10:74:
+         75:32:a5:93:75:b5:9d:39:72:ed:0e:4d:94:b4:c5:c3:a4:b9:
+         1d:01:44:a0:7a:c4:be:46:6f:84:6a:51:ec:b4:cd:35:f7:4e:
+         de:76:32:e8:86:59:06:11:db:2b:13:a2:60:de:2f:fd:d2:03:
+         02:7f:f0:6b:0b:cd:90:b2:bc:c0:64:d4:d7:c3:3e:22:a7:89:
+         f7:1e:51:9b:a4:56:56:2f:2c:4d:1f:b8:88:de:04:d3:ce:5c:
+         9c:00:32:78:88:11:66:79:b7:26:e3:1b:2a:f5:10:fc:71:21:
+         47:fd:b8:a4:49:83:64:3d:39:59:59:25:1d:78:76:0e:55:7b:
+         b7:c4:dd:59:fb:54:c3:66:ed:5d:77:7c:50:a3:8c:da:19:16:
+         55:da:51:65:5b:3e:00:c9:fc:19:83:35:b1:d5:80:6e:ec:33:
+         28:0a:8d:4e:a7:87:25:10:b5:f3:62:83:35:52:3a:97:1e:dc:
+         76:33:79:c5:5a:bc:cf:48:44:97:f9:62:fd:4d:d8:b0:ab:16:
+         59:cd:cb:db
 -----BEGIN CERTIFICATE-----
 MIIDEzCCAfugAwIBAgIIHvoSLIin3y8wDQYJKoZIhvcNAQELBQAwHDEaMBgGA1UE
 AxMRemxpbnQgdGVzdCAxYjRmMjMwHhcNMTYwODA3MDAwMDAwWhcNMTcwODAxMDAw

--- a/v2/testdata/dnsNameOnionTLD.pem
+++ b/v2/testdata/dnsNameOnionTLD.pem
@@ -1,3 +1,61 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2050924719016116481 (0x1c76592a6a060101)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = zlint test 6fb5e3
+        Validity
+            Not Before: Feb 20 00:00:00 2015 GMT
+            Not After : Feb 20 00:00:00 2016 GMT
+        Subject: CN = zlint.onion
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:d3:cf:55:71:96:a8:51:60:82:3d:12:84:61:82:
+                    01:67:64:d8:38:07:b7:93:7b:d1:40:c3:67:cd:dd:
+                    b0:bc:84:67:38:65:5c:69:91:33:30:84:6c:38:ae:
+                    65:c5:5f:02:39:7a:38:f1:55:9d:79:57:b8:75:47:
+                    07:55:63:9e:ff:21:a7:56:8b:be:9c:99:88:86:f9:
+                    36:64:2b:ac:a1:d8:7c:31:ad:c5:59:1e:c1:b3:06:
+                    53:d5:77:27:39:d6:68:a3:c6:5c:65:c3:d8:90:2d:
+                    2b:bd:9d:c4:39:9c:3f:53:53:af:1b:9c:6b:0f:3e:
+                    04:96:dd:40:7a:21:29:eb:76:e8:2c:95:7b:73:da:
+                    65:d0:cc:a4:51:cc:f7:6d:4c:d7:8c:e6:d8:bf:20:
+                    d9:01:a6:a4:b3:35:60:ac:c2:04:d4:02:d7:1c:8d:
+                    71:62:76:a5:10:4c:36:bf:16:c2:be:1d:71:45:95:
+                    66:17:32:d0:06:94:67:36:90:db:20:53:36:c4:55:
+                    5c:bb:cb:9c:68:29:43:b6:76:11:da:6e:c2:6c:da:
+                    ae:1c:57:c6:13:a9:2e:c0:cb:8d:de:2f:19:24:79:
+                    d8:28:83:27:5d:29:e9:4a:f7:3b:04:5a:6c:db:c9:
+                    bb:00:e1:30:e0:8e:a1:cf:92:1c:87:77:ab:82:29:
+                    66:f1
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zlint.onion
+    Signature Algorithm: sha256WithRSAEncryption
+         6f:63:1a:54:b8:27:4a:94:b1:eb:d0:8e:d4:82:0c:57:d0:c0:
+         71:7b:95:10:1e:8e:10:4c:b8:68:96:e4:de:3a:53:d1:a1:42:
+         c7:1a:67:40:6f:44:04:25:d1:96:a7:2e:d2:c7:fb:2d:d1:30:
+         8a:ec:74:16:a9:dd:78:71:95:0f:1f:e1:9f:ae:20:58:4c:f0:
+         d3:fc:39:80:a8:13:f2:56:fe:47:00:ac:04:94:97:b9:72:f3:
+         a3:f1:09:0b:90:1f:72:4b:85:3d:80:b2:95:64:c6:57:86:41:
+         f6:a3:3f:07:63:5e:d0:1d:50:8c:a4:32:98:d2:e1:72:09:d8:
+         01:63:b1:8f:62:55:a3:95:ab:7b:cd:fd:51:65:29:c0:85:77:
+         a8:2a:78:93:7b:a7:08:ff:ea:8e:76:01:91:62:f0:8e:e5:4f:
+         69:39:89:a1:c6:cc:b8:04:09:d5:3f:6f:93:e9:8f:3c:01:0b:
+         38:6b:9e:4b:bd:48:0b:c6:18:95:14:d0:da:42:0c:2d:24:50:
+         fa:b4:cb:7f:c8:5d:5b:9d:69:3d:17:29:ec:0a:ff:f9:17:c4:
+         9f:1d:21:34:99:ec:7a:2f:73:86:e9:1f:6a:a9:fc:19:2f:ee:
+         a1:b8:74:0a:91:d7:28:60:20:cf:6b:f2:51:ac:6f:d8:06:0e:
+         40:92:0b:8f
 -----BEGIN CERTIFICATE-----
 MIIDCzCCAfOgAwIBAgIIHHZZKmoGAQEwDQYJKoZIhvcNAQELBQAwHDEaMBgGA1UE
 AxMRemxpbnQgdGVzdCA2ZmI1ZTMwHhcNMTUwMjIwMDAwMDAwWhcNMTYwMjIwMDAw

--- a/v2/testdata/dnsNameWasValidTLD.pem
+++ b/v2/testdata/dnsNameWasValidTLD.pem
@@ -1,3 +1,61 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3589494128799465810 (0x31d071e466714152)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = zlint test 6afd40
+        Validity
+            Not Before: Aug  8 00:00:00 2016 GMT
+            Not After : Aug 31 00:00:00 2017 GMT
+        Subject: CN = zlint.mcdonalds
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:c3:6a:33:87:cf:6f:fc:6a:3f:25:08:1a:0a:45:
+                    ae:43:48:9c:c4:9f:95:57:63:50:10:09:82:7f:f3:
+                    27:44:bc:ae:27:2c:d2:0b:40:c4:cb:f8:8d:ce:d0:
+                    c8:f9:ef:50:55:9c:c6:c0:8f:d0:b2:84:41:61:ba:
+                    12:68:af:14:70:21:d7:8e:c1:79:8a:83:96:c8:e2:
+                    83:f2:2a:08:8c:8c:98:b9:52:0d:0d:3e:ba:5b:59:
+                    bc:6d:f1:4d:33:8d:80:b4:fb:60:3c:39:be:ec:c5:
+                    a1:7f:7a:53:9f:dc:69:71:98:1f:20:1c:99:a5:d2:
+                    0f:97:6b:72:7e:98:32:0e:04:a9:b0:60:c2:87:21:
+                    3f:ad:1f:35:cc:d8:8a:0c:45:23:49:ce:6f:14:47:
+                    02:4f:30:e7:dd:59:ca:d5:78:6c:db:53:cf:4e:02:
+                    6e:67:a0:2c:8b:2d:d5:c7:2b:67:94:ba:a1:ef:ce:
+                    9b:e4:7b:ba:7b:40:ec:3b:f7:e9:fd:33:0c:77:07:
+                    42:25:c7:22:8b:0c:4e:89:d6:aa:86:fe:1f:ce:25:
+                    48:da:31:04:5e:24:1a:25:8c:2f:34:3a:08:85:cd:
+                    c1:a8:03:41:58:67:8b:27:17:df:ad:77:d5:0b:38:
+                    fd:9d:05:c8:21:84:59:cd:c5:2c:4b:f0:e1:62:47:
+                    3b:87
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zlint.mcdonalds
+    Signature Algorithm: sha256WithRSAEncryption
+         83:9a:2c:f4:42:bd:6b:b8:b6:7d:ff:50:3c:ec:47:df:b9:f0:
+         a5:36:8b:3e:b4:7f:3b:ff:e6:d2:31:4f:57:2c:bd:9c:26:bf:
+         3c:1e:be:9e:0f:ba:0c:b9:f4:27:f8:8e:fe:2e:c7:1d:19:9b:
+         76:d7:c2:f8:cc:8f:69:a6:cd:72:6d:4a:e3:3a:e4:bc:90:14:
+         ca:62:03:44:50:51:3c:7c:db:b3:5c:ee:7c:ac:b5:fb:39:ff:
+         54:53:bf:18:f6:a1:ab:2c:ed:88:28:7c:1c:05:6c:d2:f1:0f:
+         01:9b:ca:63:8e:bb:47:b6:aa:e3:4b:fc:74:6f:7c:ec:c1:ba:
+         6a:1f:49:6b:5d:ad:ca:89:68:9c:a3:53:aa:14:99:8a:69:a3:
+         b8:40:12:51:00:ba:eb:37:3a:4a:e1:e7:97:63:c0:27:29:b8:
+         c1:45:58:90:c1:73:d7:0e:3d:24:0d:3e:ed:16:9b:0f:ed:22:
+         63:93:74:6a:5a:57:7e:90:16:63:eb:4b:c9:25:63:43:73:45:
+         4e:ee:89:b5:eb:66:17:e3:3c:70:b9:6c:b0:3e:59:c2:42:5a:
+         34:cf:f3:30:fe:bd:40:5f:c8:52:b4:47:97:20:32:ab:bb:d9:
+         27:c9:f3:6f:1a:d1:10:06:04:82:f5:43:01:fb:97:f8:90:b9:
+         6e:e9:fc:34
 -----BEGIN CERTIFICATE-----
 MIIDEzCCAfugAwIBAgIIMdBx5GZxQVIwDQYJKoZIhvcNAQELBQAwHDEaMBgGA1UE
 AxMRemxpbnQgdGVzdCA2YWZkNDAwHhcNMTYwODA4MDAwMDAwWhcNMTcwODMxMDAw

--- a/v2/testdata/ecdsaP256ValidKUs.pem
+++ b/v2/testdata/ecdsaP256ValidKUs.pem
@@ -1,3 +1,86 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            08:fd:33:75:70:34:d4:44:b1:e9:e4:e3:7e:2b:73:7f
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: C = US, ST = CA, L = San Francisco, O = "CloudFlare, Inc.", CN = CloudFlare Inc ECC CA-2
+        Validity
+            Not Before: May  3 00:00:00 2019 GMT
+            Not After : May  3 12:00:00 2020 GMT
+        Subject: C = US, ST = CA, L = San Francisco, O = "CloudFlare, Inc.", CN = scotthelme.co.uk
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:61:06:08:39:83:a4:03:44:8d:03:19:6b:b2:f4:
+                    e7:af:b0:48:3a:83:66:51:a0:45:1b:6a:17:5f:22:
+                    9f:a6:19:1c:ff:9c:17:5c:c5:35:13:3d:7e:a6:a8:
+                    c5:1d:2c:1a:02:d0:a4:81:3c:d3:34:41:0e:c6:4b:
+                    83:89:c2:4b:a8
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:3E:74:2D:1F:CF:45:75:04:7E:3F:C0:A2:87:3E:4C:43:83:51:13:C6
+
+            X509v3 Subject Key Identifier: 
+                A5:9B:64:CC:F3:79:A1:6D:6C:EA:2C:BD:92:65:19:9D:1D:B8:7F:58
+            X509v3 Subject Alternative Name: 
+                DNS:scotthelme.co.uk, DNS:*.scotthelme.co.uk
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://crl3.digicert.com/CloudFlareIncECCCA2.crl
+
+                Full Name:
+                  URI:http://crl4.digicert.com/CloudFlareIncECCCA2.crl
+
+            X509v3 Certificate Policies: 
+                Policy: 2.16.840.1.114412.1.1
+                  CPS: https://www.digicert.com/CPS
+                Policy: 2.23.140.1.2.2
+
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.digicert.com
+                CA Issuers - URI:http://cacerts.digicert.com/CloudFlareIncECCCA-2.crt
+
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : EE:4B:BD:B7:75:CE:60:BA:E1:42:69:1F:AB:E1:9E:66:
+                                A3:0F:7E:5F:B0:72:D8:83:00:C4:7B:89:7A:A8:FD:CB
+                    Timestamp : May  3 12:22:38.201 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:44:02:20:1C:0F:67:21:F6:A0:32:B1:9C:65:20:5A:
+                                AB:62:31:25:CA:FF:BA:7C:F6:F0:05:9F:82:15:28:09:
+                                5B:B7:78:72:02:20:52:7A:4E:75:AB:81:CB:D3:97:21:
+                                E4:1E:AD:8D:04:97:1A:A5:3C:31:68:D2:A4:F1:DF:83:
+                                41:A0:F9:9F:C8:E6
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 5E:A7:73:F9:DF:56:C0:E7:B5:36:48:7D:D0:49:E0:32:
+                                7A:91:9A:0C:84:A1:12:12:84:18:75:96:81:71:45:58
+                    Timestamp : May  3 12:22:38.096 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:45:02:21:00:E5:0D:CA:41:93:05:76:DB:9B:68:A0:
+                                68:83:99:65:F8:6F:0B:E9:92:8E:A7:99:79:D0:F1:10:
+                                5E:4A:5B:54:18:02:20:5D:40:AC:90:0C:E7:2C:A3:DC:
+                                A9:FE:DE:E7:97:84:8F:DC:70:6A:0A:36:F2:B2:59:9F:
+                                2E:AC:B4:FF:4D:A9:A9
+    Signature Algorithm: ecdsa-with-SHA256
+         30:44:02:1f:55:71:11:9c:1d:54:90:aa:6a:ef:7c:6c:bf:41:
+         f7:a3:44:82:fd:51:9d:ca:e2:22:cd:37:35:1c:77:8f:ea:02:
+         21:00:a4:88:a7:8c:df:80:e2:cf:de:5e:3a:cb:6c:87:ce:2a:
+         fd:3d:d7:82:73:e4:46:51:58:38:3f:82:20:00:03:6f
 -----BEGIN CERTIFICATE-----
 MIIE0DCCBHegAwIBAgIQCP0zdXA01ESx6eTjfitzfzAKBggqhkjOPQQDAjBvMQsw
 CQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28x

--- a/v2/testdata/ecdsaP384InvalidKUs.pem
+++ b/v2/testdata/ecdsaP384InvalidKUs.pem
@@ -1,3 +1,60 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2675329675607315554 (0x2520ae2a5ba29462)
+        Signature Algorithm: ecdsa-with-SHA384
+        Issuer: C = JP, O = National Institute of Informatics, CN = NII Open Domain CA - G6
+        Validity
+            Not Before: Sep 13 07:37:09 2018 GMT
+            Not After : Oct 14 07:37:09 2020 GMT
+        Subject: C = JP, ST = Tokyo, O = National Institute of Informatics, OU = National Research Grid Initiative, CN = ca-perf.naregi.org
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (384 bit)
+                pub:
+                    04:fd:20:ff:bf:be:9a:4e:af:e1:c8:03:a5:d9:2d:
+                    8d:27:90:88:de:7b:1b:25:42:97:6c:e2:37:83:ba:
+                    6f:48:17:ba:b0:b6:c1:dc:38:d2:cb:0b:68:51:d4:
+                    1a:38:cc:c0:69:f0:69:f4:b4:5b:bb:0e:72:02:0c:
+                    4a:f3:8f:62:87:0c:05:5d:c5:a3:f2:d4:21:33:1f:
+                    29:41:00:38:0e:c5:57:11:e1:f1:45:6f:a8:c8:2f:
+                    11:97:16:91:6c:38:f5
+                ASN1 OID: secp384r1
+                NIST CURVE: P-384
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:39:7B:EB:89:7B:E5:2E:D5:F7:1E:95:14:CA:EE:AE:DD:58:94:46:B0
+
+            Authority Information Access: 
+                OCSP - URI:http://niig6.ocsp.secomtrust.net
+
+            X509v3 Subject Alternative Name: 
+                DNS:ca-perf.naregi.org, DNS:xn--u8jta7e.naregi.org
+            X509v3 Certificate Policies: 
+                Policy: 1.3.6.1.4.1.32264.3.2.1.1
+                  CPS: https://repo1.secomtrust.net/sppca/nii/odca3/
+                Policy: 2.23.140.1.2.2
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://repo1.secomtrust.net/sppca/nii/odca3/fullcrlg6.crl
+
+            X509v3 Subject Key Identifier: 
+                B1:C4:C2:00:1A:51:88:D3:9C:2D:2B:33:67:9A:2A:41:38:79:5A:93
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            CT Precertificate Poison: critical
+                NULL
+    Signature Algorithm: ecdsa-with-SHA384
+         30:65:02:31:00:d8:91:22:ef:e7:d3:12:a7:89:78:6a:50:05:
+         8b:a0:aa:1b:c9:f2:f5:a8:a4:d4:af:03:f4:94:80:12:2a:7f:
+         86:9f:00:0b:92:80:38:55:83:d6:fe:b6:0b:f7:23:83:2a:02:
+         30:71:bc:0d:60:4d:46:d7:cd:a6:64:39:b5:e0:4d:6b:60:0d:
+         39:42:bd:d8:84:2f:79:e7:90:11:8c:8c:17:ab:a9:e7:d6:e8:
+         df:0a:ca:5c:7b:6c:ae:83:86:0f:b7:26:39
 -----BEGIN CERTIFICATE-----
 MIIDzjCCA1SgAwIBAgIIJSCuKluilGIwCgYIKoZIzj0EAwMwWzELMAkGA1UEBhMC
 SlAxKjAoBgNVBAoTIU5hdGlvbmFsIEluc3RpdHV0ZSBvZiBJbmZvcm1hdGljczEg

--- a/v2/testdata/evAllGood.pem
+++ b/v2/testdata/evAllGood.pem
@@ -1,3 +1,119 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 4642058949754430460 (0x406be805268923fc)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = TR, L = Ankara, O = E-Tu\C4\9Fra EBG Bili\C5\9Fim Teknolojileri ve Hizmetleri A.\C5\9E., OU = E-Tu\C4\9Fra Sertifikasyon Merkezi, CN = E-Tugra Extended Validated CA
+        Validity
+            Not Before: Jan 22 12:10:23 2018 GMT
+            Not After : Jan 22 00:19:00 2020 GMT
+        Subject: C = TR, ST = ANKARA, L = \C3\87ANKAYA, O = KEPKUR KAYITLI ELEKTRON\C4\B0K POSTA H\C4\B0ZMETLER\C4\B0 A.\C5\9E., serialNumber = 380432, CN = www.kepkur.com.tr, postalCode = 06520, street = Ehlibeyt Mah. Ceyhun At\C4\B1f Kansu cad. no:130/49 Balgat/ANKARA, jurisdictionC = TR
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:96:9b:2d:d5:3b:b6:b2:3c:01:3f:31:fc:1b:60:
+                    78:bb:eb:b9:e5:33:1e:92:18:80:0d:cc:f5:82:40:
+                    9c:75:bb:66:4a:22:0d:5a:f4:a4:4c:78:a0:28:58:
+                    cc:92:3e:0a:e3:8d:c6:73:86:c8:cc:aa:f0:0b:56:
+                    60:c9:bd:5c:6f:fa:2d:94:26:f2:82:67:0f:34:19:
+                    91:4e:84:d3:81:01:38:71:59:5e:b6:37:64:91:dc:
+                    b3:ac:67:db:e7:29:38:65:31:4f:6a:6f:84:f9:17:
+                    81:7a:f9:1e:52:a8:6f:68:79:64:b5:e2:5e:7c:93:
+                    56:58:0d:f6:20:b8:d1:ee:37:7c:06:33:90:32:d1:
+                    02:6f:35:39:af:3f:47:e8:93:4a:3f:d9:87:22:e9:
+                    24:94:c6:97:0e:dd:9f:b7:b2:ff:45:c4:53:35:7b:
+                    3d:11:50:cc:66:3d:14:bd:51:ad:ed:98:a3:60:a5:
+                    b7:7e:ee:7c:42:15:fe:3d:97:a0:12:41:e4:40:03:
+                    4e:ba:5a:90:18:ef:92:ed:90:f7:fd:1f:03:93:5d:
+                    44:b0:12:ec:93:1c:62:c7:8b:8e:ee:57:97:c4:bb:
+                    ac:08:25:14:eb:b5:28:5d:59:c3:72:97:58:55:4a:
+                    c1:c4:77:96:7d:8a:ea:1e:06:2d:33:59:c2:52:e3:
+                    e8:7d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: 
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                keyid:4D:BF:FA:CB:C0:AF:61:55:A0:0E:29:E7:D7:13:61:3A:D8:F1:3D:DC
+
+            Authority Information Access: 
+                CA Issuers - URI:http://www.e-tugra.com/crt/etugra_sslev_v2.crt
+                OCSP - URI:http://ocsp.e-tugra.com/status/ocsp
+
+            X509v3 Subject Alternative Name: 
+                DNS:www.kepkur.com.tr, DNS:store.kepkur.com.tr, DNS:webmail.kepkur.com.tr, DNS:kepkur.com, DNS:www.kepkur.com, DNS:www.hs06.kep.tr, DNS:webmail.hs06.kep.tr, DNS:hs06.kep.tr, DNS:pos.kepkur.com.tr, DNS:kepkur.com.tr
+            X509v3 Certificate Policies: 
+                Policy: 2.16.792.3.0.4.1.1.4
+                  CPS: http://www.e-tugra.com/cps
+
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://crl.e-tugra.com/etugra_sslev.crl
+
+                Full Name:
+                  URI:http://crl1.e-tugra.com/etugra_sslev.crl
+
+            X509v3 Subject Key Identifier: 
+                D7:4C:D6:FB:89:92:40:9C:7F:A1:BE:E0:93:36:4B:1B:F6:7D:BB:FF
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment, Data Encipherment, Key Agreement
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : DD:EB:1D:2B:7A:0D:4F:A6:20:8B:81:AD:81:68:70:7E:
+                                2E:8E:9D:01:D5:5C:88:8D:3D:11:C4:CD:B6:EC:BE:CC
+                    Timestamp : Jan 22 12:20:24.381 2018 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:46:02:21:00:A3:D5:C8:78:E9:62:7F:6C:1E:C7:E7:
+                                C5:35:42:FE:DB:AC:DC:BA:66:DA:BB:9F:8C:5B:F5:D8:
+                                62:34:F2:AC:FF:02:21:00:B0:54:CE:E0:91:70:F5:10:
+                                C5:40:60:95:4E:6D:31:B7:D6:55:5B:72:8A:A4:0F:2C:
+                                09:4F:78:1F:02:0A:42:FF
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : EE:4B:BD:B7:75:CE:60:BA:E1:42:69:1F:AB:E1:9E:66:
+                                A3:0F:7E:5F:B0:72:D8:83:00:C4:7B:89:7A:A8:FD:CB
+                    Timestamp : Jan 22 12:20:24.847 2018 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:44:02:20:39:27:37:B5:0A:AA:57:CB:9A:91:BC:1D:
+                                20:13:2C:0A:78:61:0F:0E:F8:2B:08:B5:07:FF:6B:1A:
+                                14:8B:63:5E:02:20:1F:8C:BE:1C:7F:06:62:54:8F:29:
+                                46:7B:55:CA:92:73:51:CF:58:1D:21:03:A1:CC:11:60:
+                                E5:F7:E3:7D:C7:14
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : A4:B9:09:90:B4:18:58:14:87:BB:13:A2:CC:67:70:0A:
+                                3C:35:98:04:F9:1B:DF:B8:E3:77:CD:0E:C8:0D:DC:10
+                    Timestamp : Jan 22 12:20:26.260 2018 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:44:02:20:04:0B:B7:0D:9D:14:D4:7A:29:02:20:C1:
+                                9B:50:6C:C1:CF:C1:0E:1E:28:0E:90:E9:D8:91:38:F6:
+                                76:A7:12:93:02:20:7A:0B:7C:87:88:95:EB:58:43:2A:
+                                66:07:8D:79:DB:90:D1:8F:8E:83:EB:A6:C5:5C:07:CC:
+                                CC:69:7A:2D:01:AF
+    Signature Algorithm: sha256WithRSAEncryption
+         41:fe:74:08:0f:5f:31:e7:d6:6c:58:bb:a7:02:c0:ce:2a:84:
+         fb:73:9f:74:eb:9b:ca:79:59:0e:32:e1:cb:12:82:15:fb:82:
+         e1:ee:b6:61:2c:d0:3e:be:48:9b:7b:30:2a:04:4a:ac:72:49:
+         76:df:84:df:1e:03:04:b1:0e:07:81:85:ec:31:bf:57:55:8a:
+         02:e2:4f:f3:4d:76:d5:27:7b:3c:4f:58:d9:17:1d:0f:0f:85:
+         1e:6b:fb:3b:4b:36:fe:7a:81:ac:b9:54:cc:97:88:ae:69:62:
+         fa:f6:fc:30:c0:a2:d7:93:4d:e7:03:cb:67:38:26:b4:b9:34:
+         14:bf:e4:62:a4:82:5b:37:3d:a3:6f:4c:da:7f:95:5c:08:35:
+         10:be:2c:2d:b9:54:53:ab:e5:2f:30:be:04:ab:d2:9f:0b:a9:
+         a0:29:7d:38:5f:33:4e:ac:19:39:16:05:25:7e:0c:6d:15:3e:
+         e4:c1:c8:18:7e:30:87:98:72:5f:22:61:d3:26:49:c2:bf:8b:
+         35:6c:e5:90:ed:7e:cd:36:f6:74:c3:49:5b:a0:77:71:b9:1c:
+         15:65:f6:51:a7:de:ce:0f:2c:e1:38:29:5e:39:89:25:03:92:
+         68:44:cb:5a:d1:21:5f:4e:26:2b:bf:d8:3c:70:29:4a:47:9d:
+         77:12:5f:0a
 -----BEGIN CERTIFICATE-----
 MIIIJzCCBw+gAwIBAgIIQGvoBSaJI/wwDQYJKoZIhvcNAQELBQAwgbExCzAJBgNV
 BAYTAlRSMQ8wDQYDVQQHDAZBbmthcmExQDA+BgNVBAoMN0UtVHXEn3JhIEVCRyBC

--- a/v2/testdata/extraCommonNames.pem
+++ b/v2/testdata/extraCommonNames.pem
@@ -1,3 +1,89 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            21:e8:e2:0b:88:8d:38:54:aa:b9:89:b6
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = DE, O = Verein zur Foerderung eines Deutschen Forschungsnetzes e. V., OU = DFN-PKI, CN = DFN-Verein Global Issuing CA
+        Validity
+            Not Before: Nov 11 13:39:08 2019 GMT
+            Not After : Feb 12 13:39:08 2022 GMT
+        Subject: C = DE, ST = Sachsen, L = Leipzig, O = Universitaet Leipzig, CN = planer.vetmed.uni-leipzig.de, CN = vote.vetmed.uni-leipzig.de
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:c9:ec:79:a9:ca:7b:74:de:16:06:96:d2:e9:19:
+                    51:32:15:7a:07:6c:e4:da:56:9d:27:8e:da:be:85:
+                    8e:6a:64:ba:26:41:7c:26:2a:2c:b6:e1:6c:e9:44:
+                    06:3a:a1:ce:cc:1a:2d:bf:90:52:a3:61:93:53:ce:
+                    ff:d3:f1:05:40:4c:dc:04:2f:34:ac:a2:a9:28:b0:
+                    fd:f5:90:2c:04:a4:c4:87:b4:1f:06:b2:44:da:ee:
+                    a9:80:c7:ca:78:a2:cc:57:1b:04:dd:e0:fd:11:1d:
+                    c1:25:67:45:de:4c:cd:a2:08:d5:45:53:ab:f0:16:
+                    b9:77:06:5c:c9:3e:fb:b5:da:12:1e:61:45:e6:0b:
+                    4d:92:86:b3:3d:97:0e:7c:42:08:68:6e:31:a6:c2:
+                    87:5d:c6:78:3a:3a:e7:93:cb:39:f0:7a:74:b1:93:
+                    5a:26:ce:09:f9:0e:12:82:c3:43:84:cf:e2:20:2b:
+                    0f:45:b6:54:1f:6f:e0:34:5d:8c:6a:ad:ba:17:ca:
+                    1b:35:c8:b5:fb:17:92:2d:80:fb:95:68:d6:28:e7:
+                    14:d9:04:3e:da:e6:1e:32:e3:6c:b8:2b:1c:4b:82:
+                    6d:8b:fa:16:57:c9:cd:ec:9e:2f:00:24:40:a5:4f:
+                    48:0a:4c:de:5e:ae:32:4c:05:51:ef:a6:70:02:4c:
+                    69:8d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.2
+                Policy: 1.3.6.1.4.1.22177.300.30
+                Policy: 1.3.6.1.4.1.22177.300.1.1.4
+                Policy: 1.3.6.1.4.1.22177.300.1.1.4.4
+                Policy: 1.3.6.1.4.1.22177.300.2.1.4.4
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication
+            X509v3 Subject Key Identifier: 
+                AA:A5:5B:C9:5A:63:4C:D3:19:2E:6D:E5:E6:DA:44:F3:11:B6:3D:A8
+            X509v3 Authority Key Identifier: 
+                keyid:6B:3A:98:8B:F9:F2:53:89:DA:E0:AD:B2:32:1E:09:1F:E8:AA:3B:74
+
+            X509v3 Subject Alternative Name: 
+                DNS:planer.vetmed.uni-leipzig.de, DNS:vote.vetmed.uni-leipzig.de
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://cdp1.pca.dfn.de/dfn-ca-global-g2/pub/crl/cacrl.crl
+
+                Full Name:
+                  URI:http://cdp2.pca.dfn.de/dfn-ca-global-g2/pub/crl/cacrl.crl
+
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.pca.dfn.de/OCSP-Server/OCSP
+                CA Issuers - URI:http://cdp1.pca.dfn.de/dfn-ca-global-g2/pub/cacert/cacert.crt
+                CA Issuers - URI:http://cdp2.pca.dfn.de/dfn-ca-global-g2/pub/cacert/cacert.crt
+
+            CT Precertificate Poison: critical
+                NULL
+    Signature Algorithm: sha256WithRSAEncryption
+         2b:1c:b0:83:26:f6:2e:8b:8d:1a:8d:60:1b:9e:65:e0:89:6e:
+         b2:8e:39:0d:11:ad:ec:68:0b:7d:6c:3c:44:0f:05:e7:99:54:
+         6d:73:e4:bb:f5:11:b2:10:f1:3f:1e:98:e2:29:24:33:05:2b:
+         2c:06:38:6b:43:89:3b:9c:7a:70:bb:39:d9:ce:1a:28:1d:8b:
+         6f:ad:ea:d8:6a:97:a1:86:35:ba:8e:7d:9a:f1:25:18:bc:c2:
+         70:9e:81:da:2f:87:9c:48:a2:68:f4:cc:c3:68:39:38:4f:d4:
+         a8:6a:0d:8c:7b:f9:cf:c7:2f:e5:e7:0c:b1:ea:df:c1:f6:11:
+         d2:0d:df:12:99:c5:32:ad:ca:e4:40:80:19:9e:1d:e2:ed:72:
+         74:7f:01:51:c5:1d:bb:6b:96:d5:45:f0:71:f8:96:04:a9:b8:
+         94:ff:f0:95:45:c3:2b:50:5f:4b:62:2d:38:1e:1e:ef:ad:41:
+         6c:62:ad:ac:31:22:fa:63:45:a2:88:3c:99:35:55:03:c8:08:
+         b2:24:23:c0:97:88:f6:aa:40:dd:cf:3e:94:e1:e0:ca:51:2f:
+         ac:0d:ab:d5:de:44:0c:d7:e7:12:b5:a5:c4:d3:89:f5:14:f7:
+         86:f5:dc:06:ae:b5:27:a6:93:e9:18:76:dd:e1:0b:1a:87:aa:
+         1e:ac:ac:9b
 -----BEGIN CERTIFICATE-----
 MIIGSDCCBTCgAwIBAgIMIejiC4iNOFSquYm2MA0GCSqGSIb3DQEBCwUAMIGNMQsw
 CQYDVQQGEwJERTFFMEMGA1UECgw8VmVyZWluIHp1ciBGb2VyZGVydW5nIGVpbmVz

--- a/v2/testdata/keyCertSignCA.pem
+++ b/v2/testdata/keyCertSignCA.pem
@@ -1,3 +1,71 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Mother Nature, OU = Everything, O = Mother Nature, postalCode = postalcode, C = US, GN = givenname, SN = surname
+        Validity
+            Not Before: Aug 29 22:36:57 2017 GMT
+            Not After : Nov 10 23:36:57 2017 GMT
+        Subject: CN = gov.us, OU = Chaos, O = org, street = 3210 Holly Mill Run, ST = province, postalCode = 30062, GN = hello, SN = surname
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:cd:8a:64:cb:80:d6:fb:13:76:c7:47:39:0f:e2:
+                    58:25:13:1d:18:41:f7:27:88:28:f3:bd:63:f2:bb:
+                    78:c3:37:e6:1c:d7:30:8f:f7:5d:42:0a:82:33:a1:
+                    b4:ba:ca:f1:57:27:f9:9b:9b:36:19:22:0c:5c:c3:
+                    1e:96:72:66:57:47:a5:81:25:28:4e:04:2d:d4:b4:
+                    93:51:ce:f8:5b:89:3b:7d:7b:bc:ba:1d:63:80:dc:
+                    6b:f4:cb:00:b4:59:21:cd:82:72:d9:8c:7f:cb:73:
+                    7e:6c:1e:6b:85:ec:f2:26:df:30:11:08:4a:4c:ed:
+                    e9:ec:dc:a0:43:7c:85:0c:5a:e0:38:17:2d:b6:f2:
+                    b9:79:31:f7:44:24:12:58:46:e6:d9:fd:97:53:6b:
+                    7c:36:11:5d:93:b8:c3:30:b8:5d:e5:0d:bc:42:cd:
+                    c9:c8:e6:00:b7:c2:cf:ca:e1:7a:3b:2b:e0:19:cf:
+                    98:01:db:cf:0c:6a:4e:fc:e5:e9:b5:8b:f4:4c:04:
+                    c8:0a:4b:0d:75:2f:0b:b4:ea:25:2c:17:fe:43:3a:
+                    9f:3b:38:af:f7:c6:2f:49:7b:9e:c3:6c:bb:3e:12:
+                    7a:a6:29:dd:98:81:2f:8a:bc:fd:52:49:bb:f7:d5:
+                    da:a7:24:8c:af:b9:2c:9a:b9:8a:eb:0f:42:77:d2:
+                    ac:07
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment, Certificate Sign
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Authority Key Identifier: 
+                keyid:01:02:03
+
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+
+            X509v3 Subject Alternative Name: 
+                DNS:hell,o.com.uk
+            X509v3 Certificate Policies: 
+                Policy: X509v3 Any Policy
+
+    Signature Algorithm: sha256WithRSAEncryption
+         2b:e6:1d:50:2d:ec:e0:e3:07:e4:49:68:f1:ba:70:4f:72:de:
+         d1:5d:bf:5e:c6:e2:77:7e:70:1e:87:cf:67:0a:81:3f:ca:8b:
+         a4:1c:a2:e6:a5:86:59:06:6c:a1:d0:29:5a:4e:c0:f4:10:af:
+         e4:91:c5:25:04:d1:c2:f3:9b:a9:a5:bf:03:6d:59:3d:82:ee:
+         c6:d4:01:74:ed:4f:07:eb:89:cf:87:4c:94:11:40:76:87:97:
+         98:ab:62:3a:8d:2d:2d:6a:5c:de:b1:db:c1:fa:37:02:f7:f3:
+         46:79:37:b1:97:97:72:d2:03:55:b6:cb:2d:5c:48:48:03:61:
+         60:de:e7:f0:8b:62:02:a8:3c:66:71:4c:55:25:e3:e2:dc:12:
+         49:3e:98:c7:03:08:41:2f:c0:9c:4f:37:9a:46:12:4b:11:6c:
+         8f:c2:55:c4:eb:f3:30:3c:04:e5:d8:04:ae:26:02:ae:17:5a:
+         20:10:a5:a4:20:ec:1e:e8:2f:ea:fa:fd:c8:a7:7e:de:b6:26:
+         fb:a0:55:07:20:ac:6b:f6:98:63:c9:29:58:ea:1f:29:96:fe:
+         a6:74:d5:39:95:50:76:1f:3a:91:82:82:8a:de:af:f5:29:ae:
+         7b:26:98:11:0c:17:79:45:4f:20:be:19:8f:95:87:64:f6:df:
+         07:af:97:dd
 -----BEGIN CERTIFICATE-----
 MIIEgTCCA2ugAwIBAgIBATALBgkqhkiG9w0BAQswgY8xFjAUBgNVBAMTDU1vdGhl
 ciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcxFjAUBgNVBAoTDU1vdGhlciBO

--- a/v2/testdata/mpCrossCertNoEKU.pem
+++ b/v2/testdata/mpCrossCertNoEKU.pem
@@ -1,3 +1,78 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 9197242317802154860 (0x7fa32b28b1c9ab6c)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = Texas, L = Houston, O = SSL Corporation, CN = SSL.com EV Root Certification Authority RSA R2
+        Validity
+            Not Before: Feb 14 18:08:58 2019 GMT
+            Not After : Feb 12 18:08:58 2027 GMT
+        Subject: C = US, ST = Texas, L = Houston, O = SSL Corporation, CN = SSL.com EV Root Certification Authority ECC
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (384 bit)
+                pub:
+                    04:aa:12:47:90:98:1b:fb:ef:c3:40:07:83:20:4e:
+                    f1:30:82:a2:06:d1:f2:92:86:61:f2:f6:21:68:ca:
+                    00:c4:c7:ea:43:00:54:86:dc:fd:1f:df:00:b8:41:
+                    62:5c:dc:70:16:32:de:1f:99:d4:cc:c5:07:c8:08:
+                    1f:61:16:07:51:3d:7d:5c:07:53:e3:35:38:8c:df:
+                    cd:9f:d9:2e:0d:4a:b6:19:2e:5a:70:5a:06:ed:be:
+                    f0:a1:b0:ca:d0:09:29
+                ASN1 OID: secp384r1
+                NIST CURVE: P-384
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Authority Key Identifier: 
+                keyid:F9:60:BB:D4:E3:D5:34:F6:B8:F5:06:80:25:A7:73:DB:46:69:A8:9E
+
+            Authority Information Access: 
+                CA Issuers - URI:http://www.ssl.com/repository/SSLcom-RootCA-EV-RSA-4096-R2.crt
+                OCSP - URI:http://ocsps.ssl.com
+
+            X509v3 Certificate Policies: 
+                Policy: X509v3 Any Policy
+
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://crls.ssl.com/SSLcom-RootCA-EV-RSA-4096-R2.crl
+
+            X509v3 Subject Key Identifier: 
+                5B:CA:5E:E5:DE:D2:81:AA:CD:A8:2D:64:51:B6:D9:72:9B:97:E6:4F
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+    Signature Algorithm: sha256WithRSAEncryption
+         4b:5b:cf:1d:98:b5:54:af:79:7c:23:02:03:b5:25:1a:cf:a3:
+         14:69:9e:33:94:b3:10:c8:73:2f:49:71:cf:4d:79:5b:fc:a6:
+         83:57:4a:6c:5b:f4:cd:a0:89:62:75:96:58:02:26:22:e7:ed:
+         22:2c:fb:81:66:13:4d:1b:60:80:77:2b:f3:a7:38:fc:f8:2a:
+         36:50:51:51:35:74:ff:0c:79:db:3b:ad:f4:59:89:0c:6a:0d:
+         63:28:20:31:8a:d5:72:3a:52:0d:60:43:1e:10:f3:62:b1:1b:
+         40:15:65:6f:26:dc:07:83:f7:a3:98:5a:3f:55:5d:80:1b:e7:
+         37:70:ab:0f:f6:f3:16:92:62:0b:28:a9:44:84:4e:31:4d:08:
+         b7:8f:1b:2f:88:b3:5e:00:9b:73:05:e6:44:69:d3:ff:13:92:
+         d5:26:a0:bb:5a:75:8f:85:f4:c1:7d:90:6e:9e:d0:8c:e3:c3:
+         1b:14:a4:9c:c1:99:0c:3e:cc:b6:54:25:6f:dd:0a:cd:b7:74:
+         7e:25:fa:63:13:bb:db:9d:ad:ec:2a:1d:b2:5c:71:77:78:26:
+         93:d2:2f:85:be:59:c1:7d:b3:dc:a6:4f:c1:c9:81:0f:b2:35:
+         1e:f0:94:f8:83:26:f9:2c:45:9d:00:01:06:25:72:b5:62:69:
+         a4:67:63:b0:1f:86:6a:d2:d5:0a:7f:55:42:e1:5d:01:71:c4:
+         e9:90:74:00:1c:a9:2b:d7:48:00:92:f3:f8:2c:62:a2:ae:11:
+         3a:24:9b:95:ac:e0:51:ce:17:21:2d:b7:4a:43:7c:89:1b:ac:
+         3e:e8:a6:f6:94:92:c5:f8:24:f2:43:92:39:f2:92:cf:7f:11:
+         f8:8b:71:d6:7c:f3:f3:20:64:9c:3b:c4:ae:42:69:2b:27:b4:
+         e4:6a:59:28:50:15:aa:8a:ba:47:61:5a:ed:c0:74:61:b9:26:
+         9d:0d:6d:9f:89:df:0b:35:7e:df:16:30:37:37:cc:15:cc:28:
+         6f:12:f6:2f:0e:87:be:e7:af:a2:9c:bc:98:49:fc:4b:41:05:
+         d9:21:27:5a:89:fd:b5:71:2c:09:e7:8d:33:33:c1:df:18:a8:
+         ed:7e:50:49:99:17:0b:4d:2f:30:a5:8e:96:7a:b5:35:a7:d6:
+         a6:3a:8a:39:ff:0a:c8:47:98:be:47:aa:75:b3:3b:cb:05:9e:
+         8e:2f:80:aa:4c:25:b0:68:93:d3:a5:f7:d2:96:63:e7:85:49:
+         59:bf:20:39:02:24:e2:32:39:53:ad:d2:df:f1:ad:f6:06:ef:
+         85:4e:e1:12:f6:85:f2:b4:a9:b3:ba:2a:15:be:19:aa:02:97:
+         62:f1:a7:be:03:6c:0d:df
 -----BEGIN CERTIFICATE-----
 MIIFFTCCAv2gAwIBAgIIf6MrKLHJq2wwDQYJKoZIhvcNAQELBQAwgYIxCzAJBgNV
 BAYTAlVTMQ4wDAYDVQQIDAVUZXhhczEQMA4GA1UEBwwHSG91c3RvbjEYMBYGA1UE

--- a/v2/testdata/mpExponent1.pem
+++ b/v2/testdata/mpExponent1.pem
@@ -1,3 +1,61 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0c:ac:8e:2d:a5:3c:1c:06:16:8c:17:b6:58:1f:2d:1b:7d:68:f1:1b
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = California, L = San Francisco, O = Bogus Inc., OU = Operations, CN = keyexp1.example.com
+        Validity
+            Not Before: Oct  4 15:00:38 2019 GMT
+            Not After : Oct  3 15:00:38 2021 GMT
+        Subject: C = US, ST = California, L = San Francisco, O = Bogus Inc., OU = Operations, CN = keyexp1.example.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:f1:3d:ab:73:90:30:53:5f:21:04:ce:e7:50:d4:
+                    3e:cc:99:80:ff:9f:9a:50:a2:d5:e5:f5:e9:d7:e6:
+                    c7:5c:0a:ee:eb:bd:a7:02:46:f6:88:67:c6:bf:3c:
+                    dc:43:bb:72:8c:dc:31:fb:a8:68:6d:8c:b4:92:3d:
+                    f5:a0:27:4b:91:8b:ba:f6:e5:21:72:e2:ea:bc:9f:
+                    4f:ee:1d:61:94:a0:16:ee:d6:c7:fe:06:c7:2b:e8:
+                    84:bd:24:d4:77:dc:49:b3:05:3e:41:ac:04:22:13:
+                    83:25:f7:c9:21:b9:4d:85:e7:5d:c8:e9:bb:e2:75:
+                    55:4e:43:6a:9d:7c:c8:33:e1:4c:1a:f8:96:3e:22:
+                    d3:e5:71:99:70:e0:04:25:86:fb:2a:7c:39:a7:ec:
+                    84:c3:ce:1c:d0:cb:10:e3:ee:64:23:01:2b:61:1f:
+                    4b:ed:f9:4d:07:f8:ae:54:89:89:b3:27:51:cd:26:
+                    b4:52:9a:b7:c6:4d:28:4f:47:a0:a8:12:e5:6f:03:
+                    aa:87:2e:b7:6a:e2:e2:6b:9f:b3:6f:f2:ea:07:bb:
+                    6d:16:2d:fd:d4:54:c2:e7:e3:63:ac:02:2a:fe:2c:
+                    44:df:8d:99:28:5f:e2:99:f3:a3:ae:88:d3:a4:1a:
+                    5b:af:af:2b:f0:07:67:7e:f1:bd:2f:05:4f:ed:3e:
+                    14:e9
+                Exponent: 1 (0x1)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                35:79:4B:73:AE:58:5E:58:79:49:B3:EC:A6:C2:B3:61:A3:5D:C3:79
+            X509v3 Authority Key Identifier: 
+                keyid:35:79:4B:73:AE:58:5E:58:79:49:B3:EC:A6:C2:B3:61:A3:5D:C3:79
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+    Signature Algorithm: sha256WithRSAEncryption
+         00:01:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:
+         ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:
+         ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:
+         ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:
+         ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:
+         ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:
+         ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:
+         ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:
+         ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:
+         ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:
+         ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:
+         ff:ff:ff:ff:ff:ff:00:30:31:30:0d:06:09:60:86:48:01:65:
+         03:04:02:01:05:00:04:20:67:8a:58:54:31:63:a3:83:5d:38:
+         da:1e:a6:1e:c3:8e:b6:7a:c6:7d:23:6c:59:f9:78:9c:5d:07:
+         d0:e6:73:12
 -----BEGIN CERTIFICATE-----
 MIID5TCCAs2gAwIBAgIUDKyOLaU8HAYWjBe2WB8tG31o8RswDQYJKoZIhvcNAQEL
 BQAwgYIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQH

--- a/v2/testdata/mpExponent10001.pem
+++ b/v2/testdata/mpExponent10001.pem
@@ -1,3 +1,61 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            33:b9:74:e6:b7:95:d7:c4:e7:8b:ff:e2:c3:8b:b9:ad:a8:6b:b2:ad
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = California, L = San Francisco, O = Bogus Inc., OU = Operations, CN = keyexp10001.example.com
+        Validity
+            Not Before: Oct  4 15:00:55 2019 GMT
+            Not After : Oct  3 15:00:55 2021 GMT
+        Subject: C = US, ST = California, L = San Francisco, O = Bogus Inc., OU = Operations, CN = keyexp10001.example.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:d3:a9:23:ba:52:33:24:bf:39:31:a9:cc:01:65:
+                    3d:b5:85:86:2a:7e:9a:43:8b:7d:5c:62:29:25:15:
+                    23:3e:10:b8:02:81:f9:b3:7f:37:1c:75:72:7b:f9:
+                    92:fe:dd:d9:4e:6d:56:30:ce:e4:cd:48:03:e4:6c:
+                    22:d5:61:9d:72:1d:8f:66:4f:5f:fe:1d:18:fe:f2:
+                    0b:d3:84:b2:67:9a:d3:40:0f:3d:d5:7d:ea:a0:d2:
+                    19:41:18:32:32:bc:18:05:dc:17:78:de:08:ed:cd:
+                    f3:c4:da:43:19:df:57:e2:d6:6c:71:63:a8:a5:b1:
+                    16:86:55:09:2e:3a:e0:8f:6d:bb:af:32:74:68:6f:
+                    e4:36:50:56:ac:7b:8e:16:24:84:df:5f:19:08:cd:
+                    2a:31:8f:2e:e4:fc:07:69:f2:78:5d:1b:18:4f:4a:
+                    5c:76:67:84:4c:4c:fc:a4:04:ba:22:46:6b:cb:e5:
+                    89:bd:11:15:c0:1e:07:5f:b8:88:61:a5:2e:4c:bf:
+                    7b:a2:46:a3:27:c5:8f:2a:ea:fd:30:6f:40:1b:fb:
+                    7c:41:ad:2a:28:b2:22:f6:5d:4f:6b:f8:48:4f:90:
+                    0e:f8:d8:be:d1:74:b7:a0:70:18:c9:75:e6:0c:a0:
+                    32:45:bd:48:cf:9b:ec:08:45:4b:a2:b4:ff:85:c2:
+                    1b:61
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                79:18:0A:24:98:24:5F:62:01:2F:8C:E6:B7:E1:5D:2A:73:05:AA:4D
+            X509v3 Authority Key Identifier: 
+                keyid:79:18:0A:24:98:24:5F:62:01:2F:8C:E6:B7:E1:5D:2A:73:05:AA:4D
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+    Signature Algorithm: sha256WithRSAEncryption
+         bc:d3:fc:38:c0:99:8d:45:23:80:70:d2:05:17:0e:95:b5:0f:
+         5b:43:8b:07:66:18:6b:5b:5a:3e:0e:c0:41:d3:f4:c2:59:85:
+         c7:8e:a2:f8:a2:91:33:c7:a9:de:0f:db:e9:7c:b2:29:20:95:
+         2c:5a:81:54:de:23:0f:33:35:a3:1e:7c:ad:60:ef:55:24:03:
+         d6:74:37:0d:37:3f:75:ae:dc:bd:ba:ce:dd:68:95:0d:aa:ba:
+         c9:16:e2:92:55:29:b6:76:24:94:3e:34:ce:3b:be:05:ef:62:
+         f3:dc:75:67:9f:8c:69:5b:b3:1b:32:9b:51:a8:bf:23:d1:b8:
+         c4:87:29:c8:eb:57:8b:73:03:3b:db:03:ac:fd:d0:40:71:4d:
+         3f:d0:a0:9c:78:6b:f8:b5:ff:f0:85:5a:32:ba:e1:c6:55:77:
+         d2:80:b5:aa:0b:75:21:42:7b:ae:09:ad:ec:74:b0:b2:9d:a1:
+         ed:6e:e7:40:17:96:17:9c:c5:37:e0:21:d8:c4:fd:78:73:c9:
+         2d:ed:a4:10:74:59:d0:64:58:3e:c5:cf:c4:75:a0:b6:ec:7c:
+         05:90:32:1f:7b:ce:e4:1e:84:20:ce:f6:93:cc:d5:80:82:d9:
+         57:ae:1f:58:b2:ba:0a:14:ce:48:23:81:eb:fb:9c:09:e5:a3:
+         40:e8:6f:71
 -----BEGIN CERTIFICATE-----
 MIID7zCCAtegAwIBAgIUM7l05reV18Tni//iw4u5rahrsq0wDQYJKoZIhvcNAQEL
 BQAwgYYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQH

--- a/v2/testdata/onionSANBadServDescHashMismatch.pem
+++ b/v2/testdata/onionSANBadServDescHashMismatch.pem
@@ -1,3 +1,37 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Zmap Onion CA
+        Validity
+            Not Before: Mar  2 20:51:53 2019 GMT
+            Not After : Mar  2 20:51:53 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:f4:b4:81:a4:24:7f:65:2f:40:7d:bf:74:27:03:
+                    61:d1:af:a1:df:65:4c:da:3d:38:7e:61:f4:4b:78:
+                    fa:59:d4:09:fa:27:0d:e8:74:4e:ee:13:56:79:9b:
+                    0c:d0:18:79:3f:3f:d5:14:4c:dd:e5:17:1e:01:de:
+                    9a:5c:f3:e8:45
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:zmap.onion
+            2.23.140.1.31: 
+                0604..https://zmap.onion0...`.H.e........I..I..e\..?.>.{
+    Signature Algorithm: sha256WithRSAEncryption
+         d1:c4:56:81:b8:3c:14:c8:f9:26:f4:0e:1f:dc:cb:8d:4f:b9:
+         15:b9:58:36:f7:23:38:25:3b:40:78:5b:2a:0b:84:1f:80:d6:
+         d1:6b:d7:0f:40:71:54:fb:44:bd:1f:64:0c:77:17:3b:54:19:
+         b6:42:44:22:e2:9b:33:7f:91:d9
 -----BEGIN CERTIFICATE-----
 MIIBsDCCAVqgAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNWm1h
 cCBPbmlvbiBDQTAeFw0xOTAzMDIyMDUxNTNaFw0yMDAzMDIyMDUxNTNaMBIxEDAO

--- a/v2/testdata/onionSANBadServDescInvalidUTF8OnionURI.pem
+++ b/v2/testdata/onionSANBadServDescInvalidUTF8OnionURI.pem
@@ -1,3 +1,37 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Zmap Onion CA
+        Validity
+            Not Before: Mar  2 21:00:46 2019 GMT
+            Not After : Mar  2 21:00:46 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:ab:72:43:90:82:b9:31:b2:c5:b2:43:62:17:2f:
+                    42:65:3f:a3:e8:7b:e8:03:a5:95:54:61:e4:d1:cd:
+                    87:64:28:53:a9:d5:ff:42:98:05:b6:74:4c:46:aa:
+                    af:98:78:71:ea:63:2b:6e:7e:96:36:14:5e:19:64:
+                    21:b2:d8:3c:07
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:zmap.onion
+            2.23.140.1.31: 
+                0}0D..https://zmap.onion0...`.H.e.....!..I..I..e\..?.>.{{}.G*.bx0q.9.f8\05.....0...`.H.e.....!..I..I..e\..?.>.{{}.G*.bx0q.9.f8\
+    Signature Algorithm: sha256WithRSAEncryption
+         a8:87:aa:86:97:8d:a0:03:52:f9:74:dd:0c:50:35:3f:74:d3:
+         3c:32:94:58:ee:17:d5:41:fd:03:70:6b:4f:30:5a:d5:80:76:
+         7d:fe:e4:b6:5f:3c:05:ac:45:63:f3:20:34:95:fa:17:50:2b:
+         c7:82:12:66:3a:8c:17:9c:ff:ce
 -----BEGIN CERTIFICATE-----
 MIIB+DCCAaKgAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNWm1h
 cCBPbmlvbiBDQTAeFw0xOTAzMDIyMTAwNDZaFw0yMDAzMDIyMTAwNDZaMBIxEDAO

--- a/v2/testdata/onionSANBadServDescUnknownHashAlg.pem
+++ b/v2/testdata/onionSANBadServDescUnknownHashAlg.pem
@@ -1,3 +1,37 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Zmap Onion CA
+        Validity
+            Not Before: Mar  2 20:49:33 2019 GMT
+            Not After : Mar  2 20:49:33 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:dc:ab:c3:26:e2:24:32:8f:e4:60:ba:a0:d8:57:
+                    72:ff:69:eb:58:0c:80:09:09:ce:ab:2d:a8:c1:da:
+                    15:1d:c6:b4:68:3a:ff:31:66:cf:42:17:4b:7d:2e:
+                    e0:c0:f7:51:3d:0f:07:01:22:7b:e4:5d:ce:76:cc:
+                    0c:71:dc:f6:fd
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:zmap.onion
+            2.23.140.1.31: 
+                0F0D..https://zmap.onion0...`.H.e...c.!..I..I..e\..?.>.{{}.G*.bx0q.9.f8\
+    Signature Algorithm: sha256WithRSAEncryption
+         2c:46:3f:0a:ef:55:96:1c:13:a5:da:bc:d6:a1:73:0f:77:d2:
+         43:73:30:5e:63:3d:2f:d5:c6:92:40:31:83:b0:a5:ce:94:dc:
+         bd:72:ff:71:e3:fd:91:b7:eb:4a:a3:cd:fd:4f:d5:b9:19:43:
+         80:70:a9:7b:38:4b:a2:32:16:5a
 -----BEGIN CERTIFICATE-----
 MIIBwDCCAWqgAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNWm1h
 cCBPbmlvbiBDQTAeFw0xOTAzMDIyMDQ5MzNaFw0yMDAzMDIyMDQ5MzNaMBIxEDAO

--- a/v2/testdata/onionSANEV.pem
+++ b/v2/testdata/onionSANEV.pem
@@ -1,3 +1,38 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Zmap Onion CA
+        Validity
+            Not Before: Mar  2 15:17:12 2019 GMT
+            Not After : Mar  2 15:17:12 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:e7:b5:d2:75:b1:04:c6:24:e7:b2:1f:b1:22:2b:
+                    30:35:e9:ae:d8:b4:40:a2:34:19:01:80:a4:2e:a8:
+                    0a:de:43:49:3d:70:a2:22:0a:a8:51:bd:9b:13:fb:
+                    6e:cc:60:65:88:32:fc:33:21:06:4d:a3:27:fe:b0:
+                    75:80:cc:d4:df
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:zmap.onion
+            X509v3 Certificate Policies: 
+                Policy: 1.3.6.1.4.1.36305.2
+
+    Signature Algorithm: sha256WithRSAEncryption
+         4a:8a:2f:03:b5:b0:c1:fa:ea:7f:64:2b:c2:2e:50:2e:ce:11:
+         e4:a7:6f:90:0b:da:4d:82:cb:6c:8b:1d:1f:f2:b4:0d:f9:c7:
+         bc:3f:19:ac:59:be:89:38:58:0d:56:9b:a1:ad:a7:57:00:1f:
+         7b:38:13:ff:a2:13:3a:47:3e:63
 -----BEGIN CERTIFICATE-----
 MIIBgzCCAS2gAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNWm1h
 cCBPbmlvbiBDQTAeFw0xOTAzMDIxNTE3MTJaFw0yMDAzMDIxNTE3MTJaMBIxEDAO

--- a/v2/testdata/onionSANGoodExpiry.pem
+++ b/v2/testdata/onionSANGoodExpiry.pem
@@ -1,3 +1,37 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Zmap Onion CA
+        Validity
+            Not Before: Mar  2 21:26:02 2019 GMT
+            Not After : Jun  2 20:26:02 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:9f:27:58:6b:8d:be:5c:13:8c:20:48:d3:8c:3e:
+                    e9:3a:ca:85:d4:0e:7b:99:a4:c6:d0:8f:10:c3:46:
+                    2d:1c:54:27:00:03:58:7b:51:cd:9c:90:af:a4:7d:
+                    c6:50:0d:70:0d:d5:6c:48:1c:1d:02:3b:60:35:f3:
+                    e1:5f:34:c1:b5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:zmap.onion
+            2.23.140.1.31: 
+                0F0D..https://zmap.onion0...`.H.e.....!..I..I..e\..?.>.{{}.G*.bx0q.9.f8\
+    Signature Algorithm: sha256WithRSAEncryption
+         35:1c:2f:01:b5:b4:7e:02:b4:c3:ed:43:f6:e9:b4:56:04:1b:
+         5c:3e:80:01:41:1b:5f:ea:3d:07:a0:01:86:70:9f:7d:c0:21:
+         3f:b5:41:4b:11:dd:87:35:5c:21:13:f1:eb:92:0a:bb:0b:b5:
+         a6:17:5e:22:4d:4e:45:20:91:51
 -----BEGIN CERTIFICATE-----
 MIIBwDCCAWqgAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNWm1h
 cCBPbmlvbiBDQTAeFw0xOTAzMDIyMTI2MDJaFw0yMDA2MDIyMDI2MDJaMBIxEDAO

--- a/v2/testdata/onionSANGoodServDesc.pem
+++ b/v2/testdata/onionSANGoodServDesc.pem
@@ -1,3 +1,37 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Zmap Onion CA
+        Validity
+            Not Before: Mar  2 20:21:33 2019 GMT
+            Not After : Mar  2 20:21:33 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:db:1d:4a:a1:60:f9:80:37:f9:94:a0:d8:8c:4c:
+                    53:0d:a6:8e:7a:bb:8e:8b:f5:7d:b7:18:69:33:27:
+                    85:6d:90:34:5a:c3:24:cd:a6:c2:0c:77:43:4a:c5:
+                    e6:f0:27:60:08:ca:ad:10:65:a6:3a:a4:62:4e:80:
+                    4c:69:c7:71:1b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:zmap.onion
+            2.23.140.1.31: 
+                0F0D..https://zmap.onion0...`.H.e.....!..I..I..e\..?.>.{{}.G*.bx0q.9.f8\
+    Signature Algorithm: sha256WithRSAEncryption
+         76:c5:d6:d0:6f:8a:4b:47:b0:76:bf:90:01:68:df:28:79:85:
+         2d:8a:df:97:18:ea:1c:dd:9e:51:16:01:69:06:8d:40:fc:ce:
+         51:ef:a6:ad:39:5b:64:8d:7c:3a:c8:66:f3:7d:eb:53:f6:7c:
+         e4:04:f7:f2:68:69:eb:68:9d:28
 -----BEGIN CERTIFICATE-----
 MIIBwDCCAWqgAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNWm1h
 cCBPbmlvbiBDQTAeFw0xOTAzMDIyMDIxMzNaFw0yMDAzMDIyMDIxMzNaMBIxEDAO

--- a/v2/testdata/onionSANLongExpiry.pem
+++ b/v2/testdata/onionSANLongExpiry.pem
@@ -1,3 +1,37 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Zmap Onion CA
+        Validity
+            Not Before: Mar  2 21:25:18 2019 GMT
+            Not After : Jul  2 20:25:18 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:e7:df:98:f5:d6:3d:3a:fe:bd:c4:68:39:07:a3:
+                    fd:a6:ee:bd:c4:f6:b0:bb:f8:7d:3f:39:b4:8c:a2:
+                    5f:c2:90:7b:ee:ca:b7:4d:cc:8d:8f:04:23:d6:40:
+                    43:87:b6:dd:77:50:b2:2d:34:b2:7c:f1:c4:bc:cb:
+                    19:42:ef:ce:75
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:zmap.onion
+            2.23.140.1.31: 
+                0F0D..https://zmap.onion0...`.H.e.....!..I..I..e\..?.>.{{}.G*.bx0q.9.f8\
+    Signature Algorithm: sha256WithRSAEncryption
+         83:a0:19:b6:97:2a:c0:36:9b:2d:67:d0:15:9e:dd:b1:30:7e:
+         ff:9a:ef:5b:59:fe:08:08:7a:23:7d:32:80:28:5b:95:fa:29:
+         0b:c7:b4:c9:a0:28:5e:c6:68:3f:4e:69:7d:fa:5e:e1:74:0d:
+         d2:95:e0:2e:1b:47:c2:51:49:fc
 -----BEGIN CERTIFICATE-----
 MIIBwDCCAWqgAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNWm1h
 cCBPbmlvbiBDQTAeFw0xOTAzMDIyMTI1MThaFw0yMDA3MDIyMDI1MThaMBIxEDAO

--- a/v2/testdata/onionSANLongExpiryPreBallot.pem
+++ b/v2/testdata/onionSANLongExpiryPreBallot.pem
@@ -1,3 +1,37 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Zmap Onion CA
+        Validity
+            Not Before: Mar  2 21:24:22 2009 GMT
+            Not After : Jul  2 20:24:22 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:b2:a9:0c:43:93:2d:84:49:21:ea:ec:48:1c:6e:
+                    a4:d8:14:ce:9a:b0:68:29:83:72:b7:3a:5d:c0:9b:
+                    04:12:24:88:90:46:7c:a9:0d:e7:26:54:64:2c:0d:
+                    0d:1f:0f:34:df:98:d5:6c:98:bb:6f:b3:6d:47:a2:
+                    02:7f:9c:09:87
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:zmap.onion
+            2.23.140.1.31: 
+                0F0D..https://zmap.onion0...`.H.e.....!..I..I..e\..?.>.{{}.G*.bx0q.9.f8\
+    Signature Algorithm: sha256WithRSAEncryption
+         20:47:0f:ce:fd:0b:5d:7b:f0:63:e9:f0:ca:b5:e1:72:64:de:
+         14:f0:f0:40:e9:49:67:79:c6:72:23:c6:a4:42:e1:6d:d1:63:
+         4e:a4:03:d3:13:bc:52:1b:4f:aa:42:e0:7c:70:35:d5:7b:2c:
+         1a:14:80:e4:6c:50:64:a2:f2:4d
 -----BEGIN CERTIFICATE-----
 MIIBwDCCAWqgAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNWm1h
 cCBPbmlvbiBDQTAeFw0wOTAzMDIyMTI0MjJaFw0yMDA3MDIyMDI0MjJaMBIxEDAO

--- a/v2/testdata/onionSANMissingServDescHash.pem
+++ b/v2/testdata/onionSANMissingServDescHash.pem
@@ -1,3 +1,37 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Zmap Onion CA
+        Validity
+            Not Before: Mar  2 20:54:40 2019 GMT
+            Not After : Mar  2 20:54:40 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:ca:13:05:48:8f:61:de:a3:fb:0d:1f:e5:b9:81:
+                    81:ae:a7:81:4e:64:e5:e2:9b:ec:e3:9b:63:c7:92:
+                    3d:3e:46:63:34:1f:82:73:ea:87:0a:11:e0:97:5e:
+                    51:87:f7:f6:27:47:e7:f9:15:71:e7:76:c4:6e:d4:
+                    ee:9b:2c:7c:6b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:zmap.onion, DNS:missing.onion
+            2.23.140.1.31: 
+                0F0D..https://zmap.onion0...`.H.e.....!..I..I..e\..?.>.{{}.G*.bx0q.9.f8\
+    Signature Algorithm: sha256WithRSAEncryption
+         34:7a:85:96:cb:61:a1:04:78:17:42:e5:f9:b1:e6:0a:33:f7:
+         09:4a:d3:43:d7:56:e7:97:d7:9b:ad:78:e2:16:80:66:1b:06:
+         19:d9:bc:db:8d:f8:87:6b:98:5a:ef:6a:8c:4f:b1:64:e9:eb:
+         c3:72:f5:30:7a:79:ac:1d:2a:06
 -----BEGIN CERTIFICATE-----
 MIIBzzCCAXmgAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNWm1h
 cCBPbmlvbiBDQTAeFw0xOTAzMDIyMDU0NDBaFw0yMDAzMDIyMDU0NDBaMBIxEDAO

--- a/v2/testdata/onionSANNotEV.pem
+++ b/v2/testdata/onionSANNotEV.pem
@@ -1,3 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Zmap Onion CA
+        Validity
+            Not Before: Mar  2 14:59:01 2019 GMT
+            Not After : Mar  2 14:59:01 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:c1:80:78:09:b7:3d:dc:91:09:d5:fa:d4:f6:6b:
+                    eb:5c:ec:c9:ba:ca:2c:37:c3:69:b3:63:82:fb:ac:
+                    43:01:81:d7:65:d2:3a:f4:74:df:90:33:6f:c4:cd:
+                    a6:74:2f:0d:25:ea:d8:eb:b5:ee:6b:ec:c8:85:b7:
+                    a7:a2:75:3d:0b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:zmap.onion
+    Signature Algorithm: sha256WithRSAEncryption
+         87:43:1c:72:3a:4f:1c:54:11:77:7a:06:ef:be:00:62:ad:c2:
+         84:16:a4:fb:ed:f3:aa:1f:c5:3a:89:16:ba:6d:57:13:33:82:
+         9a:30:0c:1d:9e:da:2d:1a:c9:db:44:25:f0:24:44:2c:96:1f:
+         fa:8a:b0:bd:86:ce:b9:2f:a7:7e
 -----BEGIN CERTIFICATE-----
 MIIBazCCARWgAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNWm1h
 cCBPbmlvbiBDQTAeFw0xOTAzMDIxNDU5MDFaFw0yMDAzMDIxNDU5MDFaMBIxEDAO

--- a/v2/testdata/onionSANTooManyServDesc.pem
+++ b/v2/testdata/onionSANTooManyServDesc.pem
@@ -1,3 +1,37 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Zmap Onion CA
+        Validity
+            Not Before: Mar  2 21:08:01 2019 GMT
+            Not After : Mar  2 21:08:01 2020 GMT
+        Subject: CN = zmap.io
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:d6:ef:37:e0:b6:cd:df:31:08:70:4f:bc:ea:d8:
+                    f5:b3:55:4b:d7:69:ce:9a:41:f7:57:01:6c:3b:62:
+                    70:10:c6:75:43:eb:e1:ec:9d:20:34:2b:a0:de:1f:
+                    c6:23:cc:d2:36:f4:36:99:03:c3:29:0a:06:27:bb:
+                    26:13:ef:fc:0d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:zmap.onion
+            2.23.140.1.31: 
+                0..0D..https://zmap.onion0...`.H.e.....!..I..I..e\..?.>.{{}.G*.bx0q.9.f8\0E..https://other.onion0...`.H.e.....!..I..I..e\..?.>.{{}.G*.bx0q.9.f8\
+    Signature Algorithm: sha256WithRSAEncryption
+         4c:aa:c0:d1:17:1d:4d:6f:01:1e:88:4a:2d:c0:77:67:1a:24:
+         af:b0:2a:bd:6c:24:df:cc:b9:2c:25:ad:0f:e4:0b:02:49:c6:
+         da:ba:13:ea:c8:15:ff:99:e9:78:23:9a:5b:88:04:81:43:dc:
+         d0:9c:58:60:30:f6:8a:13:99:c2
 -----BEGIN CERTIFICATE-----
 MIICCjCCAbSgAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNWm1h
 cCBPbmlvbiBDQTAeFw0xOTAzMDIyMTA4MDFaFw0yMDAzMDIyMTA4MDFaMBIxEDAO

--- a/v2/testdata/rootCAKeyUsageNotCritical.pem
+++ b/v2/testdata/rootCAKeyUsageNotCritical.pem
@@ -1,3 +1,94 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            d8:b1:0b:31:bf:60:ad:2f
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = AU, ST = AU, L = AU, O = Au, OU = AU, CN = Au, emailAddress = Au
+        Validity
+            Not Before: Aug 22 01:56:53 2017 GMT
+            Not After : Aug 17 01:56:53 2037 GMT
+        Subject: C = AU, ST = AU, L = AU, O = Au, OU = AU, CN = Au, emailAddress = Au
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:c0:51:b9:99:af:22:27:16:f7:b1:b5:31:40:78:
+                    0e:48:c2:8e:a9:95:0d:9a:64:88:9f:7f:1b:35:f3:
+                    c2:78:8b:88:94:28:d6:d2:e1:99:02:fb:d2:3d:ab:
+                    65:97:75:0e:bc:75:df:aa:a9:07:c5:56:ba:60:ef:
+                    3c:0f:39:29:6e:d5:21:6b:3c:7a:28:23:17:cc:9b:
+                    0c:1f:64:66:02:20:18:38:01:70:31:ba:4f:8f:08:
+                    da:41:d0:c7:45:b8:4c:a4:65:2a:ca:de:e4:69:04:
+                    e2:15:94:60:3f:a9:e3:32:86:fa:f1:2a:3f:f8:fc:
+                    25:bf:7f:ed:a8:76:f0:a5:15:74:8e:9e:df:5a:75:
+                    5c:1a:64:6e:01:f9:f1:51:be:cc:4b:f1:b9:75:15:
+                    a9:1f:10:b5:ec:ea:65:d5:9e:87:48:04:3a:06:7d:
+                    5e:69:0e:2d:da:63:a1:6f:ac:58:a7:e0:f9:ab:b1:
+                    cf:04:80:a6:f3:0e:85:32:13:25:90:37:a0:be:d1:
+                    f9:c9:80:8f:ad:4a:4d:4f:33:b8:e9:71:7c:cb:82:
+                    39:3e:12:72:10:c3:f2:c3:96:0f:b4:97:08:c9:96:
+                    bc:42:be:a2:08:9e:9e:95:af:e9:ab:e5:2f:e5:29:
+                    d0:22:aa:96:21:3a:76:54:c0:1a:5e:5b:bc:b8:23:
+                    27:8d:aa:b4:77:91:a5:d0:30:20:e8:ca:71:a3:cf:
+                    37:7f:2f:a7:ba:12:b8:39:cc:23:47:a6:71:8e:ae:
+                    91:b5:4b:bb:e1:8e:8b:6e:92:4e:52:bb:3f:ec:48:
+                    22:47:b8:1f:a0:c7:83:5a:e8:d8:42:b2:d4:3a:19:
+                    f1:9d:b0:dc:a6:07:fe:79:15:94:52:c7:c0:31:f1:
+                    83:13:23:8a:d5:77:3c:16:ef:e7:f9:f0:de:21:0f:
+                    e1:ea:30:d4:91:24:0e:0d:02:39:df:c1:0b:63:76:
+                    9c:a2:42:7f:63:75:f9:eb:87:f4:d7:93:d9:35:cc:
+                    7e:d7:9b:b4:35:83:eb:91:41:17:23:bc:58:d9:48:
+                    6e:4e:f2:27:d3:24:0f:9d:5a:61:d7:71:ed:53:7b:
+                    83:74:91:ad:80:ce:5c:e2:b2:71:b3:a2:7a:85:ee:
+                    56:ba:4b:3c:c9:ce:1d:99:2a:0e:85:00:26:1d:53:
+                    09:10:ef:42:c5:a9:9f:35:9c:bc:88:c5:2b:50:12:
+                    f3:04:96:25:87:51:7f:15:02:fc:ce:83:2d:83:54:
+                    c9:80:b1:60:ad:43:31:40:8b:fe:c1:0c:4b:e6:9a:
+                    01:69:cd:18:6e:63:e8:4d:b1:a7:80:c4:65:89:e7:
+                    dc:2c:71:70:11:89:c7:25:01:cb:a1:84:e6:cf:8f:
+                    06:9b:c7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                37:DD:8C:34:3B:F8:EC:65:9D:50:F8:ED:FB:FF:89:BA:BF:1C:D9:58
+            X509v3 Authority Key Identifier: 
+                keyid:37:DD:8C:34:3B:F8:EC:65:9D:50:F8:ED:FB:FF:89:BA:BF:1C:D9:58
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: 
+                Digital Signature, Certificate Sign, CRL Sign
+    Signature Algorithm: sha256WithRSAEncryption
+         72:48:af:03:0b:53:b3:9c:c8:f5:68:f3:86:a6:34:28:fc:9e:
+         af:90:eb:92:3c:b0:f4:6b:4a:05:10:40:bd:6e:0d:5d:c9:cf:
+         a1:c2:1c:fc:fc:99:98:d3:fe:34:6e:1d:86:6c:8d:aa:55:b0:
+         43:96:ef:e4:d0:ae:22:e9:82:64:57:76:03:de:b8:78:3f:be:
+         be:48:a8:b0:b7:9f:3c:2d:ac:ea:fb:20:8f:65:18:0d:64:54:
+         64:5b:2f:ed:a3:b3:5c:bf:ca:87:a5:88:f8:55:60:64:ee:ac:
+         13:65:c7:3c:7c:1d:7b:61:1b:2a:99:e3:eb:44:d5:30:77:aa:
+         c0:39:ef:c1:a2:39:a2:1c:9a:7c:96:a8:04:83:38:63:6e:be:
+         c5:63:ff:61:d8:65:08:92:33:4c:b4:80:50:03:da:45:ad:fe:
+         08:1b:06:6e:91:4d:49:74:f9:cf:cd:eb:96:29:f7:dd:39:f8:
+         3a:8b:08:af:bc:58:34:48:b7:ac:05:54:c6:fb:60:09:39:b9:
+         9c:43:59:ee:8d:6d:1e:b4:96:59:4e:53:fd:c4:78:73:e5:ab:
+         59:06:1f:c5:1c:6c:56:72:fb:ce:1c:af:5c:f7:f3:2f:d4:b1:
+         cc:66:bb:37:f0:d5:f7:c8:bb:80:b3:08:60:cf:4a:05:9e:81:
+         75:53:da:d1:73:50:c1:97:67:21:20:0d:97:a9:9d:a8:8f:81:
+         2a:49:b3:3c:a7:15:ca:1a:6f:59:8a:94:14:97:e5:3d:6a:b7:
+         38:20:f0:64:d2:0c:c7:cc:c9:db:81:4f:e9:e5:4b:be:ec:0e:
+         0f:8a:15:a8:51:70:ee:b4:50:a3:05:df:64:47:48:18:a3:d3:
+         b2:d5:16:41:6f:24:9c:f2:d6:b4:d8:87:93:ba:32:fb:8b:92:
+         74:ef:62:23:43:18:a4:d1:b1:34:b0:19:bf:1e:d9:cc:42:2f:
+         42:ec:f6:a3:a5:78:ef:c4:b1:17:db:94:f0:9f:5b:a8:3e:49:
+         9f:e3:bc:0e:50:a7:00:06:3d:cb:91:cc:04:17:a0:43:76:86:
+         f6:2f:4d:08:28:a4:4d:1e:ae:67:06:d1:44:66:4d:92:00:45:
+         e3:f3:9b:c3:5a:4c:d4:9b:9c:15:88:83:a1:ba:29:2b:0b:c4:
+         f5:3d:28:4f:47:e0:4d:82:c5:8b:17:0a:ae:f4:c1:93:71:d9:
+         2a:05:d7:e5:ec:bb:32:da:09:e2:3e:1a:e6:a9:08:b7:4e:3a:
+         7d:e3:e7:f4:c9:7f:3d:2e:36:55:d8:89:9c:2b:d1:bf:69:a6:
+         95:aa:6d:11:7e:f5:43:31:ef:18:80:18:dc:92:f1:e9:f1:00:
+         df:92:8b:9f:33:d0:fe:01
 -----BEGIN CERTIFICATE-----
 MIIFpTCCA42gAwIBAgIJANixCzG/YK0vMA0GCSqGSIb3DQEBCwUAMGExCzAJBgNV
 BAYTAkFVMQswCQYDVQQIDAJBVTELMAkGA1UEBwwCQVUxCzAJBgNVBAoMAkF1MQsw

--- a/v2/testdata/rsaAlgIDNoNULLParams.pem
+++ b/v2/testdata/rsaAlgIDNoNULLParams.pem
@@ -1,3 +1,83 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            2d:d7:20:91:05:b3:d0:06:30:01:2d:c2
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = BE, O = GlobalSign nv-sa, CN = AlphaSSL CA - SHA256 - G2
+        Validity
+            Not Before: Dec 10 11:07:33 2018 GMT
+            Not After : Jan 29 13:34:15 2020 GMT
+        Subject: C = NL, OU = Domain Control Validated, CN = www.shorearchief.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:b5:d0:25:96:79:a1:c6:8b:a5:7b:8e:5c:07:21:
+                    49:8c:8b:98:89:17:b9:62:59:4a:d1:15:98:67:c4:
+                    3d:c1:e8:63:95:84:c2:75:ee:5f:3a:d7:0c:8a:0b:
+                    6b:60:25:21:78:1e:cc:7f:5e:f7:9b:ec:6b:a7:c2:
+                    08:db:75:9f:34:ae:c2:20:a9:50:53:0b:8d:f9:b9:
+                    4f:a7:e9:6f:c6:11:10:17:9a:7e:29:a0:2d:d0:e3:
+                    e7:9b:95:8a:73:ae:c3:c3:1c:ba:af:0c:ed:37:83:
+                    ba:fa:60:49:a6:5b:8a:60:53:47:11:3f:1a:ba:4b:
+                    3c:db:66:92:14:7d:db:bd:a8:0b:79:b5:16:c5:32:
+                    0d:c6:5e:91:7d:e3:34:5b:b6:df:64:30:bc:8b:e0:
+                    da:45:fc:46:ae:08:e0:cf:7a:64:a3:ba:20:fe:ac:
+                    b8:0e:9d:2b:32:f1:56:61:23:c2:4f:f3:2c:a5:74:
+                    77:28:ea:d6:2e:ba:98:f9:6a:1a:f1:ed:99:0f:3e:
+                    53:ca:61:18:cd:03:c5:ee:12:5a:ec:a8:99:31:02:
+                    87:c8:eb:fb:13:28:2d:77:b6:df:88:a3:2d:d1:11:
+                    fe:bf:ea:e3:d1:8e:ee:51:2c:5d:2f:f8:30:15:bb:
+                    18:c0:2c:e1:43:0f:f9:7c:61:63:1f:12:ef:57:38:
+                    64:07
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            Authority Information Access: 
+                CA Issuers - URI:http://secure2.alphassl.com/cacert/gsalphasha2g2r1.crt
+                OCSP - URI:http://ocsp2.globalsign.com/gsalphasha2g2
+
+            X509v3 Certificate Policies: 
+                Policy: 1.3.6.1.4.1.4146.1.10.10
+                  CPS: https://www.globalsign.com/repository/
+                Policy: 2.23.140.1.2.1
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://crl2.alphassl.com/gs/gsalphasha2g2.crl
+
+            X509v3 Subject Alternative Name: 
+                DNS:www.shorearchief.com, DNS:shorearchief.com
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Subject Key Identifier: 
+                98:45:A2:FE:F7:3C:FC:8D:00:EE:9F:89:36:95:59:AA:14:9E:59:6D
+            X509v3 Authority Key Identifier: 
+                keyid:F5:CD:D5:3C:08:50:F9:6A:4F:3A:B7:97:DA:56:83:E6:69:D2:68:F7
+
+            CT Precertificate Poison: critical
+                NULL
+    Signature Algorithm: sha256WithRSAEncryption
+         1e:57:6a:1a:79:7e:6c:04:f5:14:cc:14:68:6b:83:29:7e:86:
+         7c:89:c0:1d:cd:ec:f2:fd:9d:43:10:4f:86:98:ca:80:c9:ad:
+         51:14:bd:83:08:c9:36:ac:f5:f5:df:76:07:a4:2d:e9:5a:40:
+         cc:76:5e:a0:9a:bc:f9:28:e0:ff:d3:cd:1e:50:8b:3f:54:4f:
+         6e:9c:3d:73:50:fb:c7:4c:0f:5a:f8:1a:24:cf:f4:69:ae:a8:
+         fd:be:ad:15:52:e1:88:d4:2a:7b:c6:56:31:b3:e8:00:bf:46:
+         53:35:c8:60:b0:6e:c5:6e:ec:33:f7:ad:8a:64:05:01:97:39:
+         ff:c7:47:3e:bd:79:8a:73:3d:2c:40:97:6d:6f:69:e7:fa:fb:
+         a9:a9:1d:2b:08:fd:0d:02:12:9d:34:c6:91:c6:03:84:66:e6:
+         63:d4:80:28:80:dc:01:78:d5:15:70:86:86:2b:13:38:b0:e3:
+         b0:74:1f:c3:8c:c5:2f:4c:79:f4:c2:14:d3:af:5e:e0:80:03:
+         d8:6f:7d:f0:ed:53:7b:9b:4b:8d:b3:94:61:1c:64:27:01:77:
+         6f:2c:63:92:91:ea:81:5a:a6:1d:b2:73:49:88:5b:f2:4b:77:
+         14:eb:e3:ec:77:a3:03:51:e2:95:34:0d:26:3f:26:16:e2:96:
+         e1:2d:f0:01
 -----BEGIN CERTIFICATE-----
 MIIFDDCCA/SgAwIBAgIMLdcgkQWz0AYwAS3CMA0GCSqGSIb3DQEBCwUAMEwxCzAJ
 BgNVBAYTAkJFMRkwFwYDVQQKExBHbG9iYWxTaWduIG52LXNhMSIwIAYDVQQDExlB

--- a/v2/testdata/rsaKeyWithParameters.pem
+++ b/v2/testdata/rsaKeyWithParameters.pem
@@ -1,3 +1,57 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1653 (0x675)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = RSA cert with key params
+        Validity
+            Not Before: May 31 22:45:59 2019 GMT
+            Not After : May 31 22:45:59 2029 GMT
+        Subject: CN = RSA cert with key params
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:b6:f0:2a:b9:97:ef:3e:2f:6d:f8:ca:5f:61:48:
+                    fb:3e:af:66:de:90:59:3d:1a:d9:cd:a8:19:2f:21:
+                    07:0f:41:2d:69:15:d4:c3:60:13:aa:34:bd:7b:9f:
+                    58:76:9e:93:9c:ef:f0:fe:0c:e6:59:fa:07:26:ec:
+                    cc:f0:11:c9:cf:00:3c:20:b6:41:72:fd:5a:79:70:
+                    98:6c:86:d3:5b:91:f8:b7:d4:8c:81:c7:41:ff:9f:
+                    81:1e:c8:4e:a3:3a:e8:4e:eb:c4:a3:61:45:98:83:
+                    92:49:b3:45:2a:75:b4:05:7a:f5:23:c0:47:73:66:
+                    14:d6:1e:51:72:40:7f:80:80:60:46:6e:f8:56:c2:
+                    11:4f:e7:1f:b1:c4:82:18:77:45:70:6e:13:f8:f1:
+                    68:6c:f8:bf:c7:07:9f:e2:05:c9:02:1b:0c:7d:8c:
+                    47:59:81:9f:89:a5:b9:dd:ef:9f:8e:10:22:cb:af:
+                    f8:fe:b5:e8:cd:95:2d:6a:0c:84:d9:25:56:ed:c6:
+                    9c:06:2f:a2:9c:95:01:40:55:a3:24:df:23:86:f9:
+                    07:7d:0e:48:70:9a:7e:d2:ac:3f:a0:5f:8b:7f:ba:
+                    92:03:e2:20:e6:c7:8d:38:0e:5b:4e:0b:40:09:4c:
+                    41:3c:7f:ed:40:8b:d0:7d:74:d3:43:26:90:0f:54:
+                    a8:77
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+    Signature Algorithm: sha256WithRSAEncryption
+         6c:f7:6e:69:73:c1:8b:cd:58:50:6d:38:c6:68:70:5f:a2:bc:
+         8d:1e:70:dc:9b:71:e1:0a:20:6f:50:cf:d3:92:f7:0a:29:52:
+         fe:f9:cd:6e:9a:8a:94:e5:8e:65:e8:97:19:2b:84:1a:78:cc:
+         37:28:36:81:d3:8d:87:4d:49:9c:3a:92:17:75:05:ff:dc:f5:
+         6d:ac:ec:88:7d:58:fe:fa:eb:d4:e9:5c:8f:71:84:bd:c1:8c:
+         ec:4a:70:a1:ba:d6:59:aa:cb:55:61:1b:76:34:bb:24:d3:b0:
+         bd:ee:78:ec:a5:e9:50:13:36:85:bb:49:34:88:bf:a1:91:05:
+         b6:5a:ef:1d:23:56:0c:5f:ed:6f:7a:6c:97:08:d5:86:b7:7f:
+         de:24:3a:d4:35:1c:9f:30:88:69:07:54:b3:ff:5f:b6:dd:c6:
+         8a:54:a8:55:94:6a:da:b1:72:6f:b6:f7:59:da:78:df:0f:50:
+         92:c2:f2:28:41:db:6b:2c:fb:21:38:1b:55:35:a4:78:a1:9b:
+         c7:a1:a8:6f:66:73:db:2d:ab:59:2a:a8:0f:ee:f3:d3:72:66:
+         8e:9a:95:76:1a:7d:59:9c:00:07:ba:71:31:e4:8e:55:50:ca:
+         b6:c0:67:d3:79:28:50:dc:bb:0e:7b:b3:06:cb:44:0d:02:ed:
+         85:32:58:8e
 -----BEGIN CERTIFICATE-----
 MIIDJzCCAg+gAwIBAgICBnUwDQYJKoZIhvcNAQELBQAwIzEhMB8GA1UEAxMYUlNB
 IGNlcnQgd2l0aCBrZXkgcGFyYW1zMB4XDTE5MDUzMTIyNDU1OVoXDTI5MDUzMTIy

--- a/v2/testdata/rsassapssWithSHA256ButIrregularSaltLength.pem
+++ b/v2/testdata/rsassapssWithSHA256ButIrregularSaltLength.pem
@@ -1,3 +1,61 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 256 (0x100)
+        Signature Algorithm: rsassaPss         
+         Hash Algorithm: sha256
+         Mask Algorithm: mgf1 with sha256
+          Salt Length: 0x11
+         Trailer Field: 0xBC (default)
+        Issuer: CN = Lint CA, OU = Test, O = MTG, C = DE
+        Validity
+            Not Before: Jan  2 09:00:00 2020 GMT
+            Not After : Jan  2 09:00:00 2022 GMT
+        Subject: CN = PSS Certificate, C = DE
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:b7:2e:fa:3e:af:af:b3:dc:af:6f:ea:3b:e8:f3:
+                    04:92:90:67:e5:f0:e2:db:b9:1e:8f:92:96:a6:4b:
+                    f1:56:70:85:88:e7:69:07:72:b0:4d:40:e6:e9:d8:
+                    dc:94:03:b3:14:2f:f1:78:58:69:07:6d:e4:d4:10:
+                    c2:ac:23:05:ab:a9:d1:05:81:be:12:77:51:7a:83:
+                    bd:b0:2b:6b:8e:5f:c4:c5:d8:dd:cd:fe:4e:c8:46:
+                    e9:e2:3e:d4:99:3c:2d:bb:34:3d:29:90:de:4b:93:
+                    29:67:10:ac:b8:1e:25:83:a2:14:bb:7b:f7:f4:7e:
+                    24:d6:89:e9:2d:3b:8d:a4:99:48:94:9a:16:31:22:
+                    71:94:e6:fe:ac:1f:35:2c:74:57:50:eb:a6:e3:e5:
+                    07:fd:b4:a8:58:f4:c1:94:a8:4c:5c:7b:6a:a3:65:
+                    a6:8f:a1:3c:d0:12:1f:7b:40:49:aa:6d:f1:f0:71:
+                    f8:84:61:d4:60:d6:78:9a:7a:9e:48:29:d0:f8:8a:
+                    85:a2:ab:92:ed:44:c3:b4:a4:30:7d:e1:d6:8e:e5:
+                    3f:3b:00:c8:a5:a0:d0:88:39:8a:e2:28:94:89:ee:
+                    50:9e:65:7c:09:43:38:15:c5:31:c3:21:49:59:c3:
+                    ae:87:f0:86:5e:52:fb:16:00:80:49:07:9b:10:22:
+                    95:f9
+                Exponent: 65537 (0x10001)
+    Signature Algorithm: rsassaPss         
+         Hash Algorithm: sha256
+         Mask Algorithm: mgf1 with sha256
+          Salt Length: 0x11
+         Trailer Field: 0xBC (default)
+
+         3e:7a:4c:41:a7:c4:d6:e5:06:2c:43:14:28:ce:b3:38:24:06:
+         52:d6:be:fe:bc:77:28:f8:25:ac:2c:c0:8f:68:a9:f3:6a:e3:
+         5d:ab:dd:e6:d5:6a:9d:d2:a5:f3:ce:07:2e:cc:26:97:99:9e:
+         6c:ad:46:32:dc:55:23:4a:31:1e:61:a5:73:28:37:b2:47:60:
+         0c:3f:5f:57:cc:8e:a5:53:09:2b:cc:3f:2b:ca:ed:3d:f5:ca:
+         7e:df:65:0c:4d:12:b7:0e:a9:8c:42:e1:b3:17:05:92:22:9b:
+         14:cf:c3:d0:3c:7d:89:e0:e0:a8:6d:38:26:db:5f:2f:a9:62:
+         fc:50:4a:3f:bc:b9:0d:3a:8a:3a:a9:20:6c:23:ec:b7:fd:22:
+         26:dc:23:22:f7:b4:1e:1d:a3:22:f4:51:ae:cb:6b:2d:17:99:
+         92:38:72:29:9e:8e:71:8d:16:60:c6:ef:45:97:e2:80:3a:21:
+         36:b0:38:4c:ba:84:22:fe:11:ee:fb:4a:9b:72:cb:ce:9b:a5:
+         a2:51:87:77:6b:08:3e:40:15:14:4c:8b:e5:b7:3c:2e:26:b3:
+         c5:54:ce:54:e2:0c:5d:d6:fd:d2:e0:d2:ab:b2:6f:73:f7:89:
+         f7:c2:24:0a:27:62:e6:1c:9d:bb:cb:59:7f:cf:12:18:01:2a:
+         45:be:f2:a1
 -----BEGIN CERTIFICATE-----
 MIIDRTCCAfmgAwIBAgICAQAwQQYJKoZIhvcNAQEKMDSgDzANBglghkgBZQMEAgEF
 AKEcMBoGCSqGSIb3DQEBCDANBglghkgBZQMEAgEFAKIDAgERMDwxEDAOBgNVBAMM

--- a/v2/testdata/subCertIsCA.pem
+++ b/v2/testdata/subCertIsCA.pem
@@ -1,3 +1,71 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Mother Nature, OU = Everything, O = Mother Nature, postalCode = postalcode, C = US, GN = givenname, SN = surname
+        Validity
+            Not Before: Aug 29 21:14:57 2017 GMT
+            Not After : Nov 10 22:14:57 2017 GMT
+        Subject: CN = gov.us, OU = Chaos, O = org, street = 3210 Holly Mill Run, ST = province, postalCode = 30062, GN = hello, SN = surname
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:c9:c5:6b:02:80:77:95:0d:55:be:cb:fa:f8:ca:
+                    d9:c6:b1:34:8b:11:c9:07:cb:6c:9b:62:b0:88:21:
+                    3c:88:c9:e7:00:33:21:84:76:75:2d:84:ba:53:ad:
+                    ff:0c:a6:8c:d3:93:33:6c:c0:f7:10:17:34:69:3c:
+                    4d:45:d3:1d:35:93:1e:13:9f:c6:72:20:4b:cc:d8:
+                    73:b4:71:63:86:dc:f2:7c:a3:a7:c7:e8:f3:b4:35:
+                    19:dd:10:47:6d:be:30:0e:50:2e:37:a7:fd:ef:63:
+                    ce:d2:b8:52:39:3e:ac:ec:33:6b:07:fa:f2:f7:23:
+                    2a:b5:88:b5:cf:cb:db:1f:92:6b:a9:f0:6c:b6:4c:
+                    72:58:ee:48:b1:cc:4e:b0:48:b9:f5:1c:f5:a6:19:
+                    27:db:17:a5:42:68:95:ac:89:32:60:6d:99:45:53:
+                    db:05:d4:f4:80:48:bd:d2:18:65:54:7e:9e:63:12:
+                    a5:b6:5d:eb:15:1e:7c:3e:bf:d4:93:bf:96:f6:58:
+                    0e:3e:ee:55:e2:94:a5:46:e1:50:bc:ee:fc:32:a4:
+                    3e:57:77:13:b6:9c:11:f0:af:ee:ed:bb:b9:a7:3f:
+                    3b:c1:ae:0d:9f:9c:0c:55:fb:a6:70:4b:2e:3b:8d:
+                    32:6d:4e:28:2b:43:cd:40:2e:a2:df:79:82:27:4b:
+                    0c:f5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Authority Key Identifier: 
+                keyid:01:02:03
+
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+
+            X509v3 Subject Alternative Name: 
+                DNS:hell,o.com.uk
+            X509v3 Certificate Policies: 
+                Policy: X509v3 Any Policy
+
+    Signature Algorithm: sha256WithRSAEncryption
+         4c:cc:37:a3:94:f0:11:25:68:ea:62:3e:67:93:f6:a2:dd:97:
+         af:54:2d:73:84:4e:71:47:d2:99:38:06:9d:58:67:3a:f2:04:
+         5d:6b:0f:c5:7f:58:32:33:c5:c8:7b:9e:6d:35:85:12:8c:c5:
+         fa:f5:54:8d:13:c7:73:aa:44:1c:a4:ec:11:44:16:7f:37:1c:
+         a8:1a:d1:99:8d:73:91:84:00:c0:24:19:1a:cd:ad:30:42:6d:
+         82:46:10:ce:bb:ab:b0:2f:d5:d6:45:ce:c4:e1:44:3a:5b:cb:
+         43:ac:5b:fd:8d:f6:9e:ae:86:eb:63:ec:30:90:fe:a9:4c:0f:
+         71:35:6c:6b:ed:08:44:10:0d:9a:46:a2:2d:47:2d:bd:05:bd:
+         24:24:66:40:a3:45:98:ca:29:64:d2:11:86:ea:77:a0:cf:d5:
+         ea:ff:aa:59:80:8a:fb:97:49:54:5a:2e:e8:2f:12:c0:fe:65:
+         ad:da:b2:df:62:d5:9c:ab:29:e1:b5:0d:95:72:91:b0:d4:69:
+         b3:5c:12:50:4c:04:86:fd:e3:d4:5b:2e:ba:8f:c4:e5:79:ef:
+         2b:5b:8b:48:c0:7a:1d:3e:f7:33:b5:17:a3:e2:81:09:3d:21:
+         aa:1f:51:8c:be:46:45:a6:70:b1:b8:4b:2f:76:cd:0f:8a:40:
+         a7:8d:d7:cc
 -----BEGIN CERTIFICATE-----
 MIIEgTCCA2ugAwIBAgIBATALBgkqhkiG9w0BAQswgY8xFjAUBgNVBAMTDU1vdGhl
 ciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcxFjAUBgNVBAoTDU1vdGhlciBO

--- a/v2/testdata/subCertIsNotCA.pem
+++ b/v2/testdata/subCertIsNotCA.pem
@@ -1,3 +1,71 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Mother Nature, OU = Everything, O = Mother Nature, postalCode = postalcode, C = US, GN = givenname, SN = surname
+        Validity
+            Not Before: Aug 29 21:13:52 2017 GMT
+            Not After : Nov 10 22:13:52 2017 GMT
+        Subject: CN = gov.us, OU = Chaos, O = org, street = 3210 Holly Mill Run, ST = province, postalCode = 30062, GN = hello, SN = surname
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:94:08:e9:e8:d8:6f:7b:c0:ac:55:cc:ed:21:48:
+                    d0:01:5e:b1:27:4a:77:c8:9a:65:ef:29:6c:31:ef:
+                    b9:04:3e:65:c7:d8:31:e6:af:b5:bd:3a:18:ef:b7:
+                    1e:ac:d9:90:c5:e8:cd:17:0c:68:08:76:2b:ea:50:
+                    dd:f8:8f:c6:e7:02:ea:a3:36:d6:bb:81:6f:02:72:
+                    2c:76:12:f6:51:9e:92:a9:eb:cd:a6:01:2c:14:06:
+                    2b:0a:10:9a:fb:68:98:26:0c:06:5e:5e:48:18:6f:
+                    d9:08:78:14:56:62:bb:b6:dd:69:63:66:a5:dc:49:
+                    14:2a:07:7e:92:e5:b9:44:04:e4:21:bc:43:67:b4:
+                    21:5f:da:f7:ca:16:ac:f6:53:ea:3a:43:d0:d3:cd:
+                    2c:d9:57:5b:61:b3:cc:e3:f8:34:92:a4:67:3b:a6:
+                    9b:b5:d2:fe:5c:fe:40:fb:e8:34:8f:7e:f3:f2:34:
+                    28:68:b6:20:63:6c:09:67:0c:16:74:42:a2:d1:76:
+                    bd:89:a2:f9:4d:30:74:fa:85:48:c6:52:c8:77:9a:
+                    22:71:28:dd:fc:80:0c:ec:f4:ff:c7:83:f0:8c:65:
+                    5d:44:b9:81:ac:62:f0:12:69:43:73:d2:eb:55:7c:
+                    d7:56:c6:60:52:82:33:2f:76:0a:5d:3a:e5:9d:87:
+                    b7:59
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                keyid:01:02:03
+
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+
+            X509v3 Subject Alternative Name: 
+                DNS:hell,o.com.uk
+            X509v3 Certificate Policies: 
+                Policy: X509v3 Any Policy
+
+    Signature Algorithm: sha256WithRSAEncryption
+         9c:88:27:94:ed:6e:db:11:1a:bf:a1:56:ce:c6:0d:0b:d4:7e:
+         e4:ac:67:b5:32:76:39:cc:66:2e:69:86:15:67:b2:0f:a5:56:
+         8f:bf:3e:56:97:1c:c5:ae:1a:2a:ed:53:28:b2:a6:f9:ef:d1:
+         7d:23:18:ed:a8:c1:d8:18:ca:06:f3:44:26:05:b1:30:aa:e1:
+         c2:f3:ec:74:9b:14:bf:23:da:81:45:73:53:1e:3f:54:8d:2e:
+         7e:a7:2d:7b:be:08:4c:93:01:90:db:75:93:aa:87:9a:21:e3:
+         2d:70:d4:b5:4a:be:4b:6e:cc:b0:2c:c7:5c:fe:3d:40:38:7e:
+         1d:98:37:c2:24:2a:42:70:11:4d:2a:99:15:a9:f5:86:5d:41:
+         cf:29:f3:c4:b1:7b:79:af:45:10:5e:c3:58:1e:6a:fc:9e:05:
+         2a:e4:a6:86:c9:5a:bb:ed:c4:5a:19:e4:80:0d:02:4e:05:8a:
+         bb:e2:74:89:a9:0d:b2:72:15:f6:0f:42:f4:94:f5:6f:f3:42:
+         0d:f0:18:31:55:fa:06:0d:c6:1d:fc:8d:60:b7:90:b2:5b:0e:
+         df:59:f3:7c:9e:a6:4f:00:e7:0f:e6:76:b9:de:0f:83:92:7d:
+         0d:18:ae:88:40:96:9f:ca:2b:a5:01:ba:e6:c2:0d:af:f1:19:
+         c4:54:f9:fe
 -----BEGIN CERTIFICATE-----
 MIIEfjCCA2igAwIBAgIBATALBgkqhkiG9w0BAQswgY8xFjAUBgNVBAMTDU1vdGhl
 ciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcxFjAUBgNVBAoTDU1vdGhlciBO

--- a/v2/testdata/subCertLocalityNameDoesNotNeedToAppear.pem
+++ b/v2/testdata/subCertLocalityNameDoesNotNeedToAppear.pem
@@ -1,3 +1,6 @@
+NOTE: This certificate produces errors when fed through OpenSSL so we omit the
+-text output here.
+
 -----BEGIN CERTIFICATE-----
 MIIEGjCCAwSgAwIBAgIFBDFmk+0wCwYJKoZIhvcNAQELMFQxFjAUBgNVBAMTDU1v
 dGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcxFjAUBgNVBAoTDU1vdGhl

--- a/v2/testdata/subCertLocalityNameMustAppear.pem
+++ b/v2/testdata/subCertLocalityNameMustAppear.pem
@@ -1,3 +1,69 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Mother Nature, OU = Everything, O = Mother Nature, C = US
+        Validity
+            Not Before: Aug 24 03:06:53 2017 GMT
+            Not After : Nov  5 03:06:53 2017 GMT
+        Subject: CN = gov.us, OU = Chaos, street = 3210 Holly Mill Run, postalCode = 30062, C = US, GN = givenname
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:ce:2c:d4:27:40:48:d4:f4:6f:a1:1c:d4:4d:84:
+                    9f:bc:87:56:e6:2d:69:7b:50:aa:8a:ef:6e:9f:21:
+                    aa:03:85:e6:19:b1:ea:4a:fe:9c:09:9b:70:aa:65:
+                    cb:e3:df:de:49:85:19:8c:4d:9d:08:98:67:d0:f7:
+                    11:d7:e2:eb:cb:9d:c5:c0:8c:58:6c:24:6c:53:07:
+                    87:3a:3c:8c:4f:62:82:7e:db:69:3d:88:6e:c4:e4:
+                    57:b6:e3:4d:e6:f0:ef:62:02:57:b2:8b:02:f5:34:
+                    e4:60:94:70:53:83:c7:7a:2c:6e:ae:f0:c7:6b:2e:
+                    c8:b0:9d:fc:cf:00:a5:68:db:94:d2:fe:25:18:64:
+                    42:74:22:2a:d7:b7:ce:bd:d4:76:50:b8:c8:6c:38:
+                    4c:69:2b:54:ad:18:c4:16:bc:19:49:a7:07:f5:38:
+                    9f:8d:73:4d:23:f6:51:3d:2d:8e:6e:c3:83:ac:82:
+                    bc:57:02:20:18:22:a1:7f:ca:76:85:61:3d:c7:e6:
+                    d2:8e:23:a2:ce:8e:77:d3:c6:32:05:e6:ca:41:e4:
+                    f2:d5:be:53:2d:45:29:ff:90:fd:6b:fb:96:0b:52:
+                    9b:7e:49:26:16:e8:10:a2:27:c8:a5:fc:dc:74:d6:
+                    66:b1:06:e0:6f:15:fc:b8:3b:b4:80:a5:98:67:df:
+                    17:3f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                keyid:01:02:03
+
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.3
+
+            Authority Information Access: critical
+                OCSP - URI:http://ss.symcd.com
+                CA Issuers - URI:http://ss.symcb.com/ss.crt
+
+    Signature Algorithm: sha256WithRSAEncryption
+         71:b9:93:1b:7c:c8:87:9c:fa:da:7e:33:87:63:94:6a:05:34:
+         69:ed:2d:82:e5:b0:0f:fe:45:cd:d8:84:67:30:a9:39:1c:f7:
+         bd:f3:7f:23:b1:89:e2:dd:53:a1:a9:1d:12:84:86:11:62:17:
+         12:51:35:bb:e5:c6:cf:1e:ae:2d:fc:2d:da:4a:03:30:d2:d6:
+         f2:0d:29:12:55:f6:9d:11:3e:8e:d0:00:ec:9f:be:20:4a:cb:
+         2a:d0:86:d9:e0:6a:7a:e5:00:9b:b5:fc:02:5d:d9:4c:88:29:
+         b0:fc:33:a8:8b:40:72:4f:4f:c8:ff:3d:7d:4d:e2:3a:45:8e:
+         ae:45:9c:e9:8f:a3:65:16:de:e6:66:75:ed:fc:0b:37:e8:af:
+         9e:1d:2d:86:eb:10:36:94:60:53:53:b5:f0:1f:33:67:90:4c:
+         5b:24:c6:32:61:b2:08:d0:f3:98:fa:bf:fb:da:53:4e:f0:2d:
+         89:7f:b2:6e:46:c9:e0:18:a1:1e:c6:cf:26:04:f8:af:df:07:
+         b1:f7:5b:a3:ab:ef:11:56:30:4b:f9:1c:11:48:18:5f:95:12:
+         31:54:db:f1:b3:f6:71:61:60:0e:ca:7d:3a:39:4a:ae:d3:7a:
+         d5:b9:a5:3e:d3:98:7c:20:d5:93:0c:28:d0:21:e2:e1:79:8b:
+         1d:17:ec:8c
 -----BEGIN CERTIFICATE-----
 MIIEAzCCAu2gAwIBAgIFBDFmk+0wCwYJKoZIhvcNAQELMFQxFjAUBgNVBAMTDU1v
 dGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcxFjAUBgNVBAoTDU1vdGhl

--- a/v2/testdata/subCertLocalityNameNotProhibited.pem
+++ b/v2/testdata/subCertLocalityNameNotProhibited.pem
@@ -1,3 +1,69 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Mother Nature, OU = Everything, O = Mother Nature, C = US
+        Validity
+            Not Before: Aug 24 03:18:47 2017 GMT
+            Not After : Nov  5 03:18:47 2017 GMT
+        Subject: CN = gov.us, OU = Chaos, street = 3210 Holly Mill Run, postalCode = 30062, C = US, GN = givenname
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:bb:43:53:50:31:67:26:64:ec:06:23:29:59:58:
+                    38:54:b7:95:9e:00:98:e5:a0:47:5d:18:54:97:c5:
+                    60:e1:61:f3:2b:e1:d7:22:ba:89:59:96:88:a5:72:
+                    14:61:7a:92:70:81:15:95:41:87:1d:9b:1e:88:a6:
+                    d4:b9:f4:46:d0:c7:11:31:1a:3a:5e:c5:96:72:96:
+                    cc:50:d6:65:f9:13:8a:88:a3:81:f6:4a:8c:9b:64:
+                    a4:3f:89:5b:2e:5f:3a:d3:1f:7a:8e:db:1e:a3:77:
+                    0d:ce:f6:95:26:9d:46:1a:11:06:67:93:88:eb:6a:
+                    66:4a:54:49:bf:0c:65:28:57:a7:d1:a6:28:87:b1:
+                    37:b3:2d:13:3c:f7:00:e3:59:1b:f9:f6:92:8b:a8:
+                    ae:85:54:a2:0a:a2:33:cd:8f:a8:ca:8e:13:ff:9c:
+                    b4:61:62:94:92:9e:4c:ee:f7:04:db:0e:01:4a:16:
+                    43:53:11:ae:67:af:50:fe:64:3d:31:08:87:99:e3:
+                    12:75:35:87:a0:1e:00:75:bc:6e:85:21:a4:0e:06:
+                    38:26:fb:34:49:d7:78:3a:b3:61:f8:61:91:8e:fe:
+                    20:bb:ed:66:e4:1a:a0:2e:14:b2:d3:1a:66:32:4d:
+                    89:ef:7c:e4:2c:c6:99:b1:8b:ab:d2:23:02:a3:44:
+                    5b:45
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                keyid:01:02:03
+
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.3
+
+            Authority Information Access: critical
+                OCSP - URI:http://ss.symcd.com
+                CA Issuers - URI:http://ss.symcb.com/ss.crt
+
+    Signature Algorithm: sha256WithRSAEncryption
+         e1:e2:e0:57:31:46:68:51:23:98:97:93:a3:5d:7d:cc:d1:42:
+         f3:c0:87:dc:a6:e1:76:54:49:99:9a:91:09:e4:20:4a:a0:4a:
+         bb:05:8d:d7:a0:87:cc:c9:0a:9a:50:6e:85:8b:63:66:1e:c9:
+         b2:48:45:9e:52:28:48:0b:5e:62:ec:0f:3b:e2:71:fe:37:ee:
+         df:d2:1d:67:59:a1:5c:c6:38:6f:78:ea:a3:cb:43:ac:6e:ce:
+         63:bd:f6:35:98:e4:7c:49:9e:a0:80:67:0f:b8:ae:88:02:04:
+         10:ba:ad:c4:35:97:04:0d:59:4e:ee:1a:07:34:a5:55:ae:5f:
+         fc:5a:e3:65:f3:d6:6a:ba:4b:61:7c:41:dd:9a:e7:c7:19:a0:
+         71:a3:3e:f3:14:c5:7e:ec:ec:73:59:e8:df:16:90:c5:59:ce:
+         2c:fc:7b:36:2d:24:2f:ac:39:ef:5e:2c:12:58:93:2f:bd:3a:
+         bd:7b:1a:2b:52:9e:43:25:f1:5f:56:63:91:36:89:26:4f:8b:
+         8d:f9:10:a9:32:ef:e9:97:7c:87:7c:d7:34:f2:ff:ad:c2:89:
+         21:bc:61:bf:ac:cb:50:3d:e4:50:3e:8b:cd:48:58:7d:d8:35:
+         d8:c3:84:51:c3:b6:a0:29:10:5b:6f:41:ec:cb:e4:24:63:90:
+         b2:a1:19:6a
 -----BEGIN CERTIFICATE-----
 MIIEAzCCAu2gAwIBAgIFBDFmk+0wCwYJKoZIhvcNAQELMFQxFjAUBgNVBAMTDU1v
 dGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcxFjAUBgNVBAoTDU1vdGhl

--- a/v2/testdata/subCertLocalityNameProhibited.pem
+++ b/v2/testdata/subCertLocalityNameProhibited.pem
@@ -1,3 +1,69 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Mother Nature, OU = Everything, O = Mother Nature, C = US
+        Validity
+            Not Before: Aug 24 03:19:50 2017 GMT
+            Not After : Nov  5 03:19:50 2017 GMT
+        Subject: CN = gov.us, OU = Chaos, street = 3210 Holly Mill Run, L = localility, postalCode = 30062, C = US
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:b7:ed:99:d7:4f:8c:4c:b4:3d:b5:d5:19:54:e1:
+                    95:32:78:08:5f:c8:a6:00:2f:66:fa:bc:85:46:56:
+                    29:fd:89:a2:87:1c:68:9b:f3:18:17:e9:01:85:2f:
+                    09:ce:a3:bc:74:89:be:24:b6:ed:e7:84:b6:0c:80:
+                    3e:72:7c:b6:6f:65:66:6e:c2:23:94:2d:97:c6:d9:
+                    10:12:d3:68:5d:c7:71:d1:ca:0d:39:9c:b9:72:bf:
+                    b6:08:0f:88:c6:4e:57:8d:27:15:48:02:81:32:be:
+                    bf:80:00:55:06:47:1f:af:19:77:42:27:f9:9a:e6:
+                    6a:0f:74:b6:a0:13:96:ef:0a:da:aa:d9:75:a6:f3:
+                    0b:06:07:5f:10:3d:5b:d3:90:0e:86:4c:9a:58:6c:
+                    5b:6b:4c:29:29:d8:33:ca:4e:48:cc:7f:26:dc:99:
+                    32:3c:39:39:4b:03:cc:6e:c3:7f:58:d3:1e:bc:d7:
+                    5c:8f:d4:02:1f:78:9b:0c:7a:72:16:36:20:f7:74:
+                    de:16:cf:ac:f5:23:4d:3b:11:f1:8d:d5:e1:71:48:
+                    f6:42:e3:98:74:8d:7a:9a:7c:50:c6:aa:0b:08:d3:
+                    3d:63:87:67:7a:21:e7:e4:2c:29:29:44:64:eb:4d:
+                    cf:e5:ec:fa:ca:91:6e:a4:4e:fd:18:e5:76:0c:38:
+                    f5:e3
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                keyid:01:02:03
+
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.3
+
+            Authority Information Access: critical
+                OCSP - URI:http://ss.symcd.com
+                CA Issuers - URI:http://ss.symcb.com/ss.crt
+
+    Signature Algorithm: sha256WithRSAEncryption
+         dc:36:ce:ed:32:a2:5e:72:7d:f4:01:65:90:77:a3:23:c0:75:
+         cc:af:51:b0:09:e4:ed:03:96:01:ad:54:09:85:c2:48:c9:2e:
+         69:68:59:1a:6d:db:15:cc:ec:b8:c9:7d:8b:92:20:ad:1e:1d:
+         9c:2f:43:85:89:70:46:eb:a9:1f:ee:85:39:a6:3b:b4:5d:89:
+         f2:29:96:9e:c8:92:cc:20:f9:c4:f6:4a:4a:78:b0:e3:12:69:
+         ac:ef:9f:bc:c3:c7:b4:9d:12:c1:74:19:cf:8c:ce:e2:bc:cb:
+         27:c7:e0:0c:5e:a0:92:04:51:0c:5e:66:5f:96:42:90:fc:56:
+         51:3a:bd:4a:3f:c1:5c:c4:86:d2:87:e6:ba:7a:f9:c4:dc:6e:
+         04:00:ef:50:3d:2d:48:49:07:2f:ad:8e:98:30:6a:f8:56:fa:
+         29:82:72:fe:50:bd:82:1d:3b:16:46:1d:6b:ab:a1:12:ce:65:
+         2d:58:1f:57:dd:66:19:cc:96:52:1a:67:55:96:e7:c0:e1:64:
+         22:b4:5e:65:52:57:da:46:47:33:7d:53:a5:42:b3:6f:f9:9a:
+         40:9e:55:1e:ce:42:2e:66:8c:72:a5:2e:95:0d:48:97:9d:34:
+         14:70:f6:ae:21:2e:b1:e2:26:98:b0:d0:49:05:c4:ba:4f:a6:
+         46:ae:22:b5
 -----BEGIN CERTIFICATE-----
 MIIEBDCCAu6gAwIBAgIFBDFmk+0wCwYJKoZIhvcNAQELMFQxFjAUBgNVBAMTDU1v
 dGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcxFjAUBgNVBAoTDU1vdGhl

--- a/v2/testdata/subCertProvinceCanAppear.pem
+++ b/v2/testdata/subCertProvinceCanAppear.pem
@@ -1,3 +1,69 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Mother Nature, OU = Everything, O = Mother Nature, C = US
+        Validity
+            Not Before: Aug 24 03:47:24 2017 GMT
+            Not After : Nov  5 03:47:24 2017 GMT
+        Subject: CN = gov.us, OU = Chaos, street = 3210 Holly Mill Run, ST = province, postalCode = 30062, C = US, GN = hello
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:b7:7d:99:9d:ce:0b:2a:7e:93:30:91:ef:9f:75:
+                    b9:d4:3e:9a:6f:e9:0b:7f:d0:9e:a7:6b:0f:53:e1:
+                    13:ad:3e:13:dc:5f:19:8b:8a:46:6a:b5:c0:46:04:
+                    c0:93:90:3d:b0:1c:be:19:b5:4e:a4:2f:eb:8d:39:
+                    f0:bd:4a:ab:b7:0c:0b:46:46:4f:a6:65:a7:ba:6f:
+                    4b:6a:37:8a:51:bf:18:76:4b:a2:53:38:86:f8:c9:
+                    ad:22:8c:5c:88:8d:78:d5:48:3b:93:95:64:9c:54:
+                    d2:cb:bd:e1:43:a5:59:1d:25:c4:af:fb:94:92:5c:
+                    6f:2a:c5:19:2f:dc:fb:79:f4:dd:cc:3d:3f:78:5d:
+                    76:4b:c1:79:93:a5:7e:d4:31:7d:20:1b:4e:6f:79:
+                    5a:96:ca:66:f2:13:72:ef:83:4f:e6:6e:84:24:aa:
+                    75:6c:d7:df:b7:3f:b6:7b:55:fa:b5:e7:65:18:e1:
+                    79:2c:a3:a3:79:45:79:94:4e:c2:d8:c8:a7:cd:8c:
+                    57:21:b9:94:05:a2:b3:e6:83:c2:da:0b:77:71:a5:
+                    a6:a0:d4:3d:45:1b:af:4f:07:da:93:fb:84:de:b4:
+                    bf:f3:94:de:63:12:34:60:d9:31:3b:24:34:a8:6f:
+                    84:10:b5:13:f6:39:88:9a:59:aa:3b:09:68:08:4c:
+                    b6:1d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                keyid:01:02:03
+
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.3
+
+            Authority Information Access: critical
+                OCSP - URI:http://ss.symcd.com
+                CA Issuers - URI:http://ss.symcb.com/ss.crt
+
+    Signature Algorithm: sha256WithRSAEncryption
+         96:fd:5b:9b:2c:5c:5d:54:03:68:30:96:dc:ce:9e:9a:02:97:
+         ed:e7:b6:6e:4b:8c:0c:7a:c2:69:a6:f7:21:d0:22:38:c0:c0:
+         14:b3:ea:b9:39:20:dd:37:20:a3:6f:57:1f:27:91:f7:cb:b5:
+         d4:2f:14:04:1f:eb:bc:4d:49:e6:af:37:15:e1:e4:d5:ab:57:
+         1b:04:9f:02:63:ac:69:88:3b:00:21:73:e3:e3:f4:d2:25:5a:
+         3c:7f:bb:36:de:ad:df:4e:7e:28:bc:c4:22:e8:34:c4:f3:d0:
+         45:2c:40:48:64:94:5b:06:9f:5b:53:5b:ed:6c:84:d4:33:e6:
+         05:e6:b8:27:98:32:6f:02:a1:1a:a0:b0:80:11:50:7a:03:85:
+         a6:a5:9a:a5:d6:41:ac:7c:9b:7c:4f:ea:54:1d:1b:cf:29:7e:
+         9d:49:71:5b:35:bc:dd:03:d6:32:c0:82:c2:0c:8f:11:62:f4:
+         90:b5:23:8c:a2:3a:ae:89:12:07:61:3b:04:b7:28:32:c6:c4:
+         dd:1e:b8:61:11:27:2c:ee:82:29:23:6a:d3:21:27:f9:c6:4c:
+         0b:a5:7b:82:78:46:c9:4f:f6:4b:d1:43:18:a8:3e:00:3f:6d:
+         97:b5:d9:e0:94:a5:41:a5:e3:b3:ef:62:93:35:0e:4f:90:69:
+         19:c0:b5:55
 -----BEGIN CERTIFICATE-----
 MIIEEzCCAv2gAwIBAgIFBDFmk+0wCwYJKoZIhvcNAQELMFQxFjAUBgNVBAMTDU1v
 dGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcxFjAUBgNVBAoTDU1vdGhl

--- a/v2/testdata/subCertProvinceMustNotAppear.pem
+++ b/v2/testdata/subCertProvinceMustNotAppear.pem
@@ -1,3 +1,69 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Mother Nature, OU = Everything, O = Mother Nature, C = US
+        Validity
+            Not Before: Aug 24 03:45:36 2017 GMT
+            Not After : Nov  5 03:45:36 2017 GMT
+        Subject: CN = gov.us, OU = Chaos, street = 3210 Holly Mill Run, ST = province, postalCode = 30062, C = US
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:d3:94:ac:e4:53:92:3d:21:0a:8e:73:ff:9c:2d:
+                    3c:e5:d5:30:7f:2f:73:d6:57:7a:0d:02:18:87:f6:
+                    d5:71:a0:0b:66:21:03:38:f7:7f:8b:22:7b:41:12:
+                    12:e0:82:78:10:b0:99:d2:f1:2c:8f:e5:00:91:ba:
+                    c1:2c:63:9e:dd:8c:f3:ac:59:7a:b1:b5:14:23:4e:
+                    4a:74:4f:16:89:d6:ce:ec:13:45:a4:14:00:00:74:
+                    82:be:91:a7:e2:de:da:80:bb:f6:c0:34:23:dc:f8:
+                    81:f7:75:df:ff:f0:fb:b3:5b:81:6f:a4:b6:41:2d:
+                    4d:b3:74:61:52:13:a7:f3:98:b4:81:b9:55:6d:25:
+                    c4:8c:f2:eb:c9:bb:0b:3b:42:69:79:a9:ea:29:c9:
+                    db:3f:bb:8a:69:83:cf:16:f9:c9:d8:57:5b:e1:2a:
+                    45:05:46:b2:36:d4:06:70:29:29:49:ee:31:33:59:
+                    46:20:63:2e:fd:12:eb:38:73:93:6a:d4:6d:9f:a4:
+                    fe:6e:ea:3b:0c:eb:9b:fe:75:09:9e:21:8d:fe:32:
+                    fc:eb:02:d1:7f:e6:98:cf:dc:4a:e5:4a:ec:b6:06:
+                    d6:29:8b:bb:ce:7d:36:fe:a4:5e:3f:30:b5:c9:1c:
+                    7f:49:27:fa:96:67:94:92:fa:f0:46:54:36:5f:6a:
+                    cd:3d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                keyid:01:02:03
+
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.3
+
+            Authority Information Access: critical
+                OCSP - URI:http://ss.symcd.com
+                CA Issuers - URI:http://ss.symcb.com/ss.crt
+
+    Signature Algorithm: sha256WithRSAEncryption
+         09:f1:0c:3b:f9:6d:29:66:8b:35:79:6b:92:15:54:75:0a:10:
+         ac:d0:1c:08:05:45:bc:9d:d9:09:da:bc:91:85:4d:45:d7:c5:
+         0d:ee:d2:28:68:59:93:3e:5c:90:e9:25:64:4b:15:85:97:39:
+         d3:34:25:c0:bb:d0:38:cb:cf:6c:c4:7c:79:82:fc:cb:39:cf:
+         22:82:a2:8e:4a:c2:a2:46:4e:31:0d:05:0c:7d:cd:c0:83:78:
+         58:d0:ef:d6:6e:a6:ce:b5:4e:3f:55:c4:d5:a0:a9:d0:5d:0b:
+         ae:86:f7:59:11:f8:d1:23:fe:3e:fa:ac:ce:a3:a1:f9:8d:de:
+         59:2f:18:a1:0a:c8:69:2b:dc:31:0d:f4:d3:db:b8:19:8c:21:
+         7e:c6:b4:f9:ab:a6:e8:82:4c:99:c1:5c:4f:41:ba:51:e4:ef:
+         2b:2d:e0:11:41:9e:3f:72:1c:17:a8:ab:ef:80:70:c0:1c:69:
+         69:b8:47:17:b2:63:7a:75:26:e9:8c:c9:60:f8:1d:05:c6:8d:
+         84:fb:ca:3b:8e:2a:50:c1:73:87:66:12:0a:fd:9a:73:36:0a:
+         44:c0:de:4c:3b:72:40:28:5a:73:28:63:57:6b:2e:c9:06:b9:
+         5d:9b:86:e8:96:8d:ce:8e:1c:b4:35:9b:84:c6:ef:e8:b4:3a:
+         20:73:24:ae
 -----BEGIN CERTIFICATE-----
 MIIEAjCCAuygAwIBAgIFBDFmk+0wCwYJKoZIhvcNAQELMFQxFjAUBgNVBAMTDU1v
 dGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcxFjAUBgNVBAoTDU1vdGhl

--- a/v2/testdata/subCrlDistURLInCompoundFullName.pem
+++ b/v2/testdata/subCrlDistURLInCompoundFullName.pem
@@ -1,3 +1,84 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            4d:8b:9c:9c:5a:73:3d:d5:42:e4:a8:8c:89:2d:f2:cd
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = DE, ST = Bayern, O = Freistaat Bayern, CN = Bayerische SSL-CA-2017-01
+        Validity
+            Not Before: Sep 20 10:20:18 2017 GMT
+            Not After : Sep 20 10:20:18 2020 GMT
+        Subject: C = DE, ST = Bayern, O = Freistaat Bayern, OU = ldbv, CN = www.piwik.bayern.de, serialNumber = 1003672
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:dc:e2:64:6e:f1:3e:57:09:c7:f0:fd:5a:7f:4b:
+                    72:96:0e:0d:37:2f:b2:6e:02:6a:08:eb:29:de:f2:
+                    35:c2:fe:de:4c:fe:c1:9a:18:a9:d0:f4:2d:ed:ee:
+                    c5:91:95:c5:8f:9a:cd:19:94:39:20:7f:a5:dc:11:
+                    7e:61:51:3f:5c:38:9e:cc:8c:4f:99:27:35:6a:96:
+                    bb:70:bf:1b:5d:9b:15:37:eb:99:35:05:60:79:1f:
+                    55:93:1a:ae:82:3d:a5:e3:89:18:48:11:14:70:ff:
+                    7e:de:b8:8d:33:77:37:d2:1e:8f:45:84:7f:97:0c:
+                    47:68:de:13:d3:03:0c:0c:93:59:95:4a:5e:e9:c1:
+                    09:ee:be:5e:e8:0c:04:3c:16:6c:bc:fc:9a:d4:c9:
+                    81:c7:2f:84:7b:dc:ee:97:e5:3c:aa:95:e4:f5:16:
+                    05:d1:df:f4:59:a9:d2:bb:f9:eb:78:bf:72:6e:19:
+                    4d:e3:a5:c3:82:03:02:9b:74:be:ae:19:3c:bc:d8:
+                    65:af:95:de:9d:61:5c:19:9d:a6:87:01:6e:20:a0:
+                    98:20:f7:70:13:27:70:1d:fc:31:b3:2d:a9:eb:ad:
+                    02:8e:4e:50:27:bd:97:99:b5:67:2f:92:16:1e:81:
+                    8a:be:24:14:a6:14:20:18:54:1c:2e:49:c2:b1:8d:
+                    f1:81
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: critical
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Authority Key Identifier: 
+                keyid:4B:49:46:61:45:00:FD:6B:B6:0C:EE:B6:CB:04:A1:BC:12:E1:C4:4E
+
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.pki.bayern.de:8080
+                CA Issuers - URI:ldap://directory2.bayern.de/cn=Bayerische%20SSL-CA-2017-01,ou=CA-certs,dc=pki,dc=bayern,dc=de?cACertificate?base?objectclass=certificationAuthority
+                CA Issuers - URI:http://www.pki.bayern.de/download/sslpki/certs/Bayerische_SSL-CA-2017-01.cer
+                CA Issuers - URI:ldap://directory.bayern.de/cn=Bayerische%20SSL-CA-2017-01,ou=CA-certs,dc=pki,dc=bayern,dc=de?cACertificate?base?objectclass=certificationAuthority
+
+            X509v3 Certificate Policies: 
+                Policy: 1.3.6.1.4.1.19266.1.2.3
+                  CPS: https://www.pki.bayern.de/policy/policy_ssl-ca_1.0.pdf
+
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:ldap://directory.bayern.de/cn=Bayerische%20SSL-CA-2017-01,ou=crl,dc=pki,dc=bayern,dc=de?certificateRevocationList?base?objectclass=cRLDistributionPoint
+                  URI:ldap://directory2.bayern.de/cn=Bayerische%20SSL-CA-2017-01,ou=crl,dc=pki,dc=bayern,dc=de?certificateRevocationList?base?objectclass=cRLDistributionPoint
+                  URI:http://ocsp.pki.bayern.de/crl/Bayerische%20SSL-CA-2017-01.crl
+
+            X509v3 Subject Key Identifier: 
+                44:36:0B:58:02:31:E4:FB
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment, Data Encipherment
+            X509v3 Subject Alternative Name: 
+                DNS:piwik.bayern.de, DNS:www.piwik.bayern.de
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: sha256WithRSAEncryption
+         31:66:ad:ef:a3:6d:28:b9:48:a8:f4:89:0f:fb:29:25:b7:25:
+         27:4e:44:a7:9f:5f:9a:2b:07:fc:73:94:be:bf:c9:3d:ae:a8:
+         16:5c:a6:b8:02:58:b5:e1:89:23:da:35:e8:7f:ed:b7:8e:b9:
+         6e:f3:4a:41:78:08:80:24:7e:a8:ec:b9:66:55:4e:17:00:ad:
+         41:a6:f0:6b:1f:b3:f3:b1:03:a9:ac:ee:76:f8:a2:cb:29:28:
+         35:fd:8e:ed:05:dc:a4:7c:df:1b:ba:26:d6:0d:8a:eb:8c:25:
+         cd:e0:44:c7:0c:77:93:ca:bf:88:cf:5b:09:7d:63:cd:ed:e9:
+         d8:e5:16:e7:0e:4d:1e:c4:dc:55:e2:75:3f:12:a4:52:ff:a5:
+         e2:fb:0f:fa:2e:b7:ea:f2:72:1c:18:ce:d4:b5:9a:05:51:34:
+         0a:b8:d4:c1:8c:ec:7e:50:bb:d1:f3:c9:57:1d:c9:48:2f:ff:
+         43:f0:2f:49:d9:c8:c4:02:43:87:da:df:1a:4b:41:f0:8e:60:
+         9f:b4:93:7d:de:da:d8:7f:ce:bd:ea:9b:cb:6e:98:da:cb:24:
+         68:90:1b:0f:26:d5:eb:4c:40:de:e0:29:83:ce:3b:1b:38:73:
+         a6:72:70:bc:83:e6:b0:c7:e3:e0:aa:f4:52:29:57:55:81:25:
+         ea:8c:a6:15
 -----BEGIN CERTIFICATE-----
 MIIH3DCCBsSgAwIBAgIQTYucnFpzPdVC5KiMiS3yzTANBgkqhkiG9w0BAQsFADBd
 MQswCQYDVQQGEwJERTEPMA0GA1UECAwGQmF5ZXJuMRkwFwYDVQQKDBBGcmVpc3Rh

--- a/v2/testdata/subjectCommonNamePrintableStringBadAlpha.pem
+++ b/v2/testdata/subjectCommonNamePrintableStringBadAlpha.pem
@@ -1,3 +1,78 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            03:7b:4c:a4:c9:81:9e:65:a5:05:25:17:ed:fa:93:e3:6b:11
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Let's Encrypt, CN = Let's Encrypt Authority X3
+        Validity
+            Not Before: Mar 12 22:28:26 2018 GMT
+            Not After : Jun 10 22:28:26 2018 GMT
+        Subject: CN = *.b4a87c.aws.radiantlock.org
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:fc:11:7b:d2:73:6c:2f:fc:11:6c:2d:ce:85:ae:
+                    49:80:78:13:fe:d4:1c:4f:ed:d2:94:43:c9:35:e7:
+                    5b:1f:ed:f5:e5:18:72:f8:1d:e9:93:d2:07:9e:6c:
+                    0f:dc:6b:4f:73:8d:f0:2e:b5:c8:e8:11:a9:79:f2:
+                    fd:c4:08:55:8c:a3:ad:a4:69:32:5f:88:b8:b8:9f:
+                    e5:74:a3:e5:b0:db:8b:58:fb:b3:07:2a:67:14:79:
+                    84:5e:c4:b7:32:9e:1d:ad:75:0e:14:51:f9:4d:aa:
+                    1e:02:80:d8:41:9a:90:46:fc:de:2e:40:2b:df:b8:
+                    ce:07:5d:64:2c:9d:ca:36:6a:22:5d:d4:96:ab:9c:
+                    e0:14:6e:c7:2f:9b:43:ad:54:cd:44:be:57:e4:40:
+                    ac:0a:ea:19:12:4d:b8:d7:e8:ce:ea:83:5b:bf:91:
+                    2e:d2:04:19:3c:60:7c:fb:fa:5e:a5:17:e8:61:e0:
+                    3d:a3:d3:3d:fa:c3:d6:5f:b7:6c:c4:8a:be:e3:90:
+                    2f:c6:28:08:21:bd:33:fc:8c:09:fc:26:db:16:ab:
+                    a8:ca:59:bc:66:e8:d3:98:28:d9:2d:86:78:d0:cb:
+                    61:2c:3b:5a:dc:a5:5a:e9:20:9d:45:08:12:68:51:
+                    61:58:ea:35:37:9b:81:12:67:78:73:37:cd:5f:41:
+                    65:3b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                FC:B3:85:E4:D7:4B:01:38:66:0B:42:DB:CF:04:4A:2D:95:F6:89:11
+            X509v3 Authority Key Identifier: 
+                keyid:A8:4A:6A:63:04:7D:DD:BA:E6:D1:39:B7:A6:45:65:EF:F3:A8:EC:A1
+
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.int-x3.letsencrypt.org
+                CA Issuers - URI:http://cert.int-x3.letsencrypt.org/
+
+            X509v3 Subject Alternative Name: 
+                DNS:*.b4a87c.aws.radiantlock.org, DNS:b4a87c.aws.radiantlock.org
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+                Policy: 1.3.6.1.4.1.44947.1.1.1
+                  CPS: http://cps.letsencrypt.org
+                  User Notice:
+                    Explicit Text: This Certificate may only be relied upon by Relying Parties and only in accordance with the Certificate Policy found at https://letsencrypt.org/repository/
+
+    Signature Algorithm: sha256WithRSAEncryption
+         47:67:24:53:f2:0b:b1:12:d7:b8:fb:b2:93:7f:52:0a:80:47:
+         2f:e4:45:e3:25:2a:ff:e0:cb:9d:1e:c5:c0:65:e2:d3:f0:02:
+         d5:92:93:48:27:be:c9:af:99:f6:d1:fc:57:db:83:b5:5e:25:
+         fa:a4:14:46:71:68:08:c5:68:9b:b6:f0:0b:69:db:80:03:1a:
+         2e:f6:e7:07:fa:8e:75:61:07:1b:6a:9b:05:c0:be:11:cf:be:
+         d0:69:2e:32:dc:ac:19:d2:9c:1a:02:07:05:e4:08:3f:80:30:
+         34:7c:ef:d2:32:1f:27:0b:ea:ef:22:79:e5:51:4c:0d:67:1e:
+         11:fd:ef:83:07:ec:fe:3f:d0:cd:5f:09:b1:ee:6c:02:0f:d0:
+         91:c1:90:9a:b3:53:76:a6:fc:a8:e7:f6:98:e5:d8:bd:e9:dd:
+         d3:7b:00:7b:cf:3e:7c:26:54:a9:04:8b:87:00:c1:d2:31:21:
+         52:fb:59:0f:f8:ed:23:db:40:6b:69:50:e5:bd:25:42:30:08:
+         e2:e7:a2:2b:36:bd:4d:e7:44:6f:8e:99:5f:7e:b0:d2:71:1a:
+         d6:e2:c9:d5:3a:41:22:81:94:f8:d4:41:e5:45:8f:24:dd:65:
+         f1:dd:7c:08:55:9e:da:10:dd:44:3c:5a:85:28:02:b6:f4:9d:
+         7e:92:e8:a6
 -----BEGIN CERTIFICATE-----
 MIIFNzCCBB+gAwIBAgISA3tMpMmBnmWlBSUX7fqT42sRMA0GCSqGSIb3DQEBCwUA
 MEoxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MSMwIQYDVQQD

--- a/v2/testdata/subjectRDNSIPv4BadIP.pem
+++ b/v2/testdata/subjectRDNSIPv4BadIP.pem
@@ -1,3 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: 
+        Validity
+            Not Before: Feb 27 13:58:15 2019 GMT
+            Not After : Feb 24 14:58:15 2029 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:db:d3:8f:ab:1a:f5:3c:4e:9a:20:91:1c:31:39:
+                    6f:ef:fb:01:89:b8:b7:9c:2b:29:37:89:e8:ec:64:
+                    13:7f:2c:44:f3:b4:ee:de:62:32:7a:9d:eb:56:28:
+                    39:96:f1:d9:3e:64:ed:f1:cd:8e:b6:cd:07:f3:17:
+                    0f:a2:da:bc:6d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: critical
+                DNS:zmap.io, DNS:a.b.c.d.in-addr.arpa
+    Signature Algorithm: sha256WithRSAEncryption
+         92:d4:4f:65:cb:f9:4b:c9:b2:d5:aa:d3:ac:4d:71:d4:ac:6d:
+         97:6f:82:5c:c7:9c:29:c8:1f:7c:cb:b1:59:20:f5:64:c4:00:
+         4b:04:af:c8:94:cd:ca:87:65:31:94:53:f0:37:85:fc:5b:22:
+         b0:b5:2a:51:4d:11:02:f8:fd:aa
 -----BEGIN CERTIFICATE-----
 MIIBTTCB+KADAgECAgIFOTANBgkqhkiG9w0BAQsFADAAMB4XDTE5MDIyNzEzNTgx
 NVoXDTI5MDIyNDE0NTgxNVowADBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQDb04+r

--- a/v2/testdata/subjectRDNSIPv4GoodIP.pem
+++ b/v2/testdata/subjectRDNSIPv4GoodIP.pem
@@ -1,3 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: 
+        Validity
+            Not Before: Feb 27 13:58:15 2019 GMT
+            Not After : Feb 24 14:58:15 2029 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:db:d3:8f:ab:1a:f5:3c:4e:9a:20:91:1c:31:39:
+                    6f:ef:fb:01:89:b8:b7:9c:2b:29:37:89:e8:ec:64:
+                    13:7f:2c:44:f3:b4:ee:de:62:32:7a:9d:eb:56:28:
+                    39:96:f1:d9:3e:64:ed:f1:cd:8e:b6:cd:07:f3:17:
+                    0f:a2:da:bc:6d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: critical
+                DNS:zmap.io, DNS:8.8.8.8.in-addr.arpa
+    Signature Algorithm: sha256WithRSAEncryption
+         42:1a:18:ca:6e:0c:dd:9c:ef:33:2c:73:a5:ca:bf:10:4a:61:
+         2c:70:0c:5d:0b:27:78:7e:f8:be:46:c5:8e:9b:c0:1f:d6:dd:
+         73:d6:f4:d6:e4:fe:d9:1c:12:29:2c:31:2c:bc:39:e7:fa:09:
+         1a:54:5c:14:57:5f:5e:ce:49:db
 -----BEGIN CERTIFICATE-----
 MIIBTTCB+KADAgECAgIFOTANBgkqhkiG9w0BAQsFADAAMB4XDTE5MDIyNzEzNTgx
 NVoXDTI5MDIyNDE0NTgxNVowADBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQDb04+r

--- a/v2/testdata/subjectRDNSIPv4ReservedIP.pem
+++ b/v2/testdata/subjectRDNSIPv4ReservedIP.pem
@@ -1,3 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: 
+        Validity
+            Not Before: Feb 27 13:58:15 2019 GMT
+            Not After : Feb 24 14:58:15 2029 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:db:d3:8f:ab:1a:f5:3c:4e:9a:20:91:1c:31:39:
+                    6f:ef:fb:01:89:b8:b7:9c:2b:29:37:89:e8:ec:64:
+                    13:7f:2c:44:f3:b4:ee:de:62:32:7a:9d:eb:56:28:
+                    39:96:f1:d9:3e:64:ed:f1:cd:8e:b6:cd:07:f3:17:
+                    0f:a2:da:bc:6d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: critical
+                DNS:zmap.io, DNS:1.1.168.192.in-addr.arpa
+    Signature Algorithm: sha256WithRSAEncryption
+         c7:c0:4b:37:63:e1:75:36:91:e3:48:40:e4:68:99:aa:30:42:
+         23:34:76:0d:a1:6f:40:4f:e3:9b:f4:d9:f3:f2:da:2c:9f:50:
+         78:e9:06:7e:6f:b6:ce:da:33:93:7c:f7:85:71:cb:04:26:88:
+         78:29:f1:c2:ca:9d:28:1b:87:92
 -----BEGIN CERTIFICATE-----
 MIIBUTCB/KADAgECAgIFOTANBgkqhkiG9w0BAQsFADAAMB4XDTE5MDIyNzEzNTgx
 NVoXDTI5MDIyNDE0NTgxNVowADBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQDb04+r

--- a/v2/testdata/subjectRDNSIPv4TooFewLabels.pem
+++ b/v2/testdata/subjectRDNSIPv4TooFewLabels.pem
@@ -1,3 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: 
+        Validity
+            Not Before: Feb 27 13:58:15 2019 GMT
+            Not After : Feb 24 14:58:15 2029 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:db:d3:8f:ab:1a:f5:3c:4e:9a:20:91:1c:31:39:
+                    6f:ef:fb:01:89:b8:b7:9c:2b:29:37:89:e8:ec:64:
+                    13:7f:2c:44:f3:b4:ee:de:62:32:7a:9d:eb:56:28:
+                    39:96:f1:d9:3e:64:ed:f1:cd:8e:b6:cd:07:f3:17:
+                    0f:a2:da:bc:6d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: critical
+                DNS:zmap.io, DNS:1.168.192.in-addr.arpa
+    Signature Algorithm: sha256WithRSAEncryption
+         6c:c6:f3:04:ad:13:a3:a3:76:d7:44:3c:e5:ee:6e:73:b5:5a:
+         2c:5f:35:9d:dd:7f:12:9a:3f:8f:0f:02:59:ea:13:e6:7c:90:
+         de:fe:5c:25:eb:88:ff:47:e4:3b:70:d6:49:4d:6e:7f:6a:dc:
+         94:3a:02:fa:a6:b3:dc:fa:03:70
 -----BEGIN CERTIFICATE-----
 MIIBTzCB+qADAgECAgIFOTANBgkqhkiG9w0BAQsFADAAMB4XDTE5MDIyNzEzNTgx
 NVoXDTI5MDIyNDE0NTgxNVowADBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQDb04+r

--- a/v2/testdata/subjectRDNSIPv6BadIP.pem
+++ b/v2/testdata/subjectRDNSIPv6BadIP.pem
@@ -1,3 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: 
+        Validity
+            Not Before: Feb 27 13:58:15 2019 GMT
+            Not After : Feb 24 14:58:15 2029 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:db:d3:8f:ab:1a:f5:3c:4e:9a:20:91:1c:31:39:
+                    6f:ef:fb:01:89:b8:b7:9c:2b:29:37:89:e8:ec:64:
+                    13:7f:2c:44:f3:b4:ee:de:62:32:7a:9d:eb:56:28:
+                    39:96:f1:d9:3e:64:ed:f1:cd:8e:b6:cd:07:f3:17:
+                    0f:a2:da:bc:6d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: critical
+                DNS:zmap.io, DNS:j.a.9.8.7.6.5.0.4.0.0.0.3.0.0.0.2.0.0.0.1.0.0.0.0.0.0.0.1.2.3.4.ip6.arpa
+    Signature Algorithm: sha256WithRSAEncryption
+         81:db:ec:6b:38:09:b5:e4:b0:dd:1f:97:db:27:13:28:f3:6e:
+         c8:32:92:bf:9b:40:8e:16:03:2c:6a:cc:a6:eb:b1:f0:a3:30:
+         f0:39:b6:38:86:6b:6f:0c:c3:91:16:1a:3d:48:12:61:e6:5d:
+         28:52:7c:4d:b8:45:2b:e6:28:ff
 -----BEGIN CERTIFICATE-----
 MIIBhDCCAS6gAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwADAeFw0xOTAyMjcxMzU4
 MTVaFw0yOTAyMjQxNDU4MTVaMAAwXDANBgkqhkiG9w0BAQEFAANLADBIAkEA29OP

--- a/v2/testdata/subjectRDNSIPv6GoodIP.pem
+++ b/v2/testdata/subjectRDNSIPv6GoodIP.pem
@@ -1,3 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: 
+        Validity
+            Not Before: Feb 27 13:58:15 2019 GMT
+            Not After : Feb 24 14:58:15 2029 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:db:d3:8f:ab:1a:f5:3c:4e:9a:20:91:1c:31:39:
+                    6f:ef:fb:01:89:b8:b7:9c:2b:29:37:89:e8:ec:64:
+                    13:7f:2c:44:f3:b4:ee:de:62:32:7a:9d:eb:56:28:
+                    39:96:f1:d9:3e:64:ed:f1:cd:8e:b6:cd:07:f3:17:
+                    0f:a2:da:bc:6d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: critical
+                DNS:zmap.io, DNS:8.8.8.8.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.6.8.4.0.6.8.4.1.0.0.2.ip6.arpa
+    Signature Algorithm: sha256WithRSAEncryption
+         aa:0d:46:a0:db:bb:8b:d8:67:46:85:65:13:1b:19:71:68:b8:
+         e5:8c:d9:09:e3:59:18:f9:32:65:1c:ac:34:e6:c5:a6:7d:2e:
+         0c:72:17:c7:81:e1:f7:fe:79:41:43:f5:66:ac:67:b7:eb:85:
+         ae:fd:13:3a:43:4e:a7:9f:13:cd
 -----BEGIN CERTIFICATE-----
 MIIBhDCCAS6gAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwADAeFw0xOTAyMjcxMzU4
 MTVaFw0yOTAyMjQxNDU4MTVaMAAwXDANBgkqhkiG9w0BAQEFAANLADBIAkEA29OP

--- a/v2/testdata/subjectRDNSIPv6ReservedIP.pem
+++ b/v2/testdata/subjectRDNSIPv6ReservedIP.pem
@@ -1,3 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: 
+        Validity
+            Not Before: Feb 27 16:35:26 2019 GMT
+            Not After : Feb 24 17:35:26 2029 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:b9:be:cd:60:56:dd:66:68:a5:66:1c:7a:cb:d2:
+                    5e:12:f5:40:22:94:bc:1a:08:d5:f2:bc:82:c5:58:
+                    cb:e0:74:3b:6d:d2:8b:08:61:65:73:ca:f7:6f:5b:
+                    ba:eb:a8:66:3c:3f:95:bb:c2:1d:b0:8f:e1:84:6f:
+                    cd:c6:8c:9f:65
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: critical
+                DNS:zmap.io, DNS:1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f.ip6.arpa
+    Signature Algorithm: sha256WithRSAEncryption
+         b9:6f:08:4e:35:93:f6:3e:ad:1e:e8:fd:73:ca:f9:13:a1:6c:
+         5c:18:cb:be:cb:66:08:48:af:74:70:fb:97:88:2d:a8:26:fb:
+         2f:5d:a6:7e:18:3a:27:bc:a1:eb:fb:c8:f8:81:54:4d:46:bb:
+         65:60:d3:0e:68:46:8e:78:1e:ce
 -----BEGIN CERTIFICATE-----
 MIIBhDCCAS6gAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwADAeFw0xOTAyMjcxNjM1
 MjZaFw0yOTAyMjQxNzM1MjZaMAAwXDANBgkqhkiG9w0BAQEFAANLADBIAkEAub7N

--- a/v2/testdata/subjectRDNSIPv6TooFewLabels.pem
+++ b/v2/testdata/subjectRDNSIPv6TooFewLabels.pem
@@ -1,3 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1337 (0x539)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: 
+        Validity
+            Not Before: Feb 27 13:58:15 2019 GMT
+            Not After : Feb 24 14:58:15 2029 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (512 bit)
+                Modulus:
+                    00:db:d3:8f:ab:1a:f5:3c:4e:9a:20:91:1c:31:39:
+                    6f:ef:fb:01:89:b8:b7:9c:2b:29:37:89:e8:ec:64:
+                    13:7f:2c:44:f3:b4:ee:de:62:32:7a:9d:eb:56:28:
+                    39:96:f1:d9:3e:64:ed:f1:cd:8e:b6:cd:07:f3:17:
+                    0f:a2:da:bc:6d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name: critical
+                DNS:zmap.io, DNS:a.9.8.7.6.5.0.4.0.0.0.3.0.0.0.2.0.0.0.1.0.0.0.0.0.0.0.1.2.3.4.ip6.arpa
+    Signature Algorithm: sha256WithRSAEncryption
+         a4:e0:a3:18:b7:70:4e:83:55:b2:49:97:04:05:4e:e1:d8:6f:
+         2d:56:9f:a4:53:34:23:2a:6b:50:bc:dc:06:e5:3c:ba:9a:0e:
+         4b:62:a4:d8:63:6e:15:67:0a:ea:c3:d2:bf:1e:4b:3f:57:d8:
+         ae:72:b7:f3:f0:b8:8f:00:ac:24
 -----BEGIN CERTIFICATE-----
 MIIBgjCCASygAwIBAgICBTkwDQYJKoZIhvcNAQELBQAwADAeFw0xOTAyMjcxMzU4
 MTVaFw0yOTAyMjQxNDU4MTVaMAAwXDANBgkqhkiG9w0BAQEFAANLADBIAkEA29OP

--- a/v2/testdata/subjectWithSingleQuote.pem
+++ b/v2/testdata/subjectWithSingleQuote.pem
@@ -1,3 +1,83 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0f:5e:bb:0f:06:74:02:92:c5:39:94:f6:4f:07:c5:3f
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = DigiCert Inc, OU = www.digicert.com, CN = GeoTrust EV RSA CA 2018
+        Validity
+            Not Before: Sep 18 00:00:00 2018 GMT
+            Not After : Oct  6 12:00:00 2019 GMT
+        Subject: businessCategory = Private Organization, jurisdictionC = RU, serialNumber = 1067746801814, C = RU, ST = Voronezhskaya oblast, L = Voronezh, O = LLC 'Managing Company 'Agro - Invest', OU = IT, CN = gis.agroinvest.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:85:35:3f:13:01:1f:3a:11:a5:ce:3c:9a:c8:67:
+                    89:5b:a2:4f:2e:b8:da:f5:93:6d:97:23:58:4a:4f:
+                    6f:da:c6:ff:3a:3e:98:16:a1:d5:53:6b:82:4c:59:
+                    5d:8b:77:b2:e1:cf:26:3c:39:29:96:a2:98:04:9c:
+                    a7:cf:b1:87:8f:b1:5a:6f:75:78:c2:f3:6b:a9:9a:
+                    ee:ae:64:ee:11:b9:39:02:0a:58:2e:77:43:d9:ba:
+                    4b:58:4f:cd:b4:46:64:ea:f1:80:51:13:81:a0:32:
+                    10:dd:70:94:10:d7:71:ad:e3:c0:5e:94:60:94:59:
+                    dd:9c:b3:bf:59:42:d2:2e:f8:a2:ba:ac:38:07:86:
+                    44:73:a8:65:09:10:e8:d6:6c:82:29:a1:e8:91:d9:
+                    98:a4:b1:db:6f:9d:cd:60:ff:54:dc:6b:2e:4a:83:
+                    e7:49:2b:1d:b0:ec:9e:b9:98:f1:8b:92:d7:7e:be:
+                    e3:7a:80:61:b8:47:4b:51:58:91:3a:32:64:84:00:
+                    21:a6:ca:26:fe:6a:53:16:15:7a:8b:cc:06:4b:eb:
+                    3d:5f:ef:b9:93:50:39:4f:17:64:3d:6a:c6:c8:80:
+                    f8:87:50:23:34:34:d4:27:b0:70:7e:56:db:9b:0b:
+                    ac:43:4e:8a:1b:6c:6d:f6:3b:f4:60:de:2e:3c:d7:
+                    9d:e5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:CA:92:67:52:61:DE:AE:FC:BA:22:2B:7F:1C:87:4C:25:FB:6F:99:58
+
+            X509v3 Subject Key Identifier: 
+                1A:59:66:07:6F:82:1F:29:E5:22:AB:10:B2:8E:3D:51:1D:23:A1:4A
+            X509v3 Subject Alternative Name: 
+                DNS:gis.agroinvest.com
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://cdp.geotrust.com/GeoTrustEVRSACA2018.crl
+
+            X509v3 Certificate Policies: 
+                Policy: 2.16.840.1.114412.2.1
+                  CPS: https://www.digicert.com/CPS
+                Policy: 2.23.140.1.1
+
+            Authority Information Access: 
+                OCSP - URI:http://status.geotrust.com
+                CA Issuers - URI:http://cacerts.geotrust.com/GeoTrustEVRSACA2018.crt
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+            CT Precertificate Poison: critical
+                NULL
+    Signature Algorithm: sha256WithRSAEncryption
+         7a:da:8b:78:f0:86:b6:71:fb:f0:de:4e:d9:bc:11:38:22:bd:
+         01:0a:b8:4c:a8:13:19:2c:bf:fd:91:e4:c1:2e:da:07:b8:73:
+         71:bc:be:d5:e5:8f:ec:ca:55:aa:04:d0:10:20:7c:66:cf:70:
+         7e:1b:59:a9:6f:4d:6a:fc:77:dc:77:9a:45:5c:5b:6a:a0:95:
+         76:b1:03:38:4c:5a:cd:4c:ba:f5:bb:90:a7:7f:36:37:c3:d1:
+         40:f9:70:6c:01:64:76:75:45:0d:c7:61:a2:f7:8c:2d:48:ce:
+         0b:31:eb:12:fc:d7:05:db:c0:78:8a:57:71:73:63:23:ef:2c:
+         e2:33:bf:25:9d:51:c4:ca:95:5d:18:ae:e3:2d:99:30:95:58:
+         98:4f:22:25:b6:f3:7c:73:17:15:8f:ba:99:6a:89:ed:f6:79:
+         3b:2a:2a:ec:81:b8:67:c1:2c:f6:15:72:d6:bb:dc:59:a2:b6:
+         78:e5:dd:49:0b:23:1d:35:f8:8d:cf:28:5b:74:31:53:6f:f7:
+         af:e2:27:0d:17:3d:e7:52:d8:7f:1d:c0:ce:ad:1a:64:78:95:
+         b3:62:f7:8d:9a:98:33:19:e5:29:10:fb:d1:62:98:07:b5:83:
+         48:86:74:ae:3d:4a:6e:05:15:fd:3d:0d:22:1b:05:e9:9c:dc:
+         1e:30:c4:a4
 -----BEGIN CERTIFICATE-----
 MIIFjTCCBHWgAwIBAgIQD167DwZ0ApLFOZT2TwfFPzANBgkqhkiG9w0BAQsFADBh
 MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3

--- a/v2/util/gtld_map.go
+++ b/v2/util/gtld_map.go
@@ -6676,7 +6676,7 @@ var tldMap = map[string]GTLDPeriod{
 	"vistaprint": {
 		GTLD:           "vistaprint",
 		DelegationDate: "2015-06-22",
-		RemovalDate:    "",
+		RemovalDate:    "2020-03-13",
 	},
 	"viva": {
 		GTLD:           "viva",


### PR DESCRIPTION
The old version of `test/prepend_testcerts_openssl.sh` needed to be run from a specific directory, didn't pass `shellcheck`, and would unconditionally prepend the OpenSSL text output to all certs in the testdata dir (even if they already had it).

The version in 04c9d99 should be safer and suitable to be integrated with CI. It also supports taking a glob as the first argument and only prepending certs that need it and have a filename that matches the glob. I kept it in BASH rather than rewriting it in Go since we're shelling out to `openssl` and I find that's fiddly work in Go and the overall complexity of the script is low.

b250164 contains the results of running the script against the full `testdata` directory. Many testcerts were missing OpenSSL text output and this commit fixes them across the board.

06f8b73 is the one exception where `openssl` fails to parse the certificate. For now I've added a note about this to the `.pem` file such that the `prepend_testcerts_openssl.sh` script no longer emits a warning. I haven't done any investigation work into the testcert/testcase and why it fails to parse.

db871ab updates CI to run the `test/prepend_testcerts_openssl.sh` script for each branch's build and exit with an error code if there are diffs. This will make sure we don't introduce any new test certs after b250164 that forget to include some text before the PEM contents.