### PR TITLE
Improve the error message of ReadTestCert's panic

### DIFF
--- a/v2/test/helpers.go
+++ b/v2/test/helpers.go
@@ -92,9 +92,9 @@ func ReadTestCert(inPath string) *x509.Certificate {
 	theCert, err := x509.ParseCertificate(data)
 	if err != nil {
 		panic(fmt.Sprintf(
-			"Failed to parse x509 test certificate from %q - "+
+			"Failed to parse x509 test certificate from %q - %q "+
 				"Does a unit test have a buggy test cert file?\n",
-			fullPath))
+			fullPath, err))
 	}
 
 	return theCert


### PR DESCRIPTION
The error from x509.ParseCertificate was not being included within the panic.Debugging is easier if this information is retained.