### PR TITLE
CI: Add cron workflow for gTLD update PRs, deprecate tld-update-bot.

### DIFF
--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -1,0 +1,46 @@
+name: tld-update
+on:
+  schedule:
+    # Run every hour, at the 15 minute mark. E.g.
+    # 2020-11-29 00:15:00 UTC, 2020-11-29 01:15:00 UTC, 2020-11-29 02:15:00 UTC
+    - cron:  '15 * * * *'
+jobs:
+  zlint-gtld-update:
+    name: Check for TLD data updates
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S %Z')" >> $GITHUB_ENV
+
+      - name: Install zlint-gtld-update
+        run: go install ./cmd/zlint-gtld-update/...
+        working-directory: v3
+
+      - name: Run go-generate
+        run: go generate ./...
+        working-directory: v3
+
+      - name: Create pull-request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: "util: gtld_map autopull updates for ${{ env.NOW }}"
+          title: "util: gtld_map autopull updates for ${{ env.NOW }}"
+          body: "ZLint gTLD data updates from `go generate ./...` for ${{ env.NOW }}."
+          labels: tld-update
+          branch: zlint-gtld-update
+          delete-branch: true
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
### Description

Previously we used a separate repo with [a bash script](https://github.com/cpu/zlint-autopull/blob/master/autopull) hooked up to a [bot github user](https://github.com/tld-update-bot) in a Travis CI cron build to automatically create PRs updating ZLint TLD data on a periodic basis using the `zlint-gtld-update` tool from this repo. Recently it's been having reliability issues that made us miss a TLD update: https://github.com/zmap/zlint/issues/512 

Now that we're using Github Actions we can make things much simpler and self-contained. This commit adds a `tld-update.yml` workflow that uses a [create-pull-request Github action](https://github.com/peter-evans/create-pull-request) to replace the separate repo/bash script/bot user approach.

Resolves https://github.com/zmap/zlint/issues/507

### Notable Improvements

* Reduced dependencies - we can drop the Travis integration, the @tld-update-bot account, and the bot's access to this repo.
* Consolidation - all of the configuration and logic live in the ZLint repo now as opposed to being spread across the ZLint repo, an automation repo (in a separate Github account!), and Travis CI env vars.
* More flexible scheduling - the Github Actions cron schedule is more flexible so we can run the new action once every hour instead of just once a day like the Travis version.
* Smarter integration - unlike the bash script this version shouldn't recreate the same PR over and over if it isn't merged in a timely manner.

### Testing

To test the integration I pushed a commit to a fork of ZLint that [removed some of the gTLD map data](https://github.com/cpu/zlint/commit/195e0fcc184d85495da26de7672e1f28844384f6). Afterwards I updated the action to run on push of a specific test branch in addition to the cron schedule. Pushing that test branch resulted in a correct automation PR being opened to add back the removed data (and the missed update from #512). You can see [the PR that was opened here](https://github.com/cpu/zlint/pull/5). No bot account or bash scripts required :tada: