### PR TITLE
Update apple 398 cert validity cert to not apply to CA certs

### DIFF
--- a/v2/lints/apple/lint_e_server_cert_valid_time_longer_than_398_days.go
+++ b/v2/lints/apple/lint_e_server_cert_valid_time_longer_than_398_days.go
@@ -29,7 +29,7 @@ func (l *serverCertValidityTooLong) Initialize() error {
 }
 
 func (l *serverCertValidityTooLong) CheckApplies(c *x509.Certificate) bool {
-	return util.IsServerAuthCert(c)
+	return util.IsServerAuthCert(c) && !c.IsCA
 }
 
 func (l *serverCertValidityTooLong) Execute(c *x509.Certificate) *lint.LintResult {


### PR DESCRIPTION
Hi all, noticed that the Apple lint is applying to certs marked with the CA basic constraint so added a quick boolean check to confirm. We also double checked with Clint to make sure Apple wasn't intending to apply their policy to CA certs :)