### PR TITLE
CI: Have tld-update workflow build & test pre-PR.

### DIFF
--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -29,6 +29,14 @@ jobs:
         run: go generate ./...
         working-directory: v3
 
+      - name: Build
+        run: make
+        working-directory: v3
+
+      - name: Test
+        run: make test
+        working-directory: v3
+
       - name: Create pull-request
         id: cpr
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
Once the `tld-update.yml` github workflow job has run `go generate ./...` and potentially created a local diff with updated gTLD data it should also build & test. This helps ensure that if something goes haywire and the local diff won't build/run it won't have a PR opened.

Relates to https://github.com/zmap/zlint/issues/515