### PR TITLE
lint: combine ZLint and AWSLabs Sources into Community.

### DIFF
--- a/v2/lint/source.go
+++ b/v2/lint/source.go
@@ -33,8 +33,7 @@ const (
 	CABFEVGuidelines         LintSource = "CABF_EV"
 	MozillaRootStorePolicy   LintSource = "Mozilla"
 	AppleRootStorePolicy     LintSource = "Apple"
-	ZLint                    LintSource = "ZLint"
-	AWSLabs                  LintSource = "AWSLabs"
+	Community                LintSource = "Community"
 	EtsiEsi                  LintSource = "ETSI_ESI"
 )
 
@@ -47,7 +46,7 @@ func (s *LintSource) UnmarshalJSON(data []byte) error {
 	}
 
 	switch LintSource(throwAway) {
-	case RFC5280, RFC5480, RFC5891, CABFBaselineRequirements, CABFEVGuidelines, MozillaRootStorePolicy, AppleRootStorePolicy, ZLint, AWSLabs, EtsiEsi:
+	case RFC5280, RFC5480, RFC5891, CABFBaselineRequirements, CABFEVGuidelines, MozillaRootStorePolicy, AppleRootStorePolicy, Community, EtsiEsi:
 		*s = LintSource(throwAway)
 		return nil
 	default:
@@ -79,10 +78,8 @@ func (s *LintSource) FromString(src string) {
 		*s = MozillaRootStorePolicy
 	case AppleRootStorePolicy:
 		*s = AppleRootStorePolicy
-	case ZLint:
-		*s = ZLint
-	case AWSLabs:
-		*s = AWSLabs
+	case Community:
+		*s = Community
 	case EtsiEsi:
 		*s = EtsiEsi
 	}

--- a/v2/lint/source_test.go
+++ b/v2/lint/source_test.go
@@ -27,7 +27,7 @@ func TestLintSourceMarshal(t *testing.T) {
 	throwAway := struct {
 		Source LintSource
 	}{
-		Source: ZLint,
+		Source: Community,
 	}
 
 	jsonBytes, err := json.Marshal(&throwAway)
@@ -35,7 +35,7 @@ func TestLintSourceMarshal(t *testing.T) {
 		t.Fatalf("failed to marshal LintSource: %v", err)
 	}
 
-	expectedJSON := fmt.Sprintf(`{"Source":%q}`, ZLint)
+	expectedJSON := fmt.Sprintf(`{"Source":%q}`, Community)
 	if !bytes.Equal(jsonBytes, []byte(expectedJSON)) {
 		t.Fatalf("expected JSON %q got %q", expectedJSON, string(jsonBytes))
 	}
@@ -44,8 +44,8 @@ func TestLintSourceMarshal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err unmarshalling prev. marshaled LintSource: %v", err)
 	}
-	if throwAway.Source != ZLint {
-		t.Fatalf("expected post-unmarshal value of %q got %q", ZLint, throwAway.Source)
+	if throwAway.Source != Community {
+		t.Fatalf("expected post-unmarshal value of %q got %q", Community, throwAway.Source)
 	}
 
 	badJSON := []byte(`{"Source":"cpu"}`)

--- a/v2/lints/community/lint_ian_bare_wildcard.go
+++ b/v2/lints/community/lint_ian_bare_wildcard.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "e_ian_bare_wildcard",
 		Description:   "A wildcard MUST be accompanied by other data to its right (Only checks IANDNSNames)",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &brIANBareWildcard{},
 	})

--- a/v2/lints/community/lint_ian_dns_name_includes_null_char.go
+++ b/v2/lints/community/lint_ian_dns_name_includes_null_char.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "e_ian_dns_name_includes_null_char",
 		Description:   "DNSName MUST NOT include a null character",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &IANDNSNull{},
 	})

--- a/v2/lints/community/lint_ian_dns_name_starts_with_period.go
+++ b/v2/lints/community/lint_ian_dns_name_starts_with_period.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "e_ian_dns_name_starts_with_period",
 		Description:   "DNSName MUST NOT start with a period",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &IANDNSPeriod{},
 	})

--- a/v2/lints/community/lint_ian_iana_pub_suffix_empty.go
+++ b/v2/lints/community/lint_ian_iana_pub_suffix_empty.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "w_ian_iana_pub_suffix_empty",
 		Description:   "Domain SHOULD NOT have a bare public suffix",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &IANPubSuffix{},
 	})

--- a/v2/lints/community/lint_ian_wildcard_not_first.go
+++ b/v2/lints/community/lint_ian_wildcard_not_first.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "e_ian_wildcard_not_first",
 		Description:   "A wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks IANDNSNames)",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &brIANWildcardFirst{},
 	})

--- a/v2/lints/community/lint_is_redacted_cert.go
+++ b/v2/lints/community/lint_is_redacted_cert.go
@@ -55,7 +55,7 @@ func init() {
 	lint.RegisterLint(&lint.Lint{
 		Name:          "n_contains_redacted_dnsname",
 		Description:   "Some precerts are redacted and of the form ?.?.a.com or *.?.a.com",
-		Source:        lint.ZLint,
+		Source:        lint.Community,
 		Citation:      "IETF Draft: https://tools.ietf.org/id/draft-strad-trans-redaction-00.html",
 		EffectiveDate: util.ZeroDate,
 		Lint:          &DNSNameRedacted{},

--- a/v2/lints/community/lint_issuer_dn_leading_whitespace.go
+++ b/v2/lints/community/lint_issuer_dn_leading_whitespace.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "w_issuer_dn_leading_whitespace",
 		Description:   "AttributeValue in issuer RelativeDistinguishedName sequence SHOULD NOT have leading whitespace",
 		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &IssuerDNLeadingSpace{},
 	})

--- a/v2/lints/community/lint_issuer_dn_trailing_whitespace.go
+++ b/v2/lints/community/lint_issuer_dn_trailing_whitespace.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "w_issuer_dn_trailing_whitespace",
 		Description:   "AttributeValue in issuer RelativeDistinguishedName sequence SHOULD NOT have trailing whitespace",
 		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &IssuerDNTrailingSpace{},
 	})

