### PR TITLE
Fix the EV validity period check

### DIFF
--- a/v2/integration/config.json
+++ b/v2/integration/config.json
@@ -328,7 +328,9 @@
     "e_ev_serial_number_missing": {
       "ErrCount": 1
     },
-    "e_ev_valid_time_too_long": {},
+    "e_ev_valid_time_too_long": {
+      "ErrCount": 151
+    },
     "e_ext_aia_marked_critical": {},
     "e_ext_authority_key_identifier_critical": {},
     "e_ext_authority_key_identifier_missing": {

--- a/v2/lints/cabf_br/lint_ev_valid_time_too_long.go
+++ b/v2/lints/cabf_br/lint_ev_valid_time_too_long.go
@@ -27,11 +27,16 @@ func (l *evValidTooLong) Initialize() error {
 }
 
 func (l *evValidTooLong) CheckApplies(c *x509.Certificate) bool {
-	return util.IsEV(c.PolicyIdentifiers) && util.IsSubscriberCert(c)
+	// CA/Browser Forum Ballot 193 changed the maximum validity period to be
+	// 825 days, which is more permissive than 27-month certificates, as that
+	// is 823 days.
+	return c.NotBefore.Before(util.SubCert825Days) &&
+		util.IsSubscriberCert(c) &&
+		util.IsEV(c.PolicyIdentifiers)
 }
 
 func (l *evValidTooLong) Execute(c *x509.Certificate) *lint.LintResult {
-	if c.NotBefore.AddDate(0, 0, 825).Before(c.NotAfter) {
+	if c.NotBefore.AddDate(0, 27, 0).Before(c.NotAfter) {
 		return &lint.LintResult{Status: lint.Error}
 	}
 	return &lint.LintResult{Status: lint.Pass}
@@ -40,9 +45,9 @@ func (l *evValidTooLong) Execute(c *x509.Certificate) *lint.LintResult {
 func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "e_ev_valid_time_too_long",
-		Description:   "EV certificates must be 825 days in validity or less",
-		Citation:      "BRs: 6.3.2",
-		Source:        lint.CABFBaselineRequirements,
+		Description:   "EV certificates must be 27 months in validity or less",
+		Citation:      "EVGs 1.0: 8(a), EVGs 1.6.1: 9.4",
+		Source:        lint.CABFEVGuidelines,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &evValidTooLong{},
 	})

--- a/v2/lints/cabf_br/lint_ev_valid_time_too_long_test.go
+++ b/v2/lints/cabf_br/lint_ev_valid_time_too_long_test.go
@@ -22,19 +22,33 @@ import (
 )
 
 func TestEvValidTooLong(t *testing.T) {
-	inputPath := "evValidTooLong.pem"
-	expected := lint.Error
-	out := test.TestLint("e_ev_valid_time_too_long", inputPath)
-	if out.Status != expected {
-		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	testCases := []struct {
+		Name           string
+		InputFilename  string
+		ExpectedResult lint.LintStatus
+	}{
+		{
+			Name:           "EV certificate valid for > 27 months",
+			InputFilename:  "evValidTooLong.pem",
+			ExpectedResult: lint.Error,
+		},
+		{
+			Name:           "EV certificate issued before Ballot 193 valid for 27 months",
+			InputFilename:  "evValidNotTooLong.pem",
+			ExpectedResult: lint.Pass,
+		},
+		{
+			Name:           "EV certificate issued after Ballot 193, valid for 825 days, which is >27 months",
+			InputFilename:  "evValidNotTooLong825Days.pem",
+			ExpectedResult: lint.NA,
+		},
 	}
-}
-
-func TestEvValidNotTooLong(t *testing.T) {
-	inputPath := "evValidNotTooLong.pem"
-	expected := lint.Pass
-	out := test.TestLint("e_ev_valid_time_too_long", inputPath)
-	if out.Status != expected {
-		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := test.TestLint("e_ev_valid_time_too_long", tc.InputFilename)
+			if result.Status != tc.ExpectedResult {
+				t.Errorf("expected result %v was %v", tc.ExpectedResult, result.Status)
+			}
+		})
 	}
 }

--- a/v2/testdata/evValidNotTooLong.pem
+++ b/v2/testdata/evValidNotTooLong.pem
@@ -2,131 +2,109 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            06:9e:7f:ca:9f:c8:0a:7e:75:bd:26:df:07:38:c3:a8
-    Signature Algorithm: sha256WithRSAEncryption
-        Issuer:
-            commonName                = PRINTABLESTRING:DigiCert SHA2 Extended Validation Server CA
-            organizationalUnitName    = PRINTABLESTRING:www.digicert.com
-            organizationName          = PRINTABLESTRING:DigiCert Inc
-            countryName               = PRINTABLESTRING:US
+            5e:bf:9c:6a:6c:f2:30:55:18:6d:0a:35:0a:dd:6f:cd
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = "thawte, Inc.", CN = thawte EV SSL CA - G3
         Validity
-            Not Before: Apr 30 00:00:00 2018 GMT
-            Not After : Aug  2 00:00:00 2020 GMT
-        Subject:
-            commonName                = PRINTABLESTRING:www.pillpack.com
-            organizationName          = PRINTABLESTRING:PillPack, Inc
-            localityName              = PRINTABLESTRING:Manchester
-            stateOrProvinceName       = PRINTABLESTRING:New Hampshire
-            countryName               = PRINTABLESTRING:US
-            serialNumber              = PRINTABLESTRING:5282593
-            jurisdictionStateOrProvinceName = PRINTABLESTRING:Delaware
-            jurisdictionCountryName   = PRINTABLESTRING:US
-            businessCategory          = UTF8STRING:Private Organization
+            Not Before: Aug  1 00:00:00 2017 GMT
+            Not After : Oct 17 23:59:59 2019 GMT
+        Subject: jurisdictionC = GB, O = TELEFONICA UK LIMITED, C = GB, ST = Berkshire, L = Slough, businessCategory = Private Organization, serialNumber = 01743099, OU = Operations, CN = bt-api.o2wifi.co.uk
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:cc:d8:aa:7d:94:c1:0a:33:05:03:04:7b:06:18:
-                    55:df:02:98:e0:33:26:80:aa:3e:43:0d:16:22:17:
-                    de:c1:93:33:11:96:50:73:d7:3c:6a:a5:32:73:e9:
-                    2a:bd:5a:da:ce:c5:21:45:75:d0:1a:15:7e:7f:38:
-                    82:27:ee:53:6f:d2:d3:b6:3f:9d:ad:5f:e5:7e:43:
-                    63:48:5e:c7:4a:d7:8f:ca:42:1e:c1:aa:ef:5b:e1:
-                    33:44:46:8c:75:76:1b:84:96:bc:94:51:92:cc:2c:
-                    5f:b4:75:a0:03:62:74:d4:c1:6d:ef:41:d0:89:3d:
-                    76:66:be:5e:f8:a0:ca:c3:c8:ef:92:be:ca:ab:84:
-                    81:e6:00:a8:a1:1e:ba:40:2d:43:44:0f:ca:60:b1:
-                    b5:72:94:70:72:a6:9c:83:c4:5b:8e:1a:3e:d2:dd:
-                    75:53:5e:37:4d:29:83:e4:70:53:40:66:e5:1b:32:
-                    c5:6c:c6:ac:d7:a5:73:d1:4c:0a:49:83:46:ff:ba:
-                    f0:c6:c5:98:fb:bf:a4:53:a3:16:81:cc:ea:c4:58:
-                    70:32:96:6d:31:45:ae:ab:28:58:89:e4:35:e2:78:
-                    76:9f:8b:a5:d5:88:74:ec:18:95:db:36:5d:cd:30:
-                    c2:07:b7:04:ff:1c:18:9a:45:ea:d5:8b:6a:12:a4:
-                    f3:61
+                    00:c6:44:5e:3a:23:6d:68:4d:81:2c:8a:5a:a2:cf:
+                    5f:8e:f9:a0:a9:1f:5d:fe:82:df:c7:0c:cc:34:b1:
+                    45:5e:b3:b9:ea:0a:45:b5:41:e2:8f:07:4b:51:1a:
+                    48:e9:9a:d7:4e:6b:2a:11:8f:b8:ec:3a:54:6b:e8:
+                    b0:0a:4e:20:5f:ad:05:e5:85:52:cd:aa:00:00:34:
+                    0b:e7:ca:c1:24:11:d0:73:e9:df:59:b7:97:aa:4c:
+                    7b:94:32:ec:75:e8:6d:71:fb:e2:e7:16:2d:fb:1c:
+                    45:cd:f6:c4:5c:cf:e1:6f:1d:a8:97:d2:db:09:04:
+                    2b:41:4d:4b:3d:25:62:a4:b5:25:42:af:24:53:2c:
+                    79:b3:fa:ac:ef:2d:e9:54:f6:4d:8a:df:56:54:de:
+                    34:d7:d7:2c:f4:68:0b:b9:9a:cc:95:07:b6:e2:7e:
+                    b4:1c:e6:ca:19:a8:db:84:bb:1d:81:da:9c:54:a8:
+                    d5:49:a2:9a:c0:97:23:70:9b:06:76:e5:fc:15:81:
+                    30:93:a8:6c:2a:9e:e7:6d:41:a3:13:38:00:3c:e8:
+                    57:65:01:bb:6a:3e:c4:bb:b2:7c:69:b4:c2:08:c4:
+                    1f:06:3b:11:02:74:58:17:e4:5f:ee:0b:ec:bc:e0:
+                    5c:61:13:0d:f5:dc:7b:b5:65:31:7e:28:5a:53:f1:
+                    5f:83
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
-            X509v3 Authority Key Identifier:
-                keyid:3D:D3:50:A5:D6:A0:AD:EE:F3:4A:60:0A:65:D3:21:D4:F8:F8:D6:0F
-
-            X509v3 Subject Key Identifier:
-                E9:DA:44:27:29:71:BB:2F:59:05:D3:87:2A:9C:95:F1:3A:46:A9:65
-            X509v3 Subject Alternative Name:
-                DNS:www.pillpack.com, DNS:my.pillpack.com, DNS:admin.pillpack.com, DNS:api.pillpack.com
+            X509v3 Subject Alternative Name: 
+                DNS:bt-api.o2wifi.co.uk
+            X509v3 Basic Constraints: 
+                CA:FALSE
             X509v3 Key Usage: critical
                 Digital Signature, Key Encipherment
-            X509v3 Extended Key Usage:
-                TLS Web Server Authentication, TLS Web Client Authentication
-            X509v3 CRL Distribution Points:
+            X509v3 CRL Distribution Points: 
 
                 Full Name:
-                  URI:http://crl3.digicert.com/sha2-ev-server-g2.crl
+                  URI:http://ti.symcb.com/ti.crl
 
-                Full Name:
-                  URI:http://crl4.digicert.com/sha2-ev-server-g2.crl
-
-            X509v3 Certificate Policies:
-                Policy: 2.16.840.1.114412.2.1
-                  CPS: https://www.digicert.com/CPS
+            X509v3 Certificate Policies: 
+                Policy: 2.16.840.1.113733.1.7.48.1
+                  CPS: https://www.thawte.com/cps
+                  User Notice:
+                    Explicit Text: https://www.thawte.com/repository
                 Policy: 2.23.140.1.1
 
-            Authority Information Access:
-                OCSP - URI:http://ocsp.digicert.com
-                CA Issuers - URI:http://cacerts.digicert.com/DigiCertSHA2ExtendedValidationServerCA.crt
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Authority Key Identifier: 
+                keyid:F0:70:51:DA:D3:2A:91:4F:52:77:D7:86:77:74:0F:CE:71:1A:6C:22
 
-            X509v3 Basic Constraints: critical
-                CA:FALSE
+            Authority Information Access: 
+                OCSP - URI:http://ti.symcd.com
+                CA Issuers - URI:http://ti.symcb.com/ti.crt
+
             CT Precertificate Poison: critical
-                ..
+                NULL
     Signature Algorithm: sha256WithRSAEncryption
-         01:6a:50:0f:94:5a:26:af:d8:fe:79:74:b0:d9:5a:bf:ee:05:
-         89:8c:16:38:4b:cf:86:39:cc:73:44:b4:6b:72:95:fc:ba:55:
-         47:65:74:08:7d:17:eb:d8:7e:94:2d:db:3b:90:8c:2b:15:c0:
-         d1:49:a5:94:a9:6c:a4:99:2a:bf:43:6f:b9:43:8b:7b:6b:b8:
-         19:8b:8c:b7:f6:0a:6e:c2:15:8b:c8:50:2b:62:71:bf:1c:dd:
-         26:37:aa:7e:2e:3e:fa:4d:ae:a7:a6:c4:0b:00:75:c7:61:e9:
-         ad:a4:2b:00:36:33:82:87:62:6d:e1:b6:8f:7a:ce:c0:a2:d8:
-         d3:ae:7a:34:2f:54:c6:e1:7b:4a:64:09:04:50:44:12:84:c7:
-         5b:7f:00:44:28:c0:1e:a4:b1:1f:bf:cf:8c:d3:88:84:91:73:
-         a6:10:af:6e:01:43:20:33:68:43:8e:b3:01:0d:87:ea:63:e2:
-         dc:ac:8f:86:bc:a2:b2:74:65:79:43:35:58:60:bf:00:bf:cf:
-         b3:d1:44:6f:7d:93:ae:7f:e2:eb:80:f6:90:21:33:c0:07:1c:
-         08:ee:69:54:25:68:e4:71:0a:15:f0:02:af:ae:40:5a:f0:61:
-         54:4c:d6:0a:dd:83:5f:36:e0:b8:3c:4b:27:99:71:e3:c2:ca:
-         c5:86:4e:2f
-
+         91:dc:d8:53:7c:d0:40:83:11:cc:be:6b:b9:76:da:56:85:0e:
+         b9:ee:9f:16:17:d6:85:3d:e5:25:5d:91:37:af:e3:57:9d:c1:
+         4b:01:88:6d:fb:78:7d:e0:d8:02:2e:ae:1f:1e:28:23:f0:63:
+         92:7b:e6:c4:ea:7d:6a:5e:d6:bc:61:5a:b6:e1:b2:2c:3d:dd:
+         54:f5:db:2c:8a:62:95:d9:de:19:94:2f:06:6e:cb:3f:3c:b6:
+         0f:d0:a2:8b:8c:97:68:23:03:43:2f:a0:44:22:1f:e4:d7:92:
+         d3:93:d0:1c:1e:a0:01:f8:a1:32:4d:e3:88:03:c0:52:59:86:
+         54:10:c9:85:32:8e:4d:ae:02:c3:71:c3:1c:e6:3c:0e:bd:7d:
+         2e:d2:7a:0e:c3:a0:87:30:ff:c1:c0:a7:54:23:4f:8b:5f:b0:
+         6c:36:07:f3:2a:3e:ca:8f:6c:61:34:e5:fa:ae:0c:44:5d:a1:
+         0f:f2:40:28:58:1f:6f:d9:f0:36:47:d7:d8:7f:04:c6:51:c0:
+         25:76:0c:2b:33:f8:2f:51:88:53:b3:d6:72:64:dd:db:29:54:
+         4e:1c:5c:84:88:0b:d6:0b:27:ee:5f:1b:81:17:d1:bf:18:c2:
+         5c:61:30:ea:7b:b0:25:cc:b0:9a:c3:b3:47:94:09:e4:4c:0f:
+         0e:b3:9c:b4
 -----BEGIN CERTIFICATE-----
-MIIGCTCCBPGgAwIBAgIQBp5/yp/ICn51vSbfBzjDqDANBgkqhkiG9w0BAQsFADB1
-MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
-d3cuZGlnaWNlcnQuY29tMTQwMgYDVQQDEytEaWdpQ2VydCBTSEEyIEV4dGVuZGVk
-IFZhbGlkYXRpb24gU2VydmVyIENBMB4XDTE4MDQzMDAwMDAwMFoXDTIwMDgwMjAw
-MDAwMFowgc4xHTAbBgNVBA8MFFByaXZhdGUgT3JnYW5pemF0aW9uMRMwEQYLKwYB
-BAGCNzwCAQMTAlVTMRkwFwYLKwYBBAGCNzwCAQITCERlbGF3YXJlMRAwDgYDVQQF
-Ewc1MjgyNTkzMQswCQYDVQQGEwJVUzEWMBQGA1UECBMNTmV3IEhhbXBzaGlyZTET
-MBEGA1UEBxMKTWFuY2hlc3RlcjEWMBQGA1UEChMNUGlsbFBhY2ssIEluYzEZMBcG
-A1UEAxMQd3d3LnBpbGxwYWNrLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
-AQoCggEBAMzYqn2UwQozBQMEewYYVd8CmOAzJoCqPkMNFiIX3sGTMxGWUHPXPGql
-MnPpKr1a2s7FIUV10BoVfn84gifuU2/S07Y/na1f5X5DY0hex0rXj8pCHsGq71vh
-M0RGjHV2G4SWvJRRkswsX7R1oANidNTBbe9B0Ik9dma+XvigysPI75K+yquEgeYA
-qKEeukAtQ0QPymCxtXKUcHKmnIPEW44aPtLddVNeN00pg+RwU0Bm5RsyxWzGrNel
-c9FMCkmDRv+68MbFmPu/pFOjFoHM6sRYcDKWbTFFrqsoWInkNeJ4dp+LpdWIdOwY
-lds2Xc0wwge3BP8cGJpF6tWLahKk82ECAwEAAaOCAjkwggI1MB8GA1UdIwQYMBaA
-FD3TUKXWoK3u80pgCmXTIdT4+NYPMB0GA1UdDgQWBBTp2kQnKXG7L1kF04cqnJXx
-OkapZTBSBgNVHREESzBJghB3d3cucGlsbHBhY2suY29tgg9teS5waWxscGFjay5j
-b22CEmFkbWluLnBpbGxwYWNrLmNvbYIQYXBpLnBpbGxwYWNrLmNvbTAOBgNVHQ8B
-Af8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMHUGA1UdHwRu
-MGwwNKAyoDCGLmh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9zaGEyLWV2LXNlcnZl
-ci1nMi5jcmwwNKAyoDCGLmh0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9zaGEyLWV2
-LXNlcnZlci1nMi5jcmwwSwYDVR0gBEQwQjA3BglghkgBhv1sAgEwKjAoBggrBgEF
-BQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzAHBgVngQwBATCBiAYI
-KwYBBQUHAQEEfDB6MCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5j
-b20wUgYIKwYBBQUHMAKGRmh0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdp
-Q2VydFNIQTJFeHRlbmRlZFZhbGlkYXRpb25TZXJ2ZXJDQS5jcnQwDAYDVR0TAQH/
-BAIwADATBgorBgEEAdZ5AgQDAQH/BAIFADANBgkqhkiG9w0BAQsFAAOCAQEAAWpQ
-D5RaJq/Y/nl0sNlav+4FiYwWOEvPhjnMc0S0a3KV/LpVR2V0CH0X69h+lC3bO5CM
-KxXA0UmllKlspJkqv0NvuUOLe2u4GYuMt/YKbsIVi8hQK2JxvxzdJjeqfi4++k2u
-p6bECwB1x2HpraQrADYzgodibeG2j3rOwKLY0656NC9UxuF7SmQJBFBEEoTHW38A
-RCjAHqSxH7/PjNOIhJFzphCvbgFDIDNoQ46zAQ2H6mPi3KyPhryisnRleUM1WGC/
-AL/Ps9FEb32Trn/i64D2kCEzwAccCO5pVCVo5HEKFfACr65AWvBhVEzWCt2DXzbg
-uDxLJ5lx48LKxYZOLw==
+MIIFNTCCBB2gAwIBAgIQXr+camzyMFUYbQo1Ct1vzTANBgkqhkiG9w0BAQsFADBE
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMdGhhd3RlLCBJbmMuMR4wHAYDVQQDExV0
+aGF3dGUgRVYgU1NMIENBIC0gRzMwHhcNMTcwODAxMDAwMDAwWhcNMTkxMDE3MjM1
+OTU5WjCBzDETMBEGCysGAQQBgjc8AgEDEwJHQjEeMBwGA1UECgwVVEVMRUZPTklD
+QSBVSyBMSU1JVEVEMQswCQYDVQQGEwJHQjESMBAGA1UECAwJQmVya3NoaXJlMQ8w
+DQYDVQQHDAZTbG91Z2gxHTAbBgNVBA8TFFByaXZhdGUgT3JnYW5pemF0aW9uMREw
+DwYDVQQFEwgwMTc0MzA5OTETMBEGA1UECwwKT3BlcmF0aW9uczEcMBoGA1UEAwwT
+YnQtYXBpLm8yd2lmaS5jby51azCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAMZEXjojbWhNgSyKWqLPX475oKkfXf6C38cMzDSxRV6zueoKRbVB4o8HS1Ea
+SOma105rKhGPuOw6VGvosApOIF+tBeWFUs2qAAA0C+fKwSQR0HPp31m3l6pMe5Qy
+7HXobXH74ucWLfscRc32xFzP4W8dqJfS2wkEK0FNSz0lYqS1JUKvJFMsebP6rO8t
+6VT2TYrfVlTeNNfXLPRoC7mazJUHtuJ+tBzmyhmo24S7HYHanFSo1UmimsCXI3Cb
+Bnbl/BWBMJOobCqe521BoxM4ADzoV2UBu2o+xLuyfGm0wgjEHwY7EQJ0WBfkX+4L
+7LzgXGETDfXce7VlMX4oWlPxX4MCAwEAAaOCAZgwggGUMB4GA1UdEQQXMBWCE2J0
+LWFwaS5vMndpZmkuY28udWswCQYDVR0TBAIwADAOBgNVHQ8BAf8EBAMCBaAwKwYD
+VR0fBCQwIjAgoB6gHIYaaHR0cDovL3RpLnN5bWNiLmNvbS90aS5jcmwwfAYDVR0g
+BHUwczBoBgtghkgBhvhFAQcwATBZMCYGCCsGAQUFBwIBFhpodHRwczovL3d3dy50
+aGF3dGUuY29tL2NwczAvBggrBgEFBQcCAjAjDCFodHRwczovL3d3dy50aGF3dGUu
+Y29tL3JlcG9zaXRvcnkwBwYFZ4EMAQEwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsG
+AQUFBwMCMB8GA1UdIwQYMBaAFPBwUdrTKpFPUnfXhnd0D85xGmwiMFcGCCsGAQUF
+BwEBBEswSTAfBggrBgEFBQcwAYYTaHR0cDovL3RpLnN5bWNkLmNvbTAmBggrBgEF
+BQcwAoYaaHR0cDovL3RpLnN5bWNiLmNvbS90aS5jcnQwEwYKKwYBBAHWeQIEAwEB
+/wQCBQAwDQYJKoZIhvcNAQELBQADggEBAJHc2FN80ECDEcy+a7l22laFDrnunxYX
+1oU95SVdkTev41edwUsBiG37eH3g2AIurh8eKCPwY5J75sTqfWpe1rxhWrbhsiw9
+3VT12yyKYpXZ3hmULwZuyz88tg/QoouMl2gjA0MvoEQiH+TXktOT0BweoAH4oTJN
+44gDwFJZhlQQyYUyjk2uAsNxwxzmPA69fS7Seg7DoIcw/8HAp1QjT4tfsGw2B/Mq
+PsqPbGE05fquDERdoQ/yQChYH2/Z8DZH19h/BMZRwCV2DCsz+C9RiFOz1nJk3dsp
+VE4cXISIC9YLJ+5fG4EX0b8YwlxhMOp7sCXMsJrDs0eUCeRMDw6znLQ=
 -----END CERTIFICATE-----

--- a/v2/testdata/evValidNotTooLong825Days.pem
+++ b/v2/testdata/evValidNotTooLong825Days.pem
@@ -1,0 +1,118 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            04:87:54:5e:fd:e5:e5:57:58:b3:ac:7d:59:4d:54:2b
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = NL, ST = Noord-Holland, L = Amsterdam, O = TERENA, CN = TERENA SSL High Assurance CA 3
+        Validity
+            Not Before: Jan 29 00:00:00 2019 GMT
+            Not After : May  2 12:00:00 2021 GMT
+        Subject: businessCategory = Government Entity, jurisdictionC = AT, serialNumber = Government Entity, C = AT, ST = Ober\C3\B6sterreich, L = Linz, O = Land Ober\C3\B6sterreich, OU = Abteilung Informationstechnologie, CN = sslvpn.ooe.gv.at
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:97:26:8c:a5:e8:b0:c4:38:f2:5d:3d:f3:e2:78:
+                    4f:93:e6:e8:9c:01:3c:ba:a3:c7:d9:d7:a3:24:a2:
+                    51:0e:1d:4e:e8:f3:33:71:f6:94:f3:30:ff:d9:d6:
+                    64:c0:68:a5:1e:33:60:f4:82:ef:25:fd:88:ed:67:
+                    43:bf:30:05:49:c3:2a:5f:12:f1:e0:d4:6d:1b:00:
+                    dd:5a:ac:56:db:70:4c:eb:3d:33:31:3f:12:27:65:
+                    d0:2d:52:d0:8f:fb:55:16:25:98:c2:df:08:27:11:
+                    a0:a4:13:91:be:61:64:17:59:08:97:e2:44:9c:24:
+                    27:ac:d0:f5:6f:95:d0:06:7e:2c:45:6b:ea:b3:1e:
+                    4e:27:12:a4:f5:02:c9:8c:a8:3a:43:04:9e:ea:12:
+                    cd:ef:9a:5a:7e:cb:88:da:1a:a8:24:f1:72:96:2f:
+                    83:91:0e:fc:6c:64:a6:e7:1f:24:c9:af:90:84:61:
+                    d6:1a:e2:38:20:3d:fc:fa:f2:16:23:6f:db:61:89:
+                    4c:44:ab:e1:d1:15:a4:02:ea:54:de:ef:6e:71:01:
+                    c0:23:b0:71:ab:03:3e:83:08:eb:cf:8e:0a:c1:7b:
+                    d9:ca:0d:ca:37:3d:2f:f6:f1:19:b0:c0:2e:40:c5:
+                    8a:74:e2:2d:4f:70:5e:52:48:a0:33:cd:2f:16:09:
+                    01:d1
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:C2:B8:85:D7:E1:B9:13:BD:D1:48:BC:FD:5E:DC:7D:90:42:7A:8A:A9
+
+            X509v3 Subject Key Identifier: 
+                D2:0C:21:64:BE:65:4D:51:E7:26:95:7A:2B:0C:08:EF:E5:59:88:CA
+            X509v3 Subject Alternative Name: 
+                DNS:sslvpn.ooe.gv.at, DNS:vplirz04.ooe.gv.at
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://crl3.digicert.com/TERENASSLHighAssuranceCA3.crl
+
+                Full Name:
+                  URI:http://crl4.digicert.com/TERENASSLHighAssuranceCA3.crl
+
+            X509v3 Certificate Policies: 
+                Policy: 2.16.840.1.114412.2.1
+                  CPS: https://www.digicert.com/CPS
+                Policy: 2.23.140.1.1
+
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.digicert.com
+                CA Issuers - URI:http://cacerts.digicert.com/TERENASSLHighAssuranceCA3.crt
+
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            CT Precertificate Poison: critical
+                NULL
+    Signature Algorithm: sha256WithRSAEncryption
+         04:c7:ea:79:5e:72:15:d1:5f:b7:b0:5e:0c:44:fe:e9:03:a1:
+         ed:6c:0f:b4:eb:cd:82:ca:db:3c:89:4c:65:30:de:ff:6f:3d:
+         f2:a1:74:90:f1:23:d9:e7:95:ad:e1:79:31:fd:e7:63:da:0a:
+         56:9f:d8:77:c8:bc:50:6a:63:57:d3:3b:33:c2:85:79:15:65:
+         4e:7b:07:e7:5e:f7:fb:b4:34:b4:f0:e7:f5:a6:03:55:bf:f4:
+         27:4d:95:56:cb:9b:f6:f6:e4:fb:57:93:ce:4b:b8:c1:d0:c2:
+         61:85:c2:58:5d:de:d7:6e:84:0f:de:86:54:10:20:0a:d2:c1:
+         8d:c8:cd:20:5e:ca:ab:74:2c:53:ba:1b:cf:78:ee:49:81:c9:
+         cc:32:ea:62:b6:17:a0:1d:e3:f1:f7:5a:a6:18:4d:cd:77:fb:
+         b8:d6:42:b8:51:1f:68:12:3a:fb:a5:92:dd:48:e6:0a:4a:8a:
+         ce:ea:12:ca:39:f1:55:45:cc:f4:d9:ae:3e:de:4a:f7:1e:89:
+         84:34:18:01:e5:89:77:26:2d:24:0b:5d:8e:64:24:db:e8:b1:
+         42:5d:cf:a1:a3:31:83:7a:29:1a:d5:ce:ed:5c:ac:b9:b0:7d:
+         0b:64:4b:70:92:14:32:5e:a7:f1:a7:82:1d:51:87:b8:b9:e6:
+         ef:b6:d7:0e
+-----BEGIN CERTIFICATE-----
+MIIGAjCCBOqgAwIBAgIQBIdUXv3l5VdYs6x9WU1UKzANBgkqhkiG9w0BAQsFADBz
+MQswCQYDVQQGEwJOTDEWMBQGA1UECBMNTm9vcmQtSG9sbGFuZDESMBAGA1UEBxMJ
+QW1zdGVyZGFtMQ8wDQYDVQQKEwZURVJFTkExJzAlBgNVBAMTHlRFUkVOQSBTU0wg
+SGlnaCBBc3N1cmFuY2UgQ0EgMzAeFw0xOTAxMjkwMDAwMDBaFw0yMTA1MDIxMjAw
+MDBaMIHpMRowGAYDVQQPDBFHb3Zlcm5tZW50IEVudGl0eTETMBEGCysGAQQBgjc8
+AgEDEwJBVDEaMBgGA1UEBRMRR292ZXJubWVudCBFbnRpdHkxCzAJBgNVBAYTAkFU
+MRgwFgYDVQQIDA9PYmVyw7ZzdGVycmVpY2gxDTALBgNVBAcTBExpbnoxHTAbBgNV
+BAoMFExhbmQgT2JlcsO2c3RlcnJlaWNoMSowKAYDVQQLEyFBYnRlaWx1bmcgSW5m
+b3JtYXRpb25zdGVjaG5vbG9naWUxGTAXBgNVBAMTEHNzbHZwbi5vb2UuZ3YuYXQw
+ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCXJoyl6LDEOPJdPfPieE+T
+5uicATy6o8fZ16MkolEOHU7o8zNx9pTzMP/Z1mTAaKUeM2D0gu8l/YjtZ0O/MAVJ
+wypfEvHg1G0bAN1arFbbcEzrPTMxPxInZdAtUtCP+1UWJZjC3wgnEaCkE5G+YWQX
+WQiX4kScJCes0PVvldAGfixFa+qzHk4nEqT1AsmMqDpDBJ7qEs3vmlp+y4jaGqgk
+8XKWL4ORDvxsZKbnHyTJr5CEYdYa4jggPfz68hYjb9thiUxEq+HRFaQC6lTe725x
+AcAjsHGrAz6DCOvPjgrBe9nKDco3PS/28RmwwC5AxYp04i1PcF5SSKAzzS8WCQHR
+AgMBAAGjggIZMIICFTAfBgNVHSMEGDAWgBTCuIXX4bkTvdFIvP1e3H2QQnqKqTAd
+BgNVHQ4EFgQU0gwhZL5lTVHnJpV6KwwI7+VZiMowLwYDVR0RBCgwJoIQc3NsdnBu
+Lm9vZS5ndi5hdIISdnBsaXJ6MDQub29lLmd2LmF0MA4GA1UdDwEB/wQEAwIFoDAd
+BgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwgYUGA1UdHwR+MHwwPKA6oDiG
+Nmh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9URVJFTkFTU0xIaWdoQXNzdXJhbmNl
+Q0EzLmNybDA8oDqgOIY2aHR0cDovL2NybDQuZGlnaWNlcnQuY29tL1RFUkVOQVNT
+TEhpZ2hBc3N1cmFuY2VDQTMuY3JsMEsGA1UdIAREMEIwNwYJYIZIAYb9bAIBMCow
+KAYIKwYBBQUHAgEWHGh0dHBzOi8vd3d3LmRpZ2ljZXJ0LmNvbS9DUFMwBwYFZ4EM
+AQEwewYIKwYBBQUHAQEEbzBtMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdp
+Y2VydC5jb20wRQYIKwYBBQUHMAKGOWh0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNv
+bS9URVJFTkFTU0xIaWdoQXNzdXJhbmNlQ0EzLmNydDAMBgNVHRMBAf8EAjAAMBMG
+CisGAQQB1nkCBAMBAf8EAgUAMA0GCSqGSIb3DQEBCwUAA4IBAQAEx+p5XnIV0V+3
+sF4MRP7pA6HtbA+0682Cyts8iUxlMN7/bz3yoXSQ8SPZ55Wt4Xkx/edj2gpWn9h3
+yLxQamNX0zszwoV5FWVOewfnXvf7tDS08Of1pgNVv/QnTZVWy5v29uT7V5POS7jB
+0MJhhcJYXd7XboQP3oZUECAK0sGNyM0gXsqrdCxTuhvPeO5JgcnMMupithegHePx
+91qmGE3Nd/u41kK4UR9oEjr7pZLdSOYKSorO6hLKOfFVRcz02a4+3kr3HomENBgB
+5Yl3Ji0kC12OZCTb6LFCXc+hozGDeika1c7tXKy5sH0LZEtwkhQyXqfxp4IdUYe4
+uebvttcO
+-----END CERTIFICATE-----


### PR DESCRIPTION
The lint lint_ev_valid_time_too_long has two issues:

* It set the maximum validity as 825-days, rather than 27 months
  (which is 366 + 365 + 31 + 31 + 30 = 823 days) for certs issued
  before the 825-day change (CABF Ballot 193)
* It set the source of the requirements to the BRs, rather than
  the EVGs

This updates the test to test for 27 months for certificates issued
prior to the Ballot 193 effective date. A number of certificates now
fail this check, either because they're used for code signing (but
reuse the same EV OID), or because they interpreted the validity
period as permitting "fractional months" (typically, in the form of
<24 additional hours).

Aligned with the interpretation of Ballot 193 that treats fractional
days as > 825 days, this treats fractional months as > 27 months.