### PR TITLE
project: switch to go 1.16.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.16
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.16
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
 
       - name: Set current date
         id: get-date

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ software.
 Requirements
 ------------
 
-ZLint requires [Go 1.15.x or newer](https://golang.org/doc/install) be
+ZLint requires [Go 1.16.x or newer](https://golang.org/doc/install) be
 installed. The command line setup instructions assume the `go` command is in
 your `$PATH`.
 

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -9,4 +9,4 @@ require (
 	golang.org/x/text v0.3.4
 )
 
-go 1.15
+go 1.16


### PR DESCRIPTION
[Go 1.16](https://golang.org/doc/go1.16) is the latest stable release. This PR switches the `go.mod` go version, as well as the version used in Github workflows for CI.