### PR TITLE
util: remove unused `ICANNPublicSuffixParse` helper.

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -2,7 +2,6 @@ module github.com/zmap/zlint/v3
 
 require (
 	github.com/sirupsen/logrus v1.7.0
-	github.com/weppos/publicsuffix-go v0.13.0
 	github.com/zmap/zcrypto v0.0.0-20201128221613-3719af1573cf
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b

--- a/v3/util/fqdn.go
+++ b/v3/util/fqdn.go
@@ -19,7 +19,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/weppos/publicsuffix-go/publicsuffix"
 	zcutil "github.com/zmap/zcrypto/util"
 	"github.com/zmap/zcrypto/x509"
 )
@@ -108,10 +107,6 @@ func DNSNamesExist(cert *x509.Certificate) bool {
 	} else {
 		return true
 	}
-}
-
-func ICANNPublicSuffixParse(domain string) (*publicsuffix.DomainName, error) {
-	return publicsuffix.ParseFromListWithOptions(publicsuffix.DefaultList, domain, &publicsuffix.FindOptions{IgnorePrivate: true, DefaultRule: publicsuffix.DefaultRule})
 }
 
 func CommonNameIsIP(cert *x509.Certificate) bool {


### PR DESCRIPTION
The `util.ICANNPublicSuffixParse` helper function is the only place in ZLint that directly imports `weppos/publicsuffix-go`, and it isn't called from anywhere.

By removing this unused helper we can remove the direct dependency on `weppos/publicsuffix-go` from ZLint. It remains a transitive dependency via ZCrypto.

Relates to https://github.com/zmap/zlint/issues/523