### PR TITLE
lints: return detail for e_ext_duplicate_extension.

### DIFF
--- a/v3/lints/rfc/lint_ext_duplicate_extension.go
+++ b/v3/lints/rfc/lint_ext_duplicate_extension.go
@@ -82,7 +82,7 @@ func (l *extDuplicateExtension) Execute(cert *x509.Certificate) *lint.LintResult
 	return &lint.LintResult{
 		Status: lint.Error,
 		Details: fmt.Sprintf(
-			"Found extension OIDs present more than one time: %s",
+			"The following extensions are duplicated: %s",
 			strings.Join(duplicateOIDsList, ", ")),
 	}
 }

--- a/v3/lints/rfc/lint_ext_duplicate_extension.go
+++ b/v3/lints/rfc/lint_ext_duplicate_extension.go
@@ -15,12 +15,15 @@ package rfc
  */
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/v3/lint"
 	"github.com/zmap/zlint/v3/util"
 )
 
-type ExtDuplicateExtension struct{}
+type extDuplicateExtension struct{}
 
 /************************************************
 "A certificate MUST NOT include more than one instance of a particular extension."
@@ -33,27 +36,53 @@ func init() {
 		Citation:      "RFC 5280: 4.2",
 		Source:        lint.RFC5280,
 		EffectiveDate: util.RFC2459Date,
-		Lint:          &ExtDuplicateExtension{},
+		Lint:          &extDuplicateExtension{},
 	})
 }
 
-func (l *ExtDuplicateExtension) Initialize() error {
+func (l *extDuplicateExtension) Initialize() error {
 	return nil
 }
 
-func (l *ExtDuplicateExtension) CheckApplies(cert *x509.Certificate) bool {
+func (l *extDuplicateExtension) CheckApplies(cert *x509.Certificate) bool {
 	return cert.Version == 3
 }
 
-func (l *ExtDuplicateExtension) Execute(cert *x509.Certificate) *lint.LintResult {
-	// O(n^2) is not terrible here because n is capped around 10
-	for i := 0; i < len(cert.Extensions); i++ {
-		for j := i + 1; j < len(cert.Extensions); j++ {
-			if i != j && cert.Extensions[i].Id.Equal(cert.Extensions[j].Id) {
-				return &lint.LintResult{Status: lint.Error}
-			}
+func (l *extDuplicateExtension) Execute(cert *x509.Certificate) *lint.LintResult {
+	// Make two maps: one for all of the extensions in the cert, and one for any
+	// OIDs that are found more than once.
+	extensionOIDs := make(map[string]bool)
+	duplicateOIDs := make(map[string]bool)
+
+	// Iterate through the certificate extensions and update the maps.
+	for _, ext := range cert.Extensions {
+		// We can't use the `asn1.ObjectIdentifier` as a key (it's an int slice) so use
+		// the str representation.
+		oid := ext.Id.String()
+
+		if alreadySeen := extensionOIDs[oid]; alreadySeen {
+			duplicateOIDs[oid] = true
+		} else {
+			extensionOIDs[oid] = true
 		}
 	}
-	// Nested loop will return if it finds a duplicate, so safe to assume pass
-	return &lint.LintResult{Status: lint.Pass}
+
+	// If there were no duplicates we're done, the cert passes.
+	if len(duplicateOIDs) == 0 {
+		return &lint.LintResult{Status: lint.Pass}
+	}
+
+	// If there were duplicates turn the map keys into a list so we
+	// can join them for the details string.
+	var duplicateOIDsList []string
+	for oid := range duplicateOIDs {
+		duplicateOIDsList = append(duplicateOIDsList, oid)
+	}
+
+	return &lint.LintResult{
+		Status: lint.Error,
+		Details: fmt.Sprintf(
+			"Found extension OIDs present more than one time: %s",
+			strings.Join(duplicateOIDsList, ", ")),
+	}
 }

--- a/v3/lints/rfc/lint_ext_duplicate_extension_test.go
+++ b/v3/lints/rfc/lint_ext_duplicate_extension_test.go
@@ -32,13 +32,13 @@ func TestDuplicateExtensions(t *testing.T) {
 			name:            "duplicate SAN extension",
 			path:            "extSANDuplicated.pem",
 			expectedStatus:  lint.Error,
-			expectedDetails: "Found extension OIDs present more than one time: 2.5.29.17",
+			expectedDetails: "The following extensions are duplicated: 2.5.29.17",
 		},
 		{
 			name:            "multiple duplicate extensions",
 			path:            "multDupeExts.pem",
 			expectedStatus:  lint.Error,
-			expectedDetails: "Found extension OIDs present more than one time: 2.5.29.14, 2.5.29.35",
+			expectedDetails: "The following extensions are duplicated: 2.5.29.14, 2.5.29.35",
 		},
 		{
 			name:           "no duplicate extensions",

--- a/v3/lints/rfc/lint_ext_duplicate_extension_test.go
+++ b/v3/lints/rfc/lint_ext_duplicate_extension_test.go
@@ -29,9 +29,16 @@ func TestDuplicateExtensions(t *testing.T) {
 		expectedDetails string
 	}{
 		{
-			name:           "duplicate SAN extension",
-			path:           "extSANDuplicated.pem",
-			expectedStatus: lint.Error,
+			name:            "duplicate SAN extension",
+			path:            "extSANDuplicated.pem",
+			expectedStatus:  lint.Error,
+			expectedDetails: "Found extension OIDs present more than one time: 2.5.29.17",
+		},
+		{
+			name:            "multiple duplicate extensions",
+			path:            "multDupeExts.pem",
+			expectedStatus:  lint.Error,
+			expectedDetails: "Found extension OIDs present more than one time: 2.5.29.14, 2.5.29.35",
 		},
 		{
 			name:           "no duplicate extensions",
@@ -42,6 +49,7 @@ func TestDuplicateExtensions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			actual := test.TestLint("e_ext_duplicate_extension", tc.path)
 			if actual.Status != tc.expectedStatus {
 				t.Errorf("%s: expected status %q got %q",

--- a/v3/lints/rfc/lint_ext_duplicate_extension_test.go
+++ b/v3/lints/rfc/lint_ext_duplicate_extension_test.go
@@ -21,20 +21,36 @@ import (
 	"github.com/zmap/zlint/v3/test"
 )
 
-func TestDuplicateExtension(t *testing.T) {
-	inputPath := "extSANDuplicated.pem"
-	expected := lint.Error
-	out := test.TestLint("e_ext_duplicate_extension", inputPath)
-	if out.Status != expected {
-		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+func TestDuplicateExtensions(t *testing.T) {
+	testCases := []struct {
+		name            string
+		path            string
+		expectedStatus  lint.LintStatus
+		expectedDetails string
+	}{
+		{
+			name:           "duplicate SAN extension",
+			path:           "extSANDuplicated.pem",
+			expectedStatus: lint.Error,
+		},
+		{
+			name:           "no duplicate extensions",
+			path:           "caBasicConstCrit.pem",
+			expectedStatus: lint.Pass,
+		},
 	}
-}
 
-func TestNoDuplicateExtension(t *testing.T) {
-	inputPath := "caBasicConstCrit.pem"
-	expected := lint.Pass
-	out := test.TestLint("e_ext_duplicate_extension", inputPath)
-	if out.Status != expected {
-		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := test.TestLint("e_ext_duplicate_extension", tc.path)
+			if actual.Status != tc.expectedStatus {
+				t.Errorf("%s: expected status %q got %q",
+					tc.path, tc.expectedStatus, actual.Status)
+			}
+			if actual.Details != tc.expectedDetails {
+				t.Errorf("%s: expected detail %q got %q",
+					tc.path, tc.expectedDetails, actual.Details)
+			}
+		})
 	}
 }

--- a/v3/testdata/multDupeExts.pem
+++ b/v3/testdata/multDupeExts.pem
@@ -1,0 +1,133 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = UN, ST = NYS, O = UNGA, OU = UNSC, CN = DT
+        Validity
+            Not Before: Jun 25 19:55:19 2019 GMT
+            Not After : Jan 21 03:29:38 2030 GMT
+        Subject: C = UN, ST = NYS, O = UNGA, OU = UNSC-peace, CN = DT-peace
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:d4:bb:8b:0f:4e:f9:72:0d:08:19:c0:26:a4:e8:
+                    08:2f:33:8e:6c:b0:a9:dd:42:fc:cd:28:02:8a:45:
+                    ce:ac:0f:84:77:88:87:81:45:13:81:4e:c9:db:de:
+                    ad:bd:9f:08:66:60:be:a6:01:8f:dd:95:f9:ea:f3:
+                    5a:75:21:9d:13:42:18:64:b1:71:4a:5b:69:be:61:
+                    73:62:81:1e:85:e4:95:e5:59:14:a2:6d:82:2b:74:
+                    bd:3f:95:c6:0c:7a:71:8a:6b:d3:c5:01:4d:8e:c5:
+                    18:f1:56:53:8f:5f:15:f7:30:fe:64:07:31:6f:ef:
+                    8e:b9:51:8c:7f:db:18:c3:20:d7:a7:6c:14:d6:20:
+                    64:c3:ba:7a:ca:a0:3f:9e:06:41:e9:22:5f:22:33:
+                    9f:a5:91:ab:b6:85:96:e0:7a:f6:15:e9:10:58:92:
+                    3e:98:7d:30:f1:c5:58:92:20:09:d5:2f:dd:12:67:
+                    cd:0c:be:2f:c8:64:10:be:5e:40:62:0a:97:91:99:
+                    37:1c:c9:8a:b0:9d:f0:b3:5c:58:b7:1b:34:f7:bc:
+                    4c:04:0c:59:0a:8d:ce:c9:86:cf:29:75:9f:7d:d9:
+                    21:93:ec:f0:ce:4c:dd:1e:03:2a:d6:6c:3b:5d:96:
+                    cc:0e:60:fa:b9:3c:32:e0:27:a1:4c:5f:05:82:94:
+                    f5:4f:45:5c:c7:13:e5:70:d7:62:89:1b:19:b8:5a:
+                    6b:c5:40:24:07:d4:16:f6:29:89:92:02:f2:49:95:
+                    46:ae:18:38:e2:a6:59:32:96:74:e4:3c:20:8f:49:
+                    c1:de:9d:c0:00:42:4e:26:89:df:6f:c2:ea:d3:1a:
+                    2d:e6:f8:b8:56:c9:73:30:68:41:8d:49:91:ac:1b:
+                    6f:e5:f0:bd:f4:55:92:ba:54:f5:b8:58:de:d9:aa:
+                    22:b7:10:ae:c0:8d:ba:f4:5a:5e:8c:bd:af:4b:c1:
+                    96:0c:00:4e:91:45:86:a2:7a:82:90:30:84:6e:71:
+                    8f:a0:a0:27:65:32:27:52:a8:d5:85:2e:f2:8a:f4:
+                    15:76:86:d1:19:dc:b8:84:60:8b:33:d4:ec:91:0d:
+                    af:e7:3a:9c:79:5f:1f:66:3b:86:a9:47:62:ca:76:
+                    cd:ec:38:fb:c8:f5:b3:f4:9e:65:12:0a:7f:ae:25:
+                    25:54:59:f7:b5:02:ca:64:d4:9b:c3:f2:0f:3b:fe:
+                    80:af:7f:34:02:c8:da:7f:c3:f6:92:fd:6c:13:aa:
+                    b9:35:41:15:7e:29:73:7a:84:62:eb:5b:ba:9a:89:
+                    f5:84:b5:bf:0e:3c:ac:e6:cf:f5:61:61:97:ec:64:
+                    c9:b8:78:ab:a1:93:fa:05:fc:28:17:cb:aa:75:5b:
+                    41:6d:97
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:EA:D3:9D:F2:FA:12:15:1D:6B:90:01:1F:1D:DB:27:7F:AF:D1:65:D7
+
+            X509v3 Subject Key Identifier: 
+                BC:93:A7:C1:4D:51:A1:B1:1E:5D:C9:C1:91:EA:DB:5B:53:D5:BC:58
+            X509v3 Key Usage: critical
+                Certificate Sign
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                BC:93:A7:C1:4D:51:A1:B1:1E:5D:C9:C1:91:EA:DB:5B:53:D5:BC:58
+            Netscape Comment: critical
+                here is the nsComment content
+            X509v3 Authority Key Identifier: 
+                DirName:/C=UN/ST=NYS/O=UNGA/OU=UNSC/CN=DT
+                serial:01
+
+    Signature Algorithm: sha256WithRSAEncryption
+         25:88:c8:ac:57:2b:09:90:77:3d:74:75:5f:39:ce:fb:c2:95:
+         30:74:ed:89:b7:6e:c1:4b:7b:28:30:10:f2:3c:2f:40:b5:46:
+         cb:2a:45:c2:81:cb:54:cd:45:84:8e:5a:f0:9b:ba:b9:5a:25:
+         00:0f:c7:f9:63:a8:1b:9b:af:84:92:69:69:2e:40:52:8e:44:
+         24:59:c4:21:4e:f9:10:c7:b8:33:87:1d:ae:b8:b9:90:f6:06:
+         7c:7f:7b:33:3d:58:94:4d:d9:fe:0a:5c:db:d6:73:5d:d8:67:
+         c6:1d:30:54:6c:bc:eb:d5:72:e3:66:2f:b8:e6:84:9b:91:59:
+         4a:f8:a8:9a:47:a0:d6:c2:4c:16:2a:17:e4:de:32:23:5f:28:
+         cd:56:99:70:b5:a9:50:fe:a2:ce:15:03:d3:87:78:0d:10:24:
+         ad:34:d6:ed:3a:cc:35:ff:e5:1d:73:b6:fc:fa:07:b7:f6:c4:
+         41:85:26:a1:da:bb:aa:11:15:52:b3:d6:88:f7:c3:0d:7d:44:
+         83:6c:8f:9d:99:6a:f8:81:5f:eb:de:5b:0c:b9:07:cd:2d:81:
+         49:fb:f7:fa:9a:1c:53:2b:b1:e4:6f:02:52:d4:ad:d9:8d:f8:
+         c9:ef:e8:61:33:a1:81:a8:fc:80:24:51:92:ef:0a:ce:18:10:
+         fa:42:da:33:1e:73:c3:11:ed:0f:17:0d:46:f1:b7:40:18:9b:
+         46:d6:bd:c4:bd:a7:0c:d7:08:1d:63:c8:41:ee:a7:6f:a8:1f:
+         e0:1d:a6:d9:3a:86:ee:89:0c:92:24:1f:69:ab:c4:9b:9e:aa:
+         ff:72:a0:34:f9:ac:7e:2c:da:07:6c:67:ab:c3:f1:95:d5:3c:
+         6e:24:d7:08:a8:28:df:62:67:2b:b3:78:bf:e0:a4:19:b8:b6:
+         98:c4:51:79:97:2e:1c:99:60:72:3c:81:6a:d6:85:17:a8:fb:
+         1d:e2:fa:1d:48:fc:b0:6a:b3:7a:42:5a:0a:df:40:8c:13:a5:
+         81:cd:a2:70:ff:82:c8:67:df:23:7d:d9:cb:e0:6a:75:c9:78:
+         48:ee:84:e2:59:ef:e3:79:0b:4b:11:ef:d4:a1:70:97:fc:09:
+         90:c5:84:22:30:5f:3d:7a:f6:35:36:fd:f7:cd:17:e8:50:27:
+         5b:e0:5b:76:16:43:23:fd:d6:08:47:04:46:8a:da:70:b0:4c:
+         c6:13:4a:38:d7:c5:d3:d7:ba:30:2b:2a:97:c7:42:1f:22:d6:
+         4e:26:07:30:b8:f1:44:97:14:eb:66:af:ff:9c:3b:24:37:e2:
+         e5:98:f7:4b:48:be:3d:d0:6c:b7:8e:0d:de:2a:18:b0:b2:02:
+         6e:c0:72:73:55:ad:05:2f
+-----BEGIN CERTIFICATE-----
+MIIGJTCCBA2gAwIBAgIBAjANBgkqhkiG9w0BAQsFADBGMQswCQYDVQQGEwJVTjEM
+MAoGA1UECAwDTllTMQ0wCwYDVQQKDARVTkdBMQ0wCwYDVQQLDARVTlNDMQswCQYD
+VQQDDAJEVDAiGA8yMDE5MDYyNTE5NTUxOVoYDzIwMzAwMTIxMDMyOTM4WjBSMQsw
+CQYDVQQGEwJVTjEMMAoGA1UECAwDTllTMQ0wCwYDVQQKDARVTkdBMRMwEQYDVQQL
+DApVTlNDLXBlYWNlMREwDwYDVQQDDAhEVC1wZWFjZTCCAiIwDQYJKoZIhvcNAQEB
+BQADggIPADCCAgoCggIBANS7iw9O+XINCBnAJqToCC8zjmywqd1C/M0oAopFzqwP
+hHeIh4FFE4FOydverb2fCGZgvqYBj92V+erzWnUhnRNCGGSxcUpbab5hc2KBHoXk
+leVZFKJtgit0vT+Vxgx6cYpr08UBTY7FGPFWU49fFfcw/mQHMW/vjrlRjH/bGMMg
+16dsFNYgZMO6esqgP54GQekiXyIzn6WRq7aFluB69hXpEFiSPph9MPHFWJIgCdUv
+3RJnzQy+L8hkEL5eQGIKl5GZNxzJirCd8LNcWLcbNPe8TAQMWQqNzsmGzyl1n33Z
+IZPs8M5M3R4DKtZsO12WzA5g+rk8MuAnoUxfBYKU9U9FXMcT5XDXYokbGbhaa8VA
+JAfUFvYpiZIC8kmVRq4YOOKmWTKWdOQ8II9Jwd6dwABCTiaJ32/C6tMaLeb4uFbJ
+czBoQY1Jkawbb+XwvfRVkrpU9bhY3tmqIrcQrsCNuvRaXoy9r0vBlgwATpFFhqJ6
+gpAwhG5xj6CgJ2UyJ1Ko1YUu8or0FXaG0RncuIRgizPU7JENr+c6nHlfH2Y7hqlH
+Ysp2zew4+8j1s/SeZRIKf64lJVRZ97UCymTUm8PyDzv+gK9/NALI2n/D9pL9bBOq
+uTVBFX4pc3qEYutbupqJ9YS1vw48rObP9WFhl+xkybh4q6GT+gX8KBfLqnVbQW2X
+AgMBAAGjggEMMIIBCDAfBgNVHSMEGDAWgBTq053y+hIVHWuQAR8d2yd/r9Fl1zAd
+BgNVHQ4EFgQUvJOnwU1RobEeXcnBkerbW1PVvFgwDgYDVR0PAQH/BAQDAgIEMAwG
+A1UdEwEB/wQCMAAwHQYDVR0OBBYEFLyTp8FNUaGxHl3JwZHq21tT1bxYMC8GCWCG
+SAGG+EIBDQEB/wQfFh1oZXJlIGlzIHRoZSBuc0NvbW1lbnQgY29udGVudDBYBgNV
+HSMEUTBPoUqkSDBGMQswCQYDVQQGEwJVTjEMMAoGA1UECAwDTllTMQ0wCwYDVQQK
+DARVTkdBMQ0wCwYDVQQLDARVTlNDMQswCQYDVQQDDAJEVIIBATANBgkqhkiG9w0B
+AQsFAAOCAgEAJYjIrFcrCZB3PXR1XznO+8KVMHTtibduwUt7KDAQ8jwvQLVGyypF
+woHLVM1FhI5a8Ju6uVolAA/H+WOoG5uvhJJpaS5AUo5EJFnEIU75EMe4M4cdrri5
+kPYGfH97Mz1YlE3Z/gpc29ZzXdhnxh0wVGy869Vy42YvuOaEm5FZSviomkeg1sJM
+FioX5N4yI18ozVaZcLWpUP6izhUD04d4DRAkrTTW7TrMNf/lHXO2/PoHt/bEQYUm
+odq7qhEVUrPWiPfDDX1Eg2yPnZlq+IFf695bDLkHzS2BSfv3+pocUyux5G8CUtSt
+2Y34ye/oYTOhgaj8gCRRku8KzhgQ+kLaMx5zwxHtDxcNRvG3QBibRta9xL2nDNcI
+HWPIQe6nb6gf4B2m2TqG7okMkiQfaavEm56q/3KgNPmsfizaB2xnq8PxldU8biTX
+CKgo32JnK7N4v+CkGbi2mMRReZcuHJlgcjyBataFF6j7HeL6HUj8sGqzekJaCt9A
+jBOlgc2icP+CyGffI33Zy+Bqdcl4SO6E4lnv43kLSxHv1KFwl/wJkMWEIjBfPXr2
+NTb9980X6FAnW+BbdhZDI/3WCEcERoracLBMxhNKONfF09e6MCsql8dCHyLWTiYH
+MLjxRJcU62av/5w7JDfi5Zj3S0i+PdBst44N3ioYsLICbsByc1WtBS8=
+-----END CERTIFICATE-----


### PR DESCRIPTION
Previously the `e_ext_duplicate_extension` lint from the `lint.RFC5280` source only returned a `lint.Error` result as soon as one duplicate extension was found in a certificate. It did not indicate which extension OID was duplicated, or if there was more than one duplicated extensions.

This PR reworks the lint to do both of these things. The detail string now indicates all of the extension OIDs that were present more than once.

Resolves https://github.com/zmap/zlint/issues/549