### PR TITLE
ci: upgrade Go from 1.13.x -> 1.14.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 dist: trusty
 
 go:
-  - "1.13.x"
+  - "1.14.x"
 
 install:
   # Install `golangci-lint` using the installer script


### PR DESCRIPTION
_Note: We might want to hold this on https://github.com/zmap/zcrypto/pull/218 and bump that dep. at the same time. :man_shrugging:_