--- a/v2/lints/community/lint_issuer_multiple_rdn.go
+++ b/v2/lints/community/lint_issuer_multiple_rdn.go
@@ -52,7 +52,7 @@ func init() {
 		Name:          "w_multiple_issuer_rdn",
 		Description:   "Certificates should not have multiple attributes in a single RDN (issuer)",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &IssuerRDNHasMultipleAttribute{},
 	})

--- a/v2/lints/community/lint_rsa_exp_negative.go
+++ b/v2/lints/community/lint_rsa_exp_negative.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "e_rsa_exp_negative",
 		Description:   "RSA public key exponent MUST be positive",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &rsaExpNegative{},
 	})

--- a/v2/lints/community/lint_rsa_no_public_key.go
+++ b/v2/lints/community/lint_rsa_no_public_key.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "e_rsa_no_public_key",
 		Description:   "The RSA public key should be present",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &rsaParsedPubKeyExist{},
 	})

--- a/v2/lints/community/lint_san_bare_wildcard.go
+++ b/v2/lints/community/lint_san_bare_wildcard.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "e_san_bare_wildcard",
 		Description:   "A wildcard MUST be accompanied by other data to its right (Only checks DNSName)",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &brSANBareWildcard{},
 	})

--- a/v2/lints/community/lint_san_dns_name_duplicate.go
+++ b/v2/lints/community/lint_san_dns_name_duplicate.go
@@ -51,7 +51,7 @@ func init() {
 		Name:          "n_san_dns_name_duplicate",
 		Description:   "SAN DNSName contains duplicate values",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &SANDNSDuplicate{},
 	})

--- a/v2/lints/community/lint_san_dns_name_includes_null_char.go
+++ b/v2/lints/community/lint_san_dns_name_includes_null_char.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "e_san_dns_name_includes_null_char",
 		Description:   "DNSName MUST NOT include a null character",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &SANDNSNull{},
 	})

--- a/v2/lints/community/lint_san_dns_name_starts_with_period.go
+++ b/v2/lints/community/lint_san_dns_name_starts_with_period.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "e_san_dns_name_starts_with_period",
 		Description:   "DNSName MUST NOT start with a period",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &SANDNSPeriod{},
 	})

--- a/v2/lints/community/lint_san_iana_pub_suffix_empty.go
+++ b/v2/lints/community/lint_san_iana_pub_suffix_empty.go
@@ -60,7 +60,7 @@ func init() {
 		Name:          "n_san_iana_pub_suffix_empty",
 		Description:   "The domain SHOULD NOT have a bare public suffix",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &pubSuffix{},
 	})

--- a/v2/lints/community/lint_san_wildcard_not_first.go
+++ b/v2/lints/community/lint_san_wildcard_not_first.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "e_san_wildcard_not_first",
 		Description:   "A wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks DNSName)",
 		Citation:      "awslabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &SANWildCardFirst{},
 	})

--- a/v2/lints/community/lint_subject_dn_leading_whitespace.go
+++ b/v2/lints/community/lint_subject_dn_leading_whitespace.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "w_subject_dn_leading_whitespace",
 		Description:   "AttributeValue in subject RelativeDistinguishedName sequence SHOULD NOT have leading whitespace",
 		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &SubjectDNLeadingSpace{},
 	})

--- a/v2/lints/community/lint_subject_dn_trailing_whitespace.go
+++ b/v2/lints/community/lint_subject_dn_trailing_whitespace.go
@@ -46,7 +46,7 @@ func init() {
 		Name:          "w_subject_dn_trailing_whitespace",
 		Description:   "AttributeValue in subject RelativeDistinguishedName sequence SHOULD NOT have trailing whitespace",
 		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &SubjectDNTrailingSpace{},
 	})

--- a/v2/lints/community/lint_subject_multiple_rdn.go
+++ b/v2/lints/community/lint_subject_multiple_rdn.go
@@ -51,7 +51,7 @@ func init() {
 		Name:          "n_multiple_subject_rdn",
 		Description:   "Certificates typically do not have have multiple attributes in a single RDN (subject). This may be an error.",
 		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &SubjectRDNHasMultipleAttribute{},
 	})

--- a/v2/lints/community/lint_validity_time_not_positive.go
+++ b/v2/lints/community/lint_validity_time_not_positive.go
@@ -42,7 +42,7 @@ func init() {
 		Name:          "e_validity_time_not_positive",
 		Description:   "Certificates MUST have a positive time for which they are valid",
 		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.AWSLabs,
+		Source:        lint.Community,
 		EffectiveDate: util.ZeroDate,
 		Lint:          &validityNegative{},
 	})


### PR DESCRIPTION
This PR is a breaking API change that combines the `lint.ZLint` and `lint.AWSLabs` `lint.LintSource`'s into one: `lint.Community`. This better matches the directory structure we store the lints under and is more indicative of the fact that we don't intend to have perfect matching coverage of all awslabs certlint lints.

Credit to @zakird for thinking of this smart breaking change before the [v3.0.0 release](https://github.com/zmap/zlint/issues/503) :tada: