### PR TITLE
cmd: add `-version` to `zlint`, `zlint-gtld-update`.

### DIFF
--- a/v3/cmd/zlint-gtld-update/main.go
+++ b/v3/cmd/zlint-gtld-update/main.go
@@ -50,6 +50,11 @@ const (
 )
 
 var (
+	// version is replaced by GoReleaser or `make` using an LDFlags option at
+	// build time. Here we supply a default value for folks that `go install` or
+	// `go build` directly from src.
+	version = "dev-unknown"
+
 	// httpClient is a http.Client instance configured with timeouts.
 	httpClient = &http.Client{
 		Transport: &http.Transport{
@@ -104,6 +109,8 @@ var tldMap = map[string]GTLDPeriod{
 	},
 }
 `))
+
+	printVersion bool = false
 )
 
 // getData fetches the response body bytes from an HTTP get to the provider url,
@@ -297,9 +304,11 @@ func renderGTLDMap(writer io.Writer) error {
 // init sets up command line flags
 func init() {
 	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "ZLint version %s\n\n", version)
 		fmt.Fprintf(os.Stderr, "Usage: %s [flags]\n", os.Args[0])
 		flag.PrintDefaults()
 	}
+	flag.BoolVar(&printVersion, "version", false, "Print ZLint version and exit")
 	flag.Parse()
 	log.SetLevel(log.InfoLevel)
 }
@@ -311,6 +320,11 @@ func main() {
 	errQuit := func(err error) {
 		fmt.Fprintf(os.Stderr, "error updating gTLD map: %s\n", err)
 		os.Exit(1)
+	}
+
+	if printVersion {
+		fmt.Printf("ZLint version %s\n", version)
+		return
 	}
 
 	// Default to writing to standard out

--- a/v3/cmd/zlint/main.go
+++ b/v3/cmd/zlint/main.go
@@ -46,9 +46,12 @@ var ( // flags
 	excludeNames    string
 	includeSources  string
 	excludeSources  string
+	printVersion    bool
 
-	// version is replaced by GoReleaser using an LDFlags option at release time.
-	version = "dev"
+	// version is replaced by GoReleaser or `make` using an LDFlags option at
+	// build time. Here we supply a default value for folks that `go install` or
+	// `go build` directly from src.
+	version = "dev-unknown"
 )
 
 func init() {
@@ -62,6 +65,7 @@ func init() {
 	flag.StringVar(&excludeNames, "excludeNames", "", "Comma-separated list of lints to exclude by name")
 	flag.StringVar(&includeSources, "includeSources", "", "Comma-separated list of lint sources to include")
 	flag.StringVar(&excludeSources, "excludeSources", "", "Comma-separated list of lint sources to exclude")
+	flag.BoolVar(&printVersion, "version", false, "Print ZLint version and exit")
 
 	flag.BoolVar(&prettyprint, "pretty", false, "Pretty-print JSON output")
 	flag.Usage = func() {
@@ -74,6 +78,11 @@ func init() {
 }
 
 func main() {
+	if printVersion {
+		fmt.Printf("ZLint version %s\n", version)
+		return
+	}
+
 	// Build a registry of lints using the include/exclude lint name and source
 	// flags.
 	registry, err := setLints()

--- a/v3/makefile
+++ b/v3/makefile
@@ -10,9 +10,11 @@ PARALLELISM := 5
 #   make integration INT_FLAGS="-includeSources='Mozilla,ETSI_ESI' -config small.config.json"
 INT_FLAGS :=
 
+GIT_VERSION := "$(shell git describe --abbrev=8)"
+
 CMDS = zlint zlint-gtld-update
 CMD_PREFIX = ./cmd/
-BUILD = $(GO_ENV) go build
+BUILD = $(GO_ENV) go build --ldflags="-X 'main.version=$(GIT_VERSION)'"
 TEST = $(GO_ENV) GORACE=halt_on_error=1 go test -race
 INT_TEST = $(GO_ENV) go test -v -tags integration -timeout 20m ./integration/. -parallelism $(PARALLELISM) $(INT_FLAGS)
 


### PR DESCRIPTION
Our GoReleaser configuration already populates a `version` variable with `LDFLAGS` at build time. Prior to this commit we only included the dynamic version var in the usage output from `--help`. This made it easy to overlook. We also didn't set the dynamic var from the makefile, leaving all src builds as the static version "dev".

In this commit we add a `--version` flag to the `zlint` and `zlint-gtld-update` commands that prints the dynamic version andexits. We also update the `makefile` so that both binaries get built with a version that includes the latest tag, and the SHA of the local git checkout, e.g. `v3.1.0-19-g0807bf95`. This should better match user expectation for CLI tools.

Resolves #519.