### PR TITLE
Include error/warning/info overview

### DIFF
--- a/v2/integration/corpus_test.go
+++ b/v2/integration/corpus_test.go
@@ -158,11 +158,16 @@ func TestCorpus(t *testing.T) {
 			*configFile)
 	} else {
 		// Otherwise enforce the maps match
+		failCounter := 0
 		for k, v := range resultsByLint {
 			if conf.Expected[k] != v {
 				t.Errorf("expected lint %q to have result %s got %s\n",
 					k, conf.Expected[k], v)
+				failCounter++
 			}
+		}
+		if failCounter > 0 {
+			t.Errorf("%d lint(s) failed", failCounter)
 		}
 	}
 

--- a/v2/integration/corpus_test.go
+++ b/v2/integration/corpus_test.go
@@ -167,7 +167,7 @@ func TestCorpus(t *testing.T) {
 			}
 		}
 		if failCounter > 0 {
-			t.Errorf("%d lint(s) failed", failCounter)
+			fmt.Printf("%d lint(s) failed", failCounter)
 		}
 	}
 


### PR DESCRIPTION
This PR introduces an overview of how many lints fail when the complete integration test is being executed. This is information was helpful when I made a change that affected multiple lints. This PR is a split from https://github.com/zmap/zlint/pull/472

New output:
```
corpus_test.go:164: expected lint "e_cert_sig_alg_not_match_tbs_sig_alg" to have result fatals: 0    errs: 1    warns: 0    infos: 0    got fatals: 0    errs: 10   warns: 0    infos: 0
    corpus_test.go:170: 1 lint(s) failed
--- FAIL: TestCorpus (187.96s)
FAIL
FAIL    github.com/zmap/zlint/v2/integration    189.051s
FAIL
make: *** [makefile:34: integration] Error 1
```

Old output:
```
corpus_test.go:163: expected lint "e_cert_sig_alg_not_match_tbs_sig_alg" to have result fatals: 0    errs: 1    warns: 0    infos: 0    got fatals: 0    errs: 10   warns: 0    infos: 0
--- FAIL: TestCorpus (182.83s)
FAIL
FAIL    github.com/zmap/zlint/v2/integration    183.810s
FAIL
make: *** [makefile:34: integration] Error 1
```

The difference is line three: **corpus_test.go:170: 1 lint(s) failed**