### PR TITLE
Fix spelling of 'distinguished' in lint descriptions

### DIFF
--- a/v2/lints/rfc/lint_ca_subject_field_empty.go
+++ b/v2/lints/rfc/lint_ca_subject_field_empty.go
@@ -53,7 +53,7 @@ func (l *caSubjectEmpty) Execute(c *x509.Certificate) *lint.LintResult {
 func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_ca_subject_field_empty",
-		Description:   "CA Certificates subject field MUST not be empty and MUST have a non-empty distingushed name",
+		Description:   "CA Certificates subject field MUST not be empty and MUST have a non-empty distinguished name",
 		Citation:      "RFC 5280: 4.1.2.6",
 		Source:        lint.RFC5280,
 		EffectiveDate: util.RFC2459Date,

--- a/v2/lints/rfc/lint_issuer_field_empty.go
+++ b/v2/lints/rfc/lint_issuer_field_empty.go
@@ -49,7 +49,7 @@ func (l *issuerFieldEmpty) Execute(c *x509.Certificate) *lint.LintResult {
 func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_issuer_field_empty",
-		Description:   "Certificate issuer field MUST NOT be empty and must have a non-empty distingushed name",
+		Description:   "Certificate issuer field MUST NOT be empty and must have a non-empty distinguished name",
 		Citation:      "RFC 5280: 4.1.2.4",
 		Source:        lint.RFC5280,
 		EffectiveDate: util.RFC2459Date,


### PR DESCRIPTION
Two lints were missing the third 'i' in 'distinguished'.