### PR TITLE
Move EV-specific tests to cabf_ev

### DIFF
--- a/v2/lints/cabf_ev/lint_ev_business_category_missing.go
+++ b/v2/lints/cabf_ev/lint_ev_business_category_missing.go
@@ -1,4 +1,4 @@
-package cabf_br
+package cabf_ev
 
 /*
  * ZLint Copyright 2020 Regents of the University of Michigan
@@ -20,18 +20,18 @@ import (
 	"github.com/zmap/zlint/v2/util"
 )
 
-type evOrgMissing struct{}
+type evNoBiz struct{}
 
-func (l *evOrgMissing) Initialize() error {
+func (l *evNoBiz) Initialize() error {
 	return nil
 }
 
-func (l *evOrgMissing) CheckApplies(c *x509.Certificate) bool {
+func (l *evNoBiz) CheckApplies(c *x509.Certificate) bool {
 	return util.IsEV(c.PolicyIdentifiers) && util.IsSubscriberCert(c)
 }
 
-func (l *evOrgMissing) Execute(c *x509.Certificate) *lint.LintResult {
-	if util.TypeInName(&c.Subject, util.OrganizationNameOID) {
+func (l *evNoBiz) Execute(c *x509.Certificate) *lint.LintResult {
+	if util.TypeInName(&c.Subject, util.BusinessOID) {
 		return &lint.LintResult{Status: lint.Pass}
 	} else {
 		return &lint.LintResult{Status: lint.Error}
@@ -40,11 +40,11 @@ func (l *evOrgMissing) Execute(c *x509.Certificate) *lint.LintResult {
 
 func init() {
 	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ev_organization_name_missing",
-		Description:   "EV certificates must include organizationName in subject",
-		Citation:      "BRs: 7.1.6.1",
-		Source:        lint.CABFBaselineRequirements,
+		Name:          "e_ev_business_category_missing",
+		Description:   "EV certificates must include businessCategory in subject",
+		Citation:      "EVGs: 9.2.3",
+		Source:        lint.CABFEVGuidelines,
 		EffectiveDate: util.ZeroDate,
-		Lint:          &evOrgMissing{},
+		Lint:          &evNoBiz{},
 	})
 }

--- a/v2/lints/cabf_ev/lint_ev_business_category_missing_test.go
+++ b/v2/lints/cabf_ev/lint_ev_business_category_missing_test.go
@@ -1,4 +1,4 @@
-package cabf_br
+package cabf_ev
 
 /*
  * ZLint Copyright 2020 Regents of the University of Michigan
@@ -21,19 +21,10 @@ import (
 	"github.com/zmap/zlint/v2/test"
 )
 
-func TestEvHasOrg(t *testing.T) {
+func TestEvNoBiz(t *testing.T) {
 	inputPath := "evAllGood.pem"
-	expected := lint.Pass
-	out := test.TestLint("e_ev_organization_name_missing", inputPath)
-	if out.Status != expected {
-		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
-	}
-}
-
-func TestEvNoOrg(t *testing.T) {
-	inputPath := "evNoOrg.pem"
 	expected := lint.Error
-	out := test.TestLint("e_ev_organization_name_missing", inputPath)
+	out := test.TestLint("e_ev_business_category_missing", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}

--- a/v2/lints/cabf_ev/lint_ev_country_name_missing.go
+++ b/v2/lints/cabf_ev/lint_ev_country_name_missing.go
@@ -1,4 +1,4 @@
-package cabf_br
+package cabf_ev
 
 /*
  * ZLint Copyright 2020 Regents of the University of Michigan
@@ -20,30 +20,31 @@ import (
 	"github.com/zmap/zlint/v2/util"
 )
 
-type evSNMissing struct{}
+type evCountryMissing struct{}
 
-func (l *evSNMissing) Initialize() error {
+func (l *evCountryMissing) Initialize() error {
 	return nil
 }
 
-func (l *evSNMissing) CheckApplies(c *x509.Certificate) bool {
+func (l *evCountryMissing) CheckApplies(c *x509.Certificate) bool {
 	return util.IsEV(c.PolicyIdentifiers) && util.IsSubscriberCert(c)
 }
 
-func (l *evSNMissing) Execute(c *x509.Certificate) *lint.LintResult {
-	if len(c.Subject.SerialNumber) == 0 {
+func (l *evCountryMissing) Execute(c *x509.Certificate) *lint.LintResult {
+	if util.TypeInName(&c.Subject, util.CountryNameOID) {
+		return &lint.LintResult{Status: lint.Pass}
+	} else {
 		return &lint.LintResult{Status: lint.Error}
 	}
-	return &lint.LintResult{Status: lint.Pass}
 }
 
 func init() {
 	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ev_serial_number_missing",
-		Description:   "EV certificates must include serialNumber in subject",
-		Citation:      "EV gudelines: 9.2.6",
-		Source:        lint.CABFBaselineRequirements,
+		Name:          "e_ev_country_name_missing",
+		Description:   "EV certificates must include countryName in subject",
+		Citation:      "EVGs: 9.2.4",
+		Source:        lint.CABFEVGuidelines,
 		EffectiveDate: util.ZeroDate,
-		Lint:          &evSNMissing{},
+		Lint:          &evCountryMissing{},
 	})
 }

--- a/v2/lints/cabf_ev/lint_ev_country_name_missing_test.go
+++ b/v2/lints/cabf_ev/lint_ev_country_name_missing_test.go
@@ -1,4 +1,4 @@
-package cabf_br
+package cabf_ev
 
 /*
  * ZLint Copyright 2020 Regents of the University of Michigan

--- a/v2/lints/cabf_ev/lint_ev_organization_name_missing.go
+++ b/v2/lints/cabf_ev/lint_ev_organization_name_missing.go
@@ -1,4 +1,4 @@
-package cabf_br
+package cabf_ev
 
 /*
  * ZLint Copyright 2020 Regents of the University of Michigan
@@ -20,18 +20,18 @@ import (
 	"github.com/zmap/zlint/v2/util"
 )
 
-type evCountryMissing struct{}
+type evOrgMissing struct{}
 
-func (l *evCountryMissing) Initialize() error {
+func (l *evOrgMissing) Initialize() error {
 	return nil
 }
 
-func (l *evCountryMissing) CheckApplies(c *x509.Certificate) bool {
+func (l *evOrgMissing) CheckApplies(c *x509.Certificate) bool {
 	return util.IsEV(c.PolicyIdentifiers) && util.IsSubscriberCert(c)
 }
 
-func (l *evCountryMissing) Execute(c *x509.Certificate) *lint.LintResult {
-	if util.TypeInName(&c.Subject, util.CountryNameOID) {
+func (l *evOrgMissing) Execute(c *x509.Certificate) *lint.LintResult {
+	if util.TypeInName(&c.Subject, util.OrganizationNameOID) {
 		return &lint.LintResult{Status: lint.Pass}
 	} else {
 		return &lint.LintResult{Status: lint.Error}
@@ -40,11 +40,11 @@ func (l *evCountryMissing) Execute(c *x509.Certificate) *lint.LintResult {
 
 func init() {
 	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ev_country_name_missing",
-		Description:   "EV certificates must include countryName in subject",
-		Citation:      "BRs: 7.1.6.1",
-		Source:        lint.CABFBaselineRequirements,
+		Name:          "e_ev_organization_name_missing",
+		Description:   "EV certificates must include organizationName in subject",
+		Citation:      "EVGs: 9.2.1",
+		Source:        lint.CABFEVGuidelines,
 		EffectiveDate: util.ZeroDate,
-		Lint:          &evCountryMissing{},
+		Lint:          &evOrgMissing{},
 	})
 }

--- a/v2/lints/cabf_ev/lint_ev_organization_name_missing_test.go
+++ b/v2/lints/cabf_ev/lint_ev_organization_name_missing_test.go
@@ -1,4 +1,4 @@
-package cabf_br
+package cabf_ev
 
 /*
  * ZLint Copyright 2020 Regents of the University of Michigan
@@ -21,19 +21,19 @@ import (
 	"github.com/zmap/zlint/v2/test"
 )
 
-func TestEvHasSN(t *testing.T) {
+func TestEvHasOrg(t *testing.T) {
 	inputPath := "evAllGood.pem"
 	expected := lint.Pass
-	out := test.TestLint("e_ev_serial_number_missing", inputPath)
+	out := test.TestLint("e_ev_organization_name_missing", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
 
-func TestEvNoSN(t *testing.T) {
-	inputPath := "evNoSN.pem"
+func TestEvNoOrg(t *testing.T) {
+	inputPath := "evNoOrg.pem"
 	expected := lint.Error
-	out := test.TestLint("e_ev_serial_number_missing", inputPath)
+	out := test.TestLint("e_ev_organization_name_missing", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}

--- a/v2/lints/cabf_ev/lint_ev_serial_number_missing.go
+++ b/v2/lints/cabf_ev/lint_ev_serial_number_missing.go
@@ -1,4 +1,4 @@
-package cabf_br
+package cabf_ev
 
 /*
  * ZLint Copyright 2020 Regents of the University of Michigan
@@ -20,31 +20,30 @@ import (
 	"github.com/zmap/zlint/v2/util"
 )
 
-type evNoBiz struct{}
+type evSNMissing struct{}
 
-func (l *evNoBiz) Initialize() error {
+func (l *evSNMissing) Initialize() error {
 	return nil
 }
 
-func (l *evNoBiz) CheckApplies(c *x509.Certificate) bool {
+func (l *evSNMissing) CheckApplies(c *x509.Certificate) bool {
 	return util.IsEV(c.PolicyIdentifiers) && util.IsSubscriberCert(c)
 }
 
-func (l *evNoBiz) Execute(c *x509.Certificate) *lint.LintResult {
-	if util.TypeInName(&c.Subject, util.BusinessOID) {
-		return &lint.LintResult{Status: lint.Pass}
-	} else {
+func (l *evSNMissing) Execute(c *x509.Certificate) *lint.LintResult {
+	if len(c.Subject.SerialNumber) == 0 {
 		return &lint.LintResult{Status: lint.Error}
 	}
+	return &lint.LintResult{Status: lint.Pass}
 }
 
 func init() {
 	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ev_business_category_missing",
-		Description:   "EV certificates must include businessCategory in subject",
-		Citation:      "BRs: 7.1.6.1",
-		Source:        lint.CABFBaselineRequirements,
+		Name:          "e_ev_serial_number_missing",
+		Description:   "EV certificates must include serialNumber in subject",
+		Citation:      "EVGs: 9.2.6",
+		Source:        lint.CABFEVGuidelines,
 		EffectiveDate: util.ZeroDate,
-		Lint:          &evNoBiz{},
+		Lint:          &evSNMissing{},
 	})
 }

--- a/v2/lints/cabf_ev/lint_ev_serial_number_missing_test.go
+++ b/v2/lints/cabf_ev/lint_ev_serial_number_missing_test.go
@@ -1,4 +1,4 @@
-package cabf_br
+package cabf_ev
 
 /*
  * ZLint Copyright 2020 Regents of the University of Michigan
@@ -21,10 +21,19 @@ import (
 	"github.com/zmap/zlint/v2/test"
 )
 
-func TestEvNoBiz(t *testing.T) {
+func TestEvHasSN(t *testing.T) {
 	inputPath := "evAllGood.pem"
+	expected := lint.Pass
+	out := test.TestLint("e_ev_serial_number_missing", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestEvNoSN(t *testing.T) {
+	inputPath := "evNoSN.pem"
 	expected := lint.Error
-	out := test.TestLint("e_ev_business_category_missing", inputPath)
+	out := test.TestLint("e_ev_serial_number_missing", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}

--- a/v2/lints/cabf_ev/lint_ev_valid_time_too_long.go
+++ b/v2/lints/cabf_ev/lint_ev_valid_time_too_long.go
@@ -1,4 +1,4 @@
-package cabf_br
+package cabf_ev
 
 /*
  * ZLint Copyright 2020 Regents of the University of Michigan

--- a/v2/lints/cabf_ev/lint_ev_valid_time_too_long_test.go
+++ b/v2/lints/cabf_ev/lint_ev_valid_time_too_long_test.go
@@ -1,4 +1,4 @@
-package cabf_br
+package cabf_ev
 
 /*
  * ZLint Copyright 2020 Regents of the University of Michigan

--- a/v2/lints/cabf_ev/lint_onion_subject_validity_time_too_large.go
+++ b/v2/lints/cabf_ev/lint_onion_subject_validity_time_too_large.go
@@ -61,7 +61,7 @@ func init() {
 		Description: fmt.Sprintf(
 			"certificates with .onion names can not be valid for more than %d months",
 			maxOnionValidityMonths),
-		Citation:      "CABF EV Guidelines: Appendix F",
+		Citation:      "EVGs: Appendix F",
 		Source:        lint.CABFEVGuidelines,
 		EffectiveDate: util.OnionOnlyEVDate,
 		Lint:          &torValidityTooLarge{},


### PR DESCRIPTION
This moves the lints for the EV Guidelines into `cabf_ev`, ensuring a consistent sourcing and reference.

Closes #439 