### PR TITLE
Improve readability of "EKU" abbreviation

### DIFF
--- a/v2/integration/corpus_test.go
+++ b/v2/integration/corpus_test.go
@@ -158,11 +158,16 @@ func TestCorpus(t *testing.T) {
 			*configFile)
 	} else {
 		// Otherwise enforce the maps match
+		failCounter := 0
 		for k, v := range resultsByLint {
 			if conf.Expected[k] != v {
 				t.Errorf("expected lint %q to have result %s got %s\n",
 					k, conf.Expected[k], v)
+				failCounter++
 			}
+		}
+		if failCounter > 0 {
+			t.Errorf("%d lint(s) failed", failCounter)
 		}
 	}
 

--- a/v2/integration/corpus_test.go
+++ b/v2/integration/corpus_test.go
@@ -167,7 +167,7 @@ func TestCorpus(t *testing.T) {
 			}
 		}
 		if failCounter > 0 {
-			t.Errorf("%d lint(s) failed", failCounter)
+			fmt.Printf("%d lint(s) failed", failCounter)
 		}
 	}
 

--- a/v2/util/eku.go
+++ b/v2/util/eku.go
@@ -2,7 +2,7 @@ package util
 
 import "github.com/zmap/zcrypto/x509"
 
-// HasEKU tests whether an EKU is present in a certificate.
+// HasEKU tests whether an Extended Key Usage (EKU) is present in a certificate.
 func HasEKU(cert *x509.Certificate, eku x509.ExtKeyUsage) bool {
 	for _, currentEku := range cert.ExtKeyUsage {
 		if currentEku == eku {


### PR DESCRIPTION
I was at one point in time not 100% sure, what you meant by the abbreviation "EKU" in a certain context. So I decided it could be helpful to have this abbreviation one time written out in the documentation.