### PR TITLE
Lint template produces a file with an `init` function that is not at the top of the new lint

### DIFF
--- a/v3/template
+++ b/v3/template
@@ -19,6 +19,17 @@ import (
 	"github.com/zmap/zlint/v2/lint"
 )
 
+func init() {
+	lint.RegisterLint(&lint.Lint{
+		Name:          "SUBTEST",
+		Description:   "Fill this in...",
+		Citation:      "Fill this in...",
+		Source:        UnknownLintSource,
+		EffectiveDate: "Change this...",
+		Lint:          &SUBST{},
+	})
+}
+
 type SUBST struct{}
 
 func (l *SUBST) Initialize() error {
@@ -31,15 +42,4 @@ func (l *SUBST) CheckApplies(c *x509.Certificate) bool {
 
 func (l *SUBST) Execute(c *x509.Certificate) *lint.LintResult {
 	// Add actual lint here
-}
-
-func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "SUBTEST",
-		Description:   "Fill this in...",
-		Citation:      "Fill this in...",
-		Source:        UnknownLintSource,
-		EffectiveDate: "Change this...",
-		Lint:          &SUBST{},
-	})
 }

--- a/v3/template
+++ b/v3/template
@@ -16,7 +16,7 @@ package PACKAGE
 
 import (
 	"github.com/zmap/zcrypto/x509"
-	"github.com/zmap/zlint/v2/lint"
+	"github.com/zmap/zlint/v3/lint"
 )
 
 func init() {


### PR DESCRIPTION
This address issues #564 

(also caught the `v2` import, but I don't reckon that's worth another PR)