### PR TITLE
make two lints notice instead of warn, 

### DIFF
--- a/v2/benchmarks_test.go
+++ b/v2/benchmarks_test.go
@@ -119,7 +119,7 @@ func BenchmarkZlint(b *testing.B) {
 			for _, key := range names {
 				switch key {
 				case "w_dnsname_underscore_in_trd", "e_dnsname_underscore_in_sld", "e_dnsname_hyphen_in_sld",
-					"w_dnsname_wildcard_left_of_public_suffix", "w_san_iana_pub_suffix_empty":
+					"n_dnsname_wildcard_left_of_public_suffix", "n_san_iana_pub_suffix_empty":
 					continue
 				}
 				value := lint.GlobalRegistry().ByName(key)
@@ -139,7 +139,7 @@ func BenchmarkZlint(b *testing.B) {
 			for _, key := range names {
 				switch key {
 				case "w_dnsname_underscore_in_trd", "e_dnsname_underscore_in_sld", "e_dnsname_hyphen_in_sld",
-					"w_dnsname_wildcard_left_of_public_suffix", "w_san_iana_pub_suffix_empty",
+					"n_dnsname_wildcard_left_of_public_suffix", "n_san_iana_pub_suffix_empty",
 					"w_rsa_mod_factors_smaller_than_752", "e_dnsname_bad_character_in_label", "w_subject_dn_leading_whitespace",
 					"w_subject_dn_trailing_whitespace", "w_multiple_subject_rdn", "e_ext_san_dns_not_ia5_string",
 					"e_ext_san_empty_name", "e_dnsname_not_valid_tld", "e_dnsname_contains_bare_iana_suffix",

--- a/v2/integration/config.json
+++ b/v2/integration/config.json
@@ -625,6 +625,9 @@
     "n_contains_redacted_dnsname": {
       "NoticeCount": 203
     },
+    "n_dnsname_wildcard_left_of_public_suffix": {
+      "NoticeCount": 1
+    },
     "n_ecdsa_ee_invalid_ku": {
       "NoticeCount": 29
     },
@@ -634,6 +637,9 @@
     "n_multiple_subject_rdn": {},
     "n_san_dns_name_duplicate": {
       "NoticeCount": 193
+    },
+    "n_san_iana_pub_suffix_empty": {
+      "NoticeCount": 35
     },
     "n_sub_ca_eku_missing": {
       "NoticeCount": 166
@@ -652,9 +658,6 @@
     },
     "w_dnsname_underscore_in_trd": {
       "WarnCount": 83
-    },
-    "w_dnsname_wildcard_left_of_public_suffix": {
-      "WarnCount": 1
     },
     "w_eku_critical_improperly": {},
     "w_ext_aia_access_location_missing": {
@@ -711,9 +714,6 @@
     "w_rsa_mod_not_odd": {},
     "w_rsa_public_exponent_not_in_range": {
       "WarnCount": 45
-    },
-    "w_san_iana_pub_suffix_empty": {
-      "WarnCount": 35
     },
     "w_sub_ca_aia_does_not_contain_issuing_ca_url": {
       "WarnCount": 62

--- a/v2/integration/small.config.json
+++ b/v2/integration/small.config.json
@@ -305,12 +305,16 @@
     "n_contains_redacted_dnsname": {
       "NoticeCount": 8
     },
+    "n_dnsname_wildcard_left_of_public_suffix": {},
     "n_ecdsa_ee_invalid_ku": {
       "NoticeCount": 3
     },
     "n_multiple_subject_rdn": {},
     "n_san_dns_name_duplicate": {
       "NoticeCount": 23
+    },
+    "n_san_iana_pub_suffix_empty": {
+      "NoticeCount": 1
     },
     "n_sub_ca_eku_missing": {
       "NoticeCount": 29
@@ -328,7 +332,6 @@
     "w_dnsname_underscore_in_trd": {
       "WarnCount": 13
     },
-    "w_dnsname_wildcard_left_of_public_suffix": {},
     "w_eku_critical_improperly": {},
     "w_ext_aia_access_location_missing": {
       "WarnCount": 11
@@ -374,9 +377,6 @@
     "w_rsa_mod_factors_smaller_than_752": {},
     "w_rsa_mod_not_odd": {},
     "w_rsa_public_exponent_not_in_range": {},
-    "w_san_iana_pub_suffix_empty": {
-      "WarnCount": 1
-    },
     "w_sub_ca_aia_does_not_contain_issuing_ca_url": {
       "WarnCount": 23
     },

--- a/v2/lints/cabf_br/lint_dnsname_wildcard_left_of_public_suffix.go
+++ b/v2/lints/cabf_br/lint_dnsname_wildcard_left_of_public_suffix.go
@@ -38,7 +38,7 @@ func (l *DNSNameWildcardLeftofPublicSuffix) Execute(c *x509.Certificate) *lint.L
 		}
 
 		if domainInfo.ParsedDomain.SLD == "*" {
-			return &lint.LintResult{Status: lint.Warn}
+			return &lint.LintResult{Status: lint.Notice}
 		}
 	}
 
@@ -49,7 +49,7 @@ func (l *DNSNameWildcardLeftofPublicSuffix) Execute(c *x509.Certificate) *lint.L
 		}
 
 		if parsedSANDNSNames[i].ParsedDomain.SLD == "*" {
-			return &lint.LintResult{Status: lint.Warn}
+			return &lint.LintResult{Status: lint.Notice}
 		}
 	}
 	return &lint.LintResult{Status: lint.Pass}
@@ -57,7 +57,7 @@ func (l *DNSNameWildcardLeftofPublicSuffix) Execute(c *x509.Certificate) *lint.L
 
 func init() {
 	lint.RegisterLint(&lint.Lint{
-		Name:          "w_dnsname_wildcard_left_of_public_suffix",
+		Name:          "n_dnsname_wildcard_left_of_public_suffix",
 		Description:   "the CA MUST establish and follow a documented procedure[^pubsuffix] that determines if the wildcard character occurs in the first label position to the left of a “registry‐controlled” label or “public suffix”",
 		Citation:      "BRs: 3.2.2.6",
 		Source:        lint.CABFBaselineRequirements,

--- a/v2/lints/cabf_br/lint_dnsname_wildcard_left_of_public_suffix_test.go
+++ b/v2/lints/cabf_br/lint_dnsname_wildcard_left_of_public_suffix_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestWildcardLeftOfPublicSuffix(t *testing.T) {
 	inputPath := "dnsNameWildcardLeftOfPublicSuffix.pem"
-	expected := lint.Warn
+	expected := lint.Notice
 	out := test.TestLint("n_dnsname_wildcard_left_of_public_suffix", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)

--- a/v2/lints/cabf_br/lint_dnsname_wildcard_left_of_public_suffix_test.go
+++ b/v2/lints/cabf_br/lint_dnsname_wildcard_left_of_public_suffix_test.go
@@ -24,7 +24,7 @@ import (
 func TestWildcardLeftOfPublicSuffix(t *testing.T) {
 	inputPath := "dnsNameWildcardLeftOfPublicSuffix.pem"
 	expected := lint.Warn
-	out := test.TestLint("w_dnsname_wildcard_left_of_public_suffix", inputPath)
+	out := test.TestLint("n_dnsname_wildcard_left_of_public_suffix", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
@@ -33,7 +33,7 @@ func TestWildcardLeftOfPublicSuffix(t *testing.T) {
 func TestWildcardNotLeftOfPublicSuffix(t *testing.T) {
 	inputPath := "dnsNameWildcardNotLeftOfPublicSuffix.pem"
 	expected := lint.Pass
-	out := test.TestLint("w_dnsname_wildcard_left_of_public_suffix", inputPath)
+	out := test.TestLint("n_dnsname_wildcard_left_of_public_suffix", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}

--- a/v2/lints/community/lint_san_iana_pub_suffix_empty.go
+++ b/v2/lints/community/lint_san_iana_pub_suffix_empty.go
@@ -37,7 +37,7 @@ func (l *pubSuffix) Execute(c *x509.Certificate) *lint.LintResult {
 	for i := range c.GetParsedDNSNames(false) {
 		if parsedSANDNSNames[i].ParseError != nil {
 			if strings.HasSuffix(parsedSANDNSNames[i].ParseError.Error(), "is a suffix") {
-				return &lint.LintResult{Status: lint.Warn}
+				return &lint.LintResult{Status: lint.Notice}
 			} else {
 				return &lint.LintResult{Status: lint.NA}
 			}
@@ -48,7 +48,7 @@ func (l *pubSuffix) Execute(c *x509.Certificate) *lint.LintResult {
 
 func init() {
 	lint.RegisterLint(&lint.Lint{
-		Name:          "w_san_iana_pub_suffix_empty",
+		Name:          "n_san_iana_pub_suffix_empty",
 		Description:   "The domain SHOULD NOT have a bare public suffix",
 		Citation:      "awslabs certlint",
 		Source:        lint.AWSLabs,

--- a/v2/lints/community/lint_san_iana_pub_suffix_empty_test.go
+++ b/v2/lints/community/lint_san_iana_pub_suffix_empty_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestSANBarePubSuffix(t *testing.T) {
 	inputPath := "SANBareSuffix.pem"
-	expected := lint.Warn
+	expected := lint.Notice
 	out := test.TestLint("n_san_iana_pub_suffix_empty", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)

--- a/v2/lints/community/lint_san_iana_pub_suffix_empty_test.go
+++ b/v2/lints/community/lint_san_iana_pub_suffix_empty_test.go
@@ -24,7 +24,7 @@ import (
 func TestSANBarePubSuffix(t *testing.T) {
 	inputPath := "SANBareSuffix.pem"
 	expected := lint.Warn
-	out := test.TestLint("w_san_iana_pub_suffix_empty", inputPath)
+	out := test.TestLint("n_san_iana_pub_suffix_empty", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
@@ -33,7 +33,7 @@ func TestSANBarePubSuffix(t *testing.T) {
 func TestSANBarePrivatePubSuffix(t *testing.T) {
 	inputPath := "sanPrivatePublicSuffix.pem"
 	expected := lint.Pass
-	out := test.TestLint("w_san_iana_pub_suffix_empty", inputPath)
+	out := test.TestLint("n_san_iana_pub_suffix_empty", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
@@ -42,7 +42,7 @@ func TestSANBarePrivatePubSuffix(t *testing.T) {
 func TestSANGoodPubSuffix(t *testing.T) {
 	inputPath := "SANGoodSuffix.pem"
 	expected := lint.Pass
-	out := test.TestLint("w_san_iana_pub_suffix_empty", inputPath)
+	out := test.TestLint("n_san_iana_pub_suffix_empty", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}


### PR DESCRIPTION
As discussed in #492 these two lints don't make sense to be Warning level. The BR they cover is not possible to be verified by a linter (BR 3.2.2.6).

closes #492