### PR TITLE
Introduce an upper bounds to effective dates 

### DIFF
--- a/v3/lint/base.go
+++ b/v3/lint/base.go
@@ -58,20 +58,35 @@ type Lint struct {
 
 	// Lints automatically returns NE for all certificates where CheckApplies() is
 	// true but with NotBefore < EffectiveDate. This check is bypassed if
-	// EffectiveDate is zero.
+	// EffectiveDate is zero. Please see CheckEffective for more information.
 	EffectiveDate time.Time `json:"-"`
+
+	// Lints automatically returns NE for all certificates where CheckApplies() is
+	// true but with NotBefore >= IneffectiveDate. This check is bypassed if
+	// IneffectiveDate is zero. Please see CheckEffective for more information.
+	IneffectiveDate time.Time `json:"-"`
 
 	// The implementation of the lint logic.
 	Lint LintInterface `json:"-"`
 }
 
-// CheckEffective returns true if c was issued on or after the EffectiveDate. If
-// EffectiveDate is zero, CheckEffective always returns true.
+// CheckEffective returns true if c was issued on or after the EffectiveDate
+// AND before (but not on) the Ineffective date. That is, CheckEffective
+// returns true if...
+//
+// 	c.NotBefore in [EffectiveDate, IneffectiveDate)
+//
+// If EffectiveDate is zero, then only IneffectiveDate is checked. Conversely,
+// if IneffectiveDate is zero then only EffectiveDate is checked. If both EffectiveDate
+// and IneffectiveDate are zero then CheckEffective always returns true.
 func (l *Lint) CheckEffective(c *x509.Certificate) bool {
-	if l.EffectiveDate.IsZero() || !l.EffectiveDate.After(c.NotBefore) {
-		return true
-	}
-	return false
+	// This lint is effective if either it has no efficacy date or if the certificate is valid
+	// on or after the efficacy date.
+	afterOrOnEffective := l.EffectiveDate.IsZero() || c.NotBefore.After(l.EffectiveDate) || c.NotBefore.Equal(l.EffectiveDate)
+	// This lint is effective if either it has inefficacy date or if the certificate is valid
+	// before (but not on) the inefficacy date.
+	beforeIneffective := l.IneffectiveDate.IsZero() || c.NotBefore.Before(l.IneffectiveDate)
+	return afterOrOnEffective && beforeIneffective
 }
 
 // Execute runs the lint against a certificate. For lints that are

