### PR TITLE
ci: update goreleaser install URL.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
 
 install:
   # Install `golangci-lint` using the installer script
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
 
 script:
   # Fast-fail on non-zero exit codes


### PR DESCRIPTION
The [upstream project README](https://github.com/golangci/golangci-lint#install) is using a different URL now and in my tests the old URL has an HTTPS subject common name mismatch preventing installation from succeeding.

This is also manifesting as a broken [master build](https://travis-ci.org/github/zmap/zlint/jobs/685679642#L473-L474) in CI:
> $ curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
> curl: (22) The requested URL returned error: 404 Not Found