### PR TITLE
wip: LINT for the correlation between EKU and KU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ Temporary Items
 ### Vim ###
 *.swp
 
+### Visual Studio Code ###
+.vscode
+
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ZLint
 
 [![Build Status](https://travis-ci.org/zmap/zlint.svg?branch=master)](https://travis-ci.org/zmap/zlint)
 [![Go Report Card](https://goreportcard.com/badge/github.com/zmap/zlint)](https://goreportcard.com/report/github.com/zmap/zlint)
-
+added line
 ZLint is a X.509 certificate linter written in Go that checks for consistency
 with standards (e.g. [RFC 5280]) and other relevant PKI requirements (e.g.
 [CA/Browser Forum Baseline Requirements][BR v1.4.8]).


### PR DESCRIPTION
This PR will carry a lint for the correlation between EKU and KU as described in [RFC5280 4.2.1.12](https://tools.ietf.org/html/rfc5280#section-4.2.1.12). See also [issue ](https://github.com/zmap/zlint/issues/473).