### PR TITLE
CI: Cleanup hacky tld-update workflow env var use.

### DIFF
--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -18,8 +18,9 @@ jobs:
         with:
           go-version: ^1.15
 
-      - name: Set current date as env variable
-        run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S %Z')" >> $GITHUB_ENV
+      - name: Set current date
+        id: get-date
+        run: echo "::set-output name=now::$(date +'%Y-%m-%dT%H:%M:%S %Z')"
 
       - name: Install zlint-gtld-update
         run: go install ./cmd/zlint-gtld-update/...
@@ -41,9 +42,9 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: "util: gtld_map autopull updates for ${{ env.NOW }}"
-          title: "util: gtld_map autopull updates for ${{ env.NOW }}"
-          body: "ZLint gTLD data updates from `go generate ./...` for ${{ env.NOW }}."
+          commit-message: "util: gtld_map autopull updates for ${{ steps.get-date.outputs.now }}"
+          title: "util: gtld_map autopull updates for ${{ steps.get-date.outputs.now }}"
+          body: "ZLint gTLD data updates from `go generate ./...` for ${{ steps.get-date.outputs.now }}."
           committer: "GitHub <noreply@github.com>"
           author: "GitHub <noreply@github.com>"
           labels: tld-update


### PR DESCRIPTION
The `tld-update.yml` workflow needs the current date in a human readable form to include in commit messages, PR titles, and the PR body. Previously this was achieved in a clunky way with an env var echoed into `$GITHUB_ENV`.

This PR replaces that logic with a cleaner way to achieve the same thing: setting the date string as the output of a step and then referencing it later in the workflow. I learned this approach from Sleevi on https://github.com/publicsuffix/list/pull/1166 and I'm just backporting it here to keep things consistent.