--- a/v3/lint/base.go
+++ b/v3/lint/base.go
@@ -80,12 +80,11 @@ type Lint struct {
 // if IneffectiveDate is zero then only EffectiveDate is checked. If both EffectiveDate
 // and IneffectiveDate are zero then CheckEffective always returns true.
 func (l *Lint) CheckEffective(c *x509.Certificate) bool {
-	// This lint is effective if either it has no efficacy date or if the certificate is valid
-	// on or after the efficacy date.
-	afterOrOnEffective := l.EffectiveDate.IsZero() || c.NotBefore.After(l.EffectiveDate) || c.NotBefore.Equal(l.EffectiveDate)
-	// This lint is effective if either it has inefficacy date or if the certificate is valid
-	// before (but not on) the inefficacy date.
-	beforeIneffective := l.IneffectiveDate.IsZero() || c.NotBefore.Before(l.IneffectiveDate)
+	afterOrOnEffective := l.EffectiveDate.IsZero() ||
+		c.NotBefore.After(l.EffectiveDate) ||
+		c.NotBefore.Equal(l.EffectiveDate)
+	beforeIneffective := l.IneffectiveDate.IsZero() ||
+		c.NotBefore.Before(l.IneffectiveDate)
 	return afterOrOnEffective && beforeIneffective
 }
 

--- a/v3/lint/base_test.go
+++ b/v3/lint/base_test.go
@@ -21,22 +21,147 @@ import (
 	"github.com/zmap/zcrypto/x509"
 )
 
-func TestLintCheckEffective(t *testing.T) {
-	c := &x509.Certificate{
-		NotBefore: time.Now(),
-	}
-	l := Lint{}
+// This test attempts to simplify the truth table by assigning dates to the
+// single digit values 1 through 5, inclusive. As per the standard library,
+// 0 is taken to be the null value.
+//
+// E.G.
+//
+// If a lint is effective between 2 and 5, then the certs {2, 3, 4} return true.
+// If a lint is effective between 0 and 4, then the certs {0, 1, 2, 3} return true.
+// if a lint is effective between 2 and 0, then the certs {2, 3, 4, 5} return true.
+// if a lint is effective between 0 and 0, then the certs {0, 1, 2, 3, 4, 5} return true.
+func TestLint_CheckEffective(t *testing.T) {
+	zero := time.Time{}
+	one := time.Unix(1, 0)
+	two := time.Unix(2, 0)
+	three := time.Unix(3, 0)
+	four := time.Unix(4, 0)
+	five := time.Unix(5, 0)
 
-	l.EffectiveDate = time.Time{}
-	if l.CheckEffective(c) != true {
-		t.Errorf("EffectiveDate of zero should always be true")
+	lZeroZero := Lint{
+		Description:   "ZeroZero",
+		EffectiveDate: zero, IneffectiveDate: zero}
+	lTwoZero := Lint{
+		Description:   "TwoZero",
+		EffectiveDate: two, IneffectiveDate: zero}
+	lZeroFour := Lint{
+		Description:   "ZeroFour",
+		EffectiveDate: zero, IneffectiveDate: four}
+	lTwoFour := Lint{
+		Description:   "TwoFour",
+		EffectiveDate: two, IneffectiveDate: four}
+
+	type cert struct {
+		Description string
+		Certificate *x509.Certificate
 	}
-	l.EffectiveDate = time.Unix(1, 0)
-	if l.CheckEffective(c) != true {
-		t.Errorf("EffectiveDate of 1970-01-01 should be true")
+
+	cZero := cert{
+		Description: "cZero",
+		Certificate: &x509.Certificate{NotBefore: zero},
 	}
-	l.EffectiveDate = time.Unix(32503680000, 0) // 3000-01-01
-	if l.CheckEffective(c) != false {
-		t.Errorf("EffectiveDate of 3000 should be false")
+	cOne := cert{
+		Description: "cOne",
+		Certificate: &x509.Certificate{NotBefore: one},
+	}
+	cTwo := cert{
+		Description: "cTwo",
+		Certificate: &x509.Certificate{NotBefore: two},
+	}
+	cThree := cert{
+		Description: "cThree",
+		Certificate: &x509.Certificate{NotBefore: three},
+	}
+	cFour := cert{
+		Description: "cFour",
+		Certificate: &x509.Certificate{NotBefore: four},
+	}
+	cFive := cert{
+		Description: "cFive",
+		Certificate: &x509.Certificate{NotBefore: five},
+	}
+
+	data := []struct {
+		Lint        Lint
+		Certificate cert
+		Want        bool
+	}{
+		///////////////
+		{
+			Lint:        lZeroZero,
+			Certificate: cZero,
+			Want:        true,
+		},
+		{
+			Lint:        lZeroZero,
+			Certificate: cOne,
+			Want:        true,
+		},
+		//////////
+		{
+			Lint:        lTwoZero,
+			Certificate: cOne,
+			Want:        false,
+		},
+		{
+			Lint:        lTwoZero,
+			Certificate: cTwo,
+			Want:        true,
+		},
+		{
+			Lint:        lTwoZero,
+			Certificate: cThree,
+			Want:        true,
+		},
+		///////////////
+		{
+			Lint:        lZeroFour,
+			Certificate: cTwo,
+			Want:        true,
+		},
+		{
+			Lint:        lZeroFour,
+			Certificate: cFour,
+			Want:        false,
+		},
+		{
+			Lint:        lZeroFour,
+			Certificate: cFive,
+			Want:        false,
+		},
+		////////////
+		{
+			Lint:        lTwoFour,
+			Certificate: cOne,
+			Want:        false,
+		},
+		{
+			Lint:        lTwoFour,
+			Certificate: cTwo,
+			Want:        true,
+		},
+		{
+			Lint:        lTwoFour,
+			Certificate: cThree,
+			Want:        true,
+		},
+		{
+			Lint:        lTwoFour,
+			Certificate: cFour,
+			Want:        false,
+		},
+		{
+			Lint:        lTwoFour,
+			Certificate: cFive,
+			Want:        false,
+		},
+	}
+	for _, d := range data {
+		got := d.Lint.CheckEffective(d.Certificate.Certificate)
+		if got != d.Want {
+			t.Errorf("Lint %s, cert %s, got %v want %v",
+				d.Lint.Description, d.Certificate.Description, got, d.Want)
+		}
 	}
 }

--- a/v3/lint/base_test.go
+++ b/v3/lint/base_test.go
@@ -29,7 +29,7 @@ import (
 //
 // If a lint is effective between 2 and 5, then the certs {2, 3, 4} return true.
 // If a lint is effective between 0 and 4, then the certs {0, 1, 2, 3} return true.
-// if a lint is effective between 2 and 0, then the certs {2, 3, 4, 5} return true.
+// If a lint is effective between 2 and 0, then the certs {2, 3, 4, 5} return true.
 // if a lint is effective between 0 and 0, then the certs {0, 1, 2, 3, 4, 5} return true.
 func TestLint_CheckEffective(t *testing.T) {
 	zero := time.Time{}

--- a/v3/lint/base_test.go
+++ b/v3/lint/base_test.go
@@ -30,7 +30,7 @@ import (
 // If a lint is effective between 2 and 5, then the certs {2, 3, 4} return true.
 // If a lint is effective between 0 and 4, then the certs {0, 1, 2, 3} return true.
 // If a lint is effective between 2 and 0, then the certs {2, 3, 4, 5} return true.
-// if a lint is effective between 0 and 0, then the certs {0, 1, 2, 3, 4, 5} return true.
+// If a lint is effective between 0 and 0, then the certs {0, 1, 2, 3, 4, 5} return true.
 func TestLint_CheckEffective(t *testing.T) {
 	zero := time.Time{}
 	one := time.Unix(1, 0)
@@ -157,6 +157,7 @@ func TestLint_CheckEffective(t *testing.T) {
 			Want:        false,
 		},
 	}
+
 	for _, d := range data {
 		got := d.Lint.CheckEffective(d.Certificate.Certificate)
 		if got != d.Want {


### PR DESCRIPTION
We would like to add a mechanism for a lint to declare that it is no longer effective for certificates issued past a certain date. This involves:

1. Updating the `Lint` struct appropriately.
2. Updating both the `CheckEffective` body and documentation. Note that I reorganized the boolean logic to be a bit clearer (that is, I find it much easier to read these expressions when their plain English translation aligns more closely to the documentation).
3. Rewrote the unit tests since the addition of the upper bounds date greatly expanded the truth table under consideration.

I'm not particularly married to the name `IneffectiveDate`. It's just, ya know, the antonym to `EffectiveDate` so :man_shrugging: Maybe refactor the entire project to use `NotBefore` and `NotAfter`? Contributors would clearly recognize the concept at play there, but then I worry that that may cause confusion between the Linter's `NotBefore/After` and those found on certificates.

This PR resolves #575 