### PR TITLE
Lint that the EKU values within a SubCA certificate comply with CABF_BR 7.1.2.2 letter g)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Here are some projects/CAs known to integrate with ZLint in some fashion:
 * [Nexus Certificate Manager](https://doc.nexusgroup.com/display/PUB/Smart+ID+Certificate+Manager)
 * [Siemens](https://siemens.com/pki)
 * [QuoVadis](https://www.quovadisglobal.com/)
+* [Actalis](https://www.actalis.it/en/home.aspx)
 
 Please submit a pull request to update the README if you are aware of
 another CA/project that uses zlint.

--- a/v3/lints/cabf_br/lint_sub_ca_eku_incompatible_values.go
+++ b/v3/lints/cabf_br/lint_sub_ca_eku_incompatible_values.go
@@ -1,0 +1,95 @@
+/*
+ * ZLint Copyright 2021 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * This lint contributed by Adriano Santoni <adriano.santoni@staff.aruba.it>
+ * of ACTALIS S.p.A. (an ARUBA company). Last revised June 30, 2021.
+ * 
+ * Checks that the EKU extension in a Subordinate CA certificate meets the 
+ * "MUST NOT" requirement set out in the BRs 7.1.2.2, letter g):
+ * 
+ *     For Subordinate CA Certificates that will be used to issue 
+ *     TLS certificates, the value id-kp-serverAuth[RFC5280] MUST be present. 
+ *     The value id-kp-clientAuth[RFC5280] MAY be present. 
+ *     The values id-kp-emailProtection[RFC5280], id-kp-codeSigning[RFC5280], 
+ *     id-kp-timeStamping[RFC5280], and anyExtendedKeyUsage[RFC5280] MUST NOT 
+ *     be present. Other values SHOULD NOT be present. 
+ *     For Subordinate CA Certificates that are not used to issue TLS certificates, 
+ *     then the value id-kp-serverAuth[RFC5280] MUST NOT be present. 
+ *     Other values MAY be present, but SHOULD NOT combine multiple independent usages 
+ *     (e.g.including id-kp-timeStamping[RFC5280] with id-kp-codeSigning[RFC5280]).
+ */
+
+package cabf_br
+
+import (
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+func init() {
+	lint.RegisterLint(&lint.Lint{
+		Name:          "e_sub_ca_eku_incompatible_values",
+		Description:   "Subordinate CA extkeyUsage: if serverAuth is present, then emailProtection, codeSigning, timeStamping, and anyExtendedKeyUsage MUST NOT be present.",
+		Citation:      "BRs: 7.1.2.2",
+		Source:        lint.CABFBaselineRequirements,
+		EffectiveDate: util.CABFBRs_1_7_1_Date,
+		Lint:          NewSubCAEkuIncompatibleValues,
+	})
+}
+
+type subCAEkuIncompatibleValues struct{}
+
+func NewSubCAEkuIncompatibleValues() lint.LintInterface {
+    return &subCAEkuIncompatibleValues{}
+}
+
+func (l *subCAEkuIncompatibleValues) CheckApplies(c *x509.Certificate) bool {
+	return util.IsSubCA(c) && util.IsExtInCert(c, util.EkuSynOid)
+}
+
+func (l *subCAEkuIncompatibleValues) Execute(c *x509.Certificate) *lint.LintResult {
+	
+	serverAuthPresent := false
+	emailProtectionPresent := false
+	codeSigningPresent := false
+	timeStampingPresent := false
+	anyEkuPresent := false
+	
+	for _, ekuValue := range c.ExtKeyUsage {
+		if ekuValue == x509.ExtKeyUsageServerAuth {
+			serverAuthPresent = true
+		}
+		if ekuValue == x509.ExtKeyUsageEmailProtection {
+			emailProtectionPresent = true
+		}
+		if ekuValue == x509.ExtKeyUsageCodeSigning {
+			codeSigningPresent = true
+		}
+		if ekuValue == x509.ExtKeyUsageTimeStamping {
+			timeStampingPresent = true
+		}
+		if ekuValue == x509.ExtKeyUsageAny {
+			anyEkuPresent = true
+		}
+	}
+	
+	if serverAuthPresent && (emailProtectionPresent || codeSigningPresent || timeStampingPresent || anyEkuPresent) {
+		return &lint.LintResult{Status: lint.Error}
+	} else {
+		return &lint.LintResult{Status: lint.Pass}
+	}
+}
+

--- a/v3/lints/cabf_br/lint_sub_ca_eku_incompatible_values_test.go
+++ b/v3/lints/cabf_br/lint_sub_ca_eku_incompatible_values_test.go
@@ -1,0 +1,68 @@
+package cabf_br
+
+/*
+ * ZLint Copyright 2021 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestSubCAEkuServerAndClient(t *testing.T) {
+	inputPath := "SubCAEkuServerAndClient.pem"
+	expected := lint.Pass
+	out := test.TestLint("e_sub_ca_eku_incompatible_values", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestSubCAEkuServerAndCode(t *testing.T) {
+	inputPath := "SubCAEkuServerAndCode.pem"
+	expected := lint.Error
+	out := test.TestLint("e_sub_ca_eku_incompatible_values", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestSubCAEkuServerAndTime(t *testing.T) {
+	inputPath := "SubCAEkuServerAndTime.pem"
+	expected := lint.Error
+	out := test.TestLint("e_sub_ca_eku_incompatible_values", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestSubCAEkuServerAndEmail(t *testing.T) {
+	inputPath := "SubCAEkuServerAndEmail.pem"
+	expected := lint.Error
+	out := test.TestLint("e_sub_ca_eku_incompatible_values", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestSubCAEkuServerAndAny(t *testing.T) {
+	inputPath := "SubCAEkuServerAndAny.pem"
+	expected := lint.Error
+	out := test.TestLint("e_sub_ca_eku_incompatible_values", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+

--- a/v3/testdata/SubCAEkuServerAndAny.pem
+++ b/v3/testdata/SubCAEkuServerAndAny.pem
@@ -1,0 +1,141 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            d2:59:43:66:12:74:4a:dc:98:f9:54:73:6e:68:01:23
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = IT, O = Some Company SpA, CN = Fake Root CA for zlint testing
+        Validity
+            Not Before: Jun 27 08:31:39 2021 GMT
+            Not After : Jun 27 18:31:39 2031 GMT
+        Subject: C = IT, O = Some Company SpA, CN = Fake Subordinate CA for zlint testing
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:d9:40:20:43:2c:bb:54:e7:eb:ae:8d:80:fd:0a:
+                    92:13:10:f6:85:01:4d:3d:1c:57:1a:88:b0:57:39:
+                    7b:d1:5d:ad:de:67:07:b1:fb:47:22:76:39:91:39:
+                    25:28:af:a5:b8:8a:53:ab:c1:77:19:e8:16:ea:90:
+                    62:0a:6f:25:86:70:eb:8c:ff:56:57:50:ae:a7:fb:
+                    2e:b2:df:96:f5:39:90:31:c7:8c:48:85:fe:8c:76:
+                    e0:05:35:e1:eb:45:30:89:8e:9c:e7:a6:df:ad:8f:
+                    4d:28:d4:5a:67:9e:f0:da:00:f7:61:51:93:84:67:
+                    b4:87:0e:c8:7a:45:c3:5d:f9:eb:33:b9:44:ba:54:
+                    10:5b:63:44:8f:39:10:1f:bd:86:27:46:73:3b:89:
+                    ec:c3:51:6f:40:44:9b:3b:c2:bb:61:6a:ba:bc:52:
+                    9d:95:97:72:a6:46:fd:8b:f0:d3:f1:c3:29:fd:2d:
+                    78:24:e8:d2:ba:c2:f9:65:0e:c0:05:30:17:f3:2b:
+                    ec:92:36:c9:d1:fd:1c:9c:7d:21:05:2d:18:21:30:
+                    af:e4:b5:d9:43:d1:1e:67:25:c3:08:db:44:78:f8:
+                    56:8d:8f:4d:17:dd:3c:82:59:16:b7:33:f5:7d:42:
+                    d5:8a:da:02:32:70:86:72:d7:34:00:b0:d3:a8:f2:
+                    da:6e:4b:f3:8d:9f:bb:90:22:39:72:32:6b:6d:89:
+                    6a:55:e2:4c:5d:1f:35:50:3f:3b:6f:7e:18:44:69:
+                    fd:1c:72:90:e1:90:79:0b:b9:b5:89:cb:a6:64:71:
+                    d6:07:d6:cf:11:ab:fc:5e:d2:92:14:f6:17:89:f0:
+                    9f:a0:62:ba:a4:bd:1a:3f:62:b3:75:0e:f3:52:81:
+                    d8:0e:de:14:80:92:a8:8d:7a:69:63:49:67:81:e6:
+                    d1:14:bb:b6:c2:5d:6b:a3:c4:64:ba:df:cf:71:3b:
+                    9a:7a:f3:c6:35:c5:97:03:d0:49:43:62:c7:8f:12:
+                    e3:d6:a5:71:a8:3b:83:e1:f8:9c:47:6b:e6:bf:ab:
+                    0a:1a:79:19:38:c4:4a:d8:f8:41:33:9b:b0:ca:93:
+                    1f:e1:0f:d2:95:b1:a5:95:3b:dc:46:48:22:16:8f:
+                    44:9b:7a:2b:c7:7e:a9:d5:ac:82:98:e9:d1:ad:60:
+                    09:10:26:bd:14:b9:62:29:5c:7f:19:6b:13:5e:3f:
+                    70:7e:81:36:5f:e3:fc:f6:3e:fa:9c:42:23:fd:4c:
+                    c6:0a:4a:09:02:68:e1:a6:63:0d:1d:35:20:25:b5:
+                    14:8b:48:c7:c6:77:51:cf:34:30:1f:6d:06:da:09:
+                    09:94:8b:6c:cd:e5:2f:be:b7:20:cd:ac:58:e6:11:
+                    da:83:13
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Extended Key Usage: 
+                Any Extended Key Usage, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier: 
+                09:50:65:28:3C:2A:B1:F0:0D:69:78:58:48:4A:40:39:B6:C2:FB:53
+            X509v3 Authority Key Identifier: 
+                keyid:E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+
+            Authority Information Access: 
+                OCSP - URI:http://ca.somecompany.it/ocsp
+                CA Issuers - URI:http://ca.somecompany.it/root
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3
+
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://ca.somecompany.it/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+         00:5d:61:32:99:58:59:7f:2b:35:74:f3:82:cd:29:fe:da:7b:
+         43:9f:8f:09:08:f4:40:c9:73:bf:3b:8d:e1:bb:be:15:35:ed:
+         f4:6a:6c:70:35:06:f4:4c:a5:7d:23:54:23:c7:d3:99:41:58:
+         b8:52:53:6c:24:8c:e7:ba:ab:33:34:09:b9:94:8a:1f:db:84:
+         ea:f8:d0:bb:ab:0e:ef:8c:78:84:d5:f4:83:72:7f:cb:77:3b:
+         22:83:94:1b:51:2b:4d:7d:68:39:47:35:e8:02:0a:1f:1b:7c:
+         0f:11:89:e9:7e:fe:91:77:3b:18:67:a1:7d:d1:3e:c1:1b:98:
+         4f:2c:ad:8a:f9:8c:c6:14:83:b6:47:91:d5:37:d2:55:69:7c:
+         53:d3:a6:37:7b:99:6b:38:b0:29:51:d3:75:d2:b2:20:3c:b1:
+         8c:92:62:64:8d:59:36:22:f5:d0:ab:a4:47:72:e2:d2:e0:bb:
+         81:19:02:58:78:78:17:01:c7:fe:c2:a0:29:96:b9:e1:ba:99:
+         9a:47:1d:59:ec:e6:15:fa:86:39:39:54:56:33:81:39:5a:2f:
+         36:19:38:4f:b5:14:fd:85:70:11:9f:57:9f:b0:e4:9d:ac:3f:
+         03:1b:b2:ac:53:9c:1d:94:44:b8:e3:b8:46:9e:4d:d3:e9:6f:
+         ec:75:88:cf:ab:1a:20:57:a2:d5:48:a0:3d:83:19:ae:c4:40:
+         1a:f0:52:f9:78:43:48:6f:82:ce:4f:63:50:17:64:a0:b2:17:
+         4a:f7:b9:7a:fd:76:e5:cf:0b:45:78:92:d8:c8:ee:3b:23:ed:
+         32:03:cf:9f:a8:67:1b:8b:87:c8:33:a3:c9:18:8c:a9:3a:41:
+         7a:79:b4:a9:23:48:04:1e:99:c2:8f:0f:64:b1:d6:85:3c:20:
+         9a:a1:7f:db:f1:97:db:15:01:42:cb:e0:57:f0:b1:6a:7d:8c:
+         a5:0c:ba:59:ef:9b:bb:de:3d:e7:9b:5b:3b:d5:c3:bd:0b:ed:
+         55:56:93:4f:d0:57:4c:91:4a:36:a9:36:95:2c:11:16:23:01:
+         62:de:0a:ba:5b:4f:12:03:f7:26:b5:46:0d:e0:28:8d:22:b6:
+         40:f4:ea:7e:43:07:10:1e:b5:76:b5:7c:ca:79:63:e9:68:e1:
+         8b:49:52:2a:18:99:90:dd:c6:c3:24:21:d6:bb:26:ba:b8:4a:
+         b8:0f:36:b0:65:fe:63:10:5f:5d:76:f8:bd:d6:2c:d9:6f:b5:
+         9b:f0:4b:e3:cf:cf:67:73:07:f2:c1:92:76:a3:62:95:8b:d1:
+         61:b6:6b:8a:33:0a:2e:fb:f0:94:e3:89:4a:eb:f7:c5:8b:02:
+         2b:7e:67:f8:c1:84:92:47
+-----BEGIN CERTIFICATE-----
+MIIGXDCCBESgAwIBAgIRANJZQ2YSdErcmPlUc25oASMwDQYJKoZIhvcNAQELBQAw
+UTELMAkGA1UEBhMCSVQxGTAXBgNVBAoTEFNvbWUgQ29tcGFueSBTcEExJzAlBgNV
+BAMTHkZha2UgUm9vdCBDQSBmb3IgemxpbnQgdGVzdGluZzAeFw0yMTA2MjcwODMx
+MzlaFw0zMTA2MjcxODMxMzlaMFgxCzAJBgNVBAYTAklUMRkwFwYDVQQKExBTb21l
+IENvbXBhbnkgU3BBMS4wLAYDVQQDEyVGYWtlIFN1Ym9yZGluYXRlIENBIGZvciB6
+bGludCB0ZXN0aW5nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA2UAg
+Qyy7VOfrro2A/QqSExD2hQFNPRxXGoiwVzl70V2t3mcHsftHInY5kTklKK+luIpT
+q8F3GegW6pBiCm8lhnDrjP9WV1Cup/sust+W9TmQMceMSIX+jHbgBTXh60UwiY6c
+56bfrY9NKNRaZ57w2gD3YVGThGe0hw7IekXDXfnrM7lEulQQW2NEjzkQH72GJ0Zz
+O4nsw1FvQESbO8K7YWq6vFKdlZdypkb9i/DT8cMp/S14JOjSusL5ZQ7ABTAX8yvs
+kjbJ0f0cnH0hBS0YITCv5LXZQ9EeZyXDCNtEePhWjY9NF908glkWtzP1fULVitoC
+MnCGctc0ALDTqPLabkvzjZ+7kCI5cjJrbYlqVeJMXR81UD87b34YRGn9HHKQ4ZB5
+C7m1icumZHHWB9bPEav8XtKSFPYXifCfoGK6pL0aP2KzdQ7zUoHYDt4UgJKojXpp
+Y0lngebRFLu2wl1ro8Rkut/PcTuaevPGNcWXA9BJQ2LHjxLj1qVxqDuD4ficR2vm
+v6sKGnkZOMRK2PhBM5uwypMf4Q/SlbGllTvcRkgiFo9Em3orx36p1ayCmOnRrWAJ
+ECa9FLliKVx/GWsTXj9wfoE2X+P89j76nEIj/UzGCkoJAmjhpmMNHTUgJbUUi0jH
+xndRzzQwH20G2gkJlItszeUvvrcgzaxY5hHagxMCAwEAAaOCASYwggEiMA4GA1Ud
+DwEB/wQEAwIBBjAZBgNVHSUEEjAQBgRVHSUABggrBgEFBQcDATAPBgNVHRMBAf8E
+BTADAQH/MB0GA1UdDgQWBBQJUGUoPCqx8A1peFhISkA5tsL7UzAfBgNVHSMEGDAW
+gBTotvZ2S9A75Ual+VTUfgez3g1gPjBkBggrBgEFBQcBAQRYMFYwKQYIKwYBBQUH
+MAGGHWh0dHA6Ly9jYS5zb21lY29tcGFueS5pdC9vY3NwMCkGCCsGAQUFBzAChh1o
+dHRwOi8vY2Euc29tZWNvbXBhbnkuaXQvcm9vdDAPBgNVHSAECDAGMAQGAioDMC0G
+A1UdHwQmMCQwIqAgoB6GHGh0dHA6Ly9jYS5zb21lY29tcGFueS5pdC9jcmwwDQYJ
+KoZIhvcNAQELBQADggIBAABdYTKZWFl/KzV084LNKf7ae0OfjwkI9EDJc787jeG7
+vhU17fRqbHA1BvRMpX0jVCPH05lBWLhSU2wkjOe6qzM0CbmUih/bhOr40LurDu+M
+eITV9INyf8t3OyKDlBtRK019aDlHNegCCh8bfA8Riel+/pF3OxhnoX3RPsEbmE8s
+rYr5jMYUg7ZHkdU30lVpfFPTpjd7mWs4sClR03XSsiA8sYySYmSNWTYi9dCrpEdy
+4tLgu4EZAlh4eBcBx/7CoCmWueG6mZpHHVns5hX6hjk5VFYzgTlaLzYZOE+1FP2F
+cBGfV5+w5J2sPwMbsqxTnB2URLjjuEaeTdPpb+x1iM+rGiBXotVIoD2DGa7EQBrw
+Uvl4Q0hvgs5PY1AXZKCyF0r3uXr9duXPC0V4ktjI7jsj7TIDz5+oZxuLh8gzo8kY
+jKk6QXp5tKkjSAQemcKPD2Sx1oU8IJqhf9vxl9sVAULL4FfwsWp9jKUMulnvm7ve
+PeebWzvVw70L7VVWk0/QV0yRSjapNpUsERYjAWLeCrpbTxID9ya1Rg3gKI0itkD0
+6n5DBxAetXa1fMp5Y+lo4YtJUioYmZDdxsMkIda7Jrq4SrgPNrBl/mMQX112+L3W
+LNlvtZvwS+PPz2dzB/LBknajYpWL0WG2a4ozCi778JTjiUrr98WLAit+Z/jBhJJH
+-----END CERTIFICATE-----

--- a/v3/testdata/SubCAEkuServerAndClient.pem
+++ b/v3/testdata/SubCAEkuServerAndClient.pem
@@ -1,0 +1,142 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            c9:65:19:db:ab:fc:09:5a:15:50:0a:bf:eb:17:0f:e4
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = IT, O = Some Company SpA, CN = Fake Root CA for zlint testing
+        Validity
+            Not Before: Jun 26 14:45:50 2021 GMT
+            Not After : Jun 27 00:45:50 2031 GMT
+        Subject: C = IT, O = Some Company SpA, CN = Fake Subordinate CA for zlint testing
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:d4:a7:59:08:56:b8:9d:03:ac:01:b0:ca:66:dd:
+                    59:21:bb:d9:21:88:33:12:72:79:9f:85:2c:45:39:
+                    eb:d9:ca:54:98:1d:4b:65:38:ac:d2:f7:7d:d6:ad:
+                    a6:58:2d:52:6b:de:14:f7:97:76:93:07:30:c6:bc:
+                    37:1b:02:db:77:48:d2:36:fb:44:8a:3b:7b:94:2d:
+                    ac:cd:ba:53:a3:5d:c5:e6:67:a1:8d:b3:71:77:8d:
+                    c5:71:5e:f1:77:16:cd:5e:56:97:fe:db:63:d3:87:
+                    1a:e7:fa:3b:78:10:a1:03:e3:81:63:fb:da:81:d4:
+                    cb:3e:0b:c0:15:3d:9f:75:a4:b1:aa:23:71:45:02:
+                    12:d0:f4:d0:24:4e:4e:66:06:13:6e:ac:b1:53:db:
+                    8a:73:53:b1:41:2e:59:97:2c:0a:1e:91:92:7a:28:
+                    d4:ac:9a:4a:ab:4c:84:e3:67:03:fc:6f:63:05:27:
+                    73:f9:52:f4:d4:d5:4c:18:03:44:9a:db:a3:c1:56:
+                    33:e5:86:87:a0:0f:b1:89:56:52:33:b8:5d:60:f2:
+                    31:e4:58:43:37:68:46:07:61:85:90:cf:b2:df:27:
+                    2c:1d:81:b5:b4:03:21:b2:f1:8a:7c:7e:39:49:99:
+                    a8:94:6c:bf:2f:06:23:23:6a:00:72:76:72:fd:b9:
+                    1a:7b:a4:f8:66:48:cb:6e:42:3d:d1:91:a2:95:f7:
+                    33:c6:1d:3b:8a:c9:ce:a5:a0:22:3f:81:12:b5:9e:
+                    c3:54:95:ec:37:ff:1e:fc:16:2e:a9:14:0d:8f:5d:
+                    43:e9:ed:9e:b1:c6:62:62:cb:b9:a2:2b:de:82:23:
+                    d8:9f:f6:21:0e:a1:1a:01:e5:87:7a:f8:5f:8c:9a:
+                    59:0d:30:fe:47:e4:19:f3:0a:97:1a:cb:d6:14:39:
+                    57:ee:94:bd:13:4e:84:27:dc:ea:3f:77:59:0a:ff:
+                    66:6c:f0:d8:af:ad:1c:0a:5b:90:47:89:0d:a8:5a:
+                    75:98:c5:65:62:e8:34:e3:a6:15:0c:63:28:68:00:
+                    07:63:56:3b:77:50:65:9f:6b:6b:44:b8:85:71:0d:
+                    42:43:ee:b3:60:ea:02:5d:1e:8c:bd:96:16:37:14:
+                    bd:9a:19:eb:52:01:b9:3a:24:87:37:36:19:bd:04:
+                    81:c8:6f:83:ce:e2:08:27:d2:31:e0:de:9e:2c:38:
+                    7e:db:a3:94:1c:43:f8:1c:92:6e:4e:f1:46:79:d2:
+                    e0:91:68:90:df:0a:6d:e2:16:7c:b9:41:74:69:f4:
+                    db:16:b2:64:d0:02:73:37:96:d0:26:94:3e:e9:83:
+                    f2:99:a2:e9:e4:2d:71:97:87:75:57:cf:65:49:1d:
+                    42:ba:1d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier: 
+                53:1F:59:72:9F:D7:28:9E:05:0F:B9:6C:4A:C0:CF:6F:9E:1F:DF:E1
+            X509v3 Authority Key Identifier: 
+                keyid:E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+
+            Authority Information Access: 
+                OCSP - URI:http://ca.somecompany.it/ocsp
+                CA Issuers - URI:http://ca.somecompany.it/root
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3
+
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://ca.somecompany.it/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+         c1:b9:a0:b0:c0:15:1d:d9:50:e7:e8:4e:1c:fc:b2:95:43:0c:
+         ed:e6:d1:0d:b7:87:07:fe:ee:5b:8b:f4:4d:4b:2a:c5:06:a7:
+         9f:5c:35:46:6f:09:2a:aa:6c:86:ea:09:47:8b:d2:77:21:24:
+         cc:ae:db:3b:05:fb:ef:3c:a0:70:5d:a4:2d:9d:fd:92:f6:ce:
+         40:1e:df:82:48:db:35:92:d9:ca:79:e4:c1:4d:63:cf:8b:7b:
+         21:30:ca:19:7a:d3:47:4b:1b:49:a2:f8:7f:04:a5:19:2c:0a:
+         f6:5a:68:c7:59:bf:b4:5c:b9:e8:bb:94:77:2b:be:f5:67:d1:
+         c9:17:82:4b:af:e4:89:b6:92:58:1c:12:f6:8a:b5:0d:1a:2f:
+         2b:34:c8:9b:5e:a0:ab:49:b2:4f:48:85:0e:ea:8e:2c:af:02:
+         c8:24:b3:5b:fa:c8:5f:24:d1:e9:99:eb:d3:12:cd:87:ee:c8:
+         6a:e6:ce:2b:2a:f2:0a:e6:8e:29:4c:84:db:55:24:67:d6:a5:
+         b5:eb:10:a1:50:ac:ac:39:74:94:1d:7d:92:01:55:b7:c7:86:
+         f4:86:5c:52:23:35:6b:4f:b1:35:27:cd:13:0f:95:d7:f2:04:
+         1d:f8:7c:3a:b0:15:e8:66:d7:09:34:47:72:3e:4b:9f:93:78:
+         47:39:dc:e4:31:0f:5e:36:a3:92:3c:c3:fd:68:35:32:92:90:
+         ec:7c:e9:63:d8:ce:eb:1f:cb:50:16:cd:79:a9:63:07:be:11:
+         f3:ad:bf:61:56:5d:cb:97:95:f0:c7:c1:1c:c9:de:b4:cc:8b:
+         29:88:12:bb:22:86:cd:1a:54:da:d3:36:f3:24:6e:43:ba:48:
+         9c:06:11:57:46:3a:33:27:fb:07:db:df:68:21:02:81:fa:3a:
+         d3:58:02:ed:ec:c0:f3:e9:90:7a:46:a6:de:b1:0c:38:5a:bf:
+         86:71:a1:eb:84:dd:65:f5:a5:2f:f6:ba:b4:d6:73:a1:0a:b1:
+         7f:77:e6:f4:79:eb:5d:3c:fa:b4:34:bf:ec:5a:90:09:10:e5:
+         72:cc:f5:df:db:6b:f1:f7:54:e5:75:e2:a6:d0:ff:db:31:f3:
+         5e:24:e6:38:45:ad:5d:b7:86:a5:15:58:a3:1a:84:19:e5:94:
+         35:a3:16:3d:6d:3c:a3:05:96:1b:9b:0f:c7:1c:cc:16:f0:e0:
+         32:33:b7:a9:6d:e4:7d:05:2b:e6:e2:e9:81:cb:9f:05:b0:66:
+         f9:ad:04:7f:8b:26:fc:5b:45:db:92:3c:04:3f:7e:48:55:a5:
+         53:06:c0:19:ad:05:b0:8e:5f:ca:29:9f:74:f5:ad:4d:59:f3:
+         2f:f7:03:d5:d1:04:9a:61
+-----BEGIN CERTIFICATE-----
+MIIGYDCCBEigAwIBAgIRAMllGdur/AlaFVAKv+sXD+QwDQYJKoZIhvcNAQELBQAw
+UTELMAkGA1UEBhMCSVQxGTAXBgNVBAoTEFNvbWUgQ29tcGFueSBTcEExJzAlBgNV
+BAMTHkZha2UgUm9vdCBDQSBmb3IgemxpbnQgdGVzdGluZzAeFw0yMTA2MjYxNDQ1
+NTBaFw0zMTA2MjcwMDQ1NTBaMFgxCzAJBgNVBAYTAklUMRkwFwYDVQQKExBTb21l
+IENvbXBhbnkgU3BBMS4wLAYDVQQDEyVGYWtlIFN1Ym9yZGluYXRlIENBIGZvciB6
+bGludCB0ZXN0aW5nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA1KdZ
+CFa4nQOsAbDKZt1ZIbvZIYgzEnJ5n4UsRTnr2cpUmB1LZTis0vd91q2mWC1Sa94U
+95d2kwcwxrw3GwLbd0jSNvtEijt7lC2szbpTo13F5mehjbNxd43FcV7xdxbNXlaX
+/ttj04ca5/o7eBChA+OBY/vagdTLPgvAFT2fdaSxqiNxRQIS0PTQJE5OZgYTbqyx
+U9uKc1OxQS5ZlywKHpGSeijUrJpKq0yE42cD/G9jBSdz+VL01NVMGANEmtujwVYz
+5YaHoA+xiVZSM7hdYPIx5FhDN2hGB2GFkM+y3ycsHYG1tAMhsvGKfH45SZmolGy/
+LwYjI2oAcnZy/bkae6T4ZkjLbkI90ZGilfczxh07isnOpaAiP4EStZ7DVJXsN/8e
+/BYuqRQNj11D6e2escZiYsu5oivegiPYn/YhDqEaAeWHevhfjJpZDTD+R+QZ8wqX
+GsvWFDlX7pS9E06EJ9zqP3dZCv9mbPDYr60cCluQR4kNqFp1mMVlYug046YVDGMo
+aAAHY1Y7d1Bln2trRLiFcQ1CQ+6zYOoCXR6MvZYWNxS9mhnrUgG5OiSHNzYZvQSB
+yG+DzuIIJ9Ix4N6eLDh+26OUHEP4HJJuTvFGedLgkWiQ3wpt4hZ8uUF0afTbFrJk
+0AJzN5bQJpQ+6YPymaLp5C1xl4d1V89lSR1Cuh0CAwEAAaOCASowggEmMA4GA1Ud
+DwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDwYDVR0T
+AQH/BAUwAwEB/zAdBgNVHQ4EFgQUUx9Zcp/XKJ4FD7lsSsDPb54f3+EwHwYDVR0j
+BBgwFoAU6Lb2dkvQO+VGpflU1H4Hs94NYD4wZAYIKwYBBQUHAQEEWDBWMCkGCCsG
+AQUFBzABhh1odHRwOi8vY2Euc29tZWNvbXBhbnkuaXQvb2NzcDApBggrBgEFBQcw
+AoYdaHR0cDovL2NhLnNvbWVjb21wYW55Lml0L3Jvb3QwDwYDVR0gBAgwBjAEBgIq
+AzAtBgNVHR8EJjAkMCKgIKAehhxodHRwOi8vY2Euc29tZWNvbXBhbnkuaXQvY3Js
+MA0GCSqGSIb3DQEBCwUAA4ICAQDBuaCwwBUd2VDn6E4c/LKVQwzt5tENt4cH/u5b
+i/RNSyrFBqefXDVGbwkqqmyG6glHi9J3ISTMrts7BfvvPKBwXaQtnf2S9s5AHt+C
+SNs1ktnKeeTBTWPPi3shMMoZetNHSxtJovh/BKUZLAr2WmjHWb+0XLnou5R3K771
+Z9HJF4JLr+SJtpJYHBL2irUNGi8rNMibXqCrSbJPSIUO6o4srwLIJLNb+shfJNHp
+mevTEs2H7shq5s4rKvIK5o4pTITbVSRn1qW16xChUKysOXSUHX2SAVW3x4b0hlxS
+IzVrT7E1J80TD5XX8gQd+Hw6sBXoZtcJNEdyPkufk3hHOdzkMQ9eNqOSPMP9aDUy
+kpDsfOlj2M7rH8tQFs15qWMHvhHzrb9hVl3Ll5Xwx8Ecyd60zIspiBK7IobNGlTa
+0zbzJG5DukicBhFXRjozJ/sH299oIQKB+jrTWALt7MDz6ZB6RqbesQw4Wr+GcaHr
+hN1l9aUv9rq01nOhCrF/d+b0eetdPPq0NL/sWpAJEOVyzPXf22vx91TldeKm0P/b
+MfNeJOY4Ra1dt4alFVijGoQZ5ZQ1oxY9bTyjBZYbmw/HHMwW8OAyM7epbeR9BSvm
+4umBy58FsGb5rQR/iyb8W0XbkjwEP35IVaVTBsAZrQWwjl/KKZ909a1NWfMv9wPV
+0QSaYQ==
+-----END CERTIFICATE-----

--- a/v3/testdata/SubCAEkuServerAndCode.pem
+++ b/v3/testdata/SubCAEkuServerAndCode.pem
@@ -1,0 +1,142 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            4d:57:43:61:a1:0d:02:9e:3e:7f:1d:94:91:f7:d6:e9
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = IT, O = Some Company SpA, CN = Fake Root CA for zlint testing
+        Validity
+            Not Before: Jun 26 14:52:50 2021 GMT
+            Not After : Jun 27 00:52:50 2031 GMT
+        Subject: C = IT, O = Some Company SpA, CN = Fake Subordinate CA for zlint testing
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:d4:20:0d:03:a3:9f:78:10:d5:27:90:a1:7c:24:
+                    12:a7:14:eb:2f:f9:5e:43:73:89:a9:b1:cd:94:00:
+                    9a:ab:6e:f2:b8:a3:b1:12:9b:37:f7:6b:b0:81:e8:
+                    49:52:ff:ac:f6:f8:72:75:38:35:84:26:27:eb:f5:
+                    e0:58:9d:47:36:c6:2f:2c:84:f8:2a:63:f2:82:5f:
+                    59:fc:88:05:03:08:46:bd:f6:fd:3d:17:84:b6:d3:
+                    20:9d:34:67:f1:3e:93:f8:e1:59:16:d2:29:80:11:
+                    d3:ac:94:e8:c2:60:06:9b:45:ba:6f:9a:20:79:21:
+                    a6:47:14:c3:44:a4:56:a3:3a:3a:82:5b:65:b9:87:
+                    2c:7a:3b:ea:1c:b4:e8:22:a3:0b:0d:60:f2:ef:dc:
+                    86:73:6f:60:f3:4e:c3:ee:48:4d:ab:0a:06:cc:e2:
+                    ca:04:58:02:2f:c0:60:c5:46:1a:9d:6c:95:1b:1b:
+                    4a:96:90:75:07:8a:36:58:ca:73:36:72:a9:94:f7:
+                    00:07:dd:73:c1:09:95:20:92:c7:2e:04:a8:dd:9f:
+                    44:34:97:4a:b9:c8:f3:af:96:de:e7:5b:e8:35:1e:
+                    cc:d0:89:17:fa:91:b0:a5:3b:39:cd:e2:ad:ae:6f:
+                    7f:2b:10:af:f6:a5:a6:bd:50:cd:60:82:aa:23:3b:
+                    8d:58:72:5f:27:fb:d5:0e:9d:05:8c:65:15:41:4e:
+                    23:94:91:ee:f1:80:8c:37:e5:4a:bc:b3:d3:32:d3:
+                    be:eb:2e:c4:51:f2:9a:8f:eb:72:0d:53:ed:c0:f1:
+                    bf:a6:d9:54:cc:14:4b:4c:76:04:71:fa:d2:a5:bb:
+                    0c:06:69:78:e4:44:fe:c2:c6:40:2a:64:d3:ab:a1:
+                    4b:29:44:02:bd:cc:2b:fd:2f:b6:f3:b3:a5:54:77:
+                    67:c3:2b:e2:7b:92:8a:47:b7:bd:a3:2a:9d:82:5a:
+                    9d:46:8d:d6:30:5f:c4:be:f6:2b:05:b5:82:a0:80:
+                    7a:9a:5f:09:7b:ef:d0:52:7c:38:3a:d7:3c:2d:5b:
+                    67:c1:1e:65:8c:33:70:38:75:b6:0a:c9:59:ba:9d:
+                    a5:8e:54:e9:ba:1c:9e:77:43:4e:d4:82:a7:38:14:
+                    28:af:e2:30:80:10:f6:af:27:31:13:87:f8:7b:e3:
+                    a3:7e:aa:9c:75:40:24:47:ac:64:a0:02:b5:c1:4a:
+                    1f:65:88:25:9b:3e:93:95:23:4c:93:76:a8:51:93:
+                    24:36:b2:52:4b:34:b9:2b:fd:1a:d6:88:6f:c5:25:
+                    4d:78:c3:78:ac:8a:c6:1c:1a:1f:be:b9:92:ee:f7:
+                    e6:04:2e:b9:d5:c1:e0:44:dd:ea:8b:ce:5b:d0:22:
+                    b9:22:a3
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Extended Key Usage: 
+                Code Signing, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier: 
+                05:AA:4C:14:D6:1C:42:21:A6:8A:D9:43:E8:17:2A:E3:A9:3F:A9:A4
+            X509v3 Authority Key Identifier: 
+                keyid:E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+
+            Authority Information Access: 
+                OCSP - URI:http://ca.somecompany.it/ocsp
+                CA Issuers - URI:http://ca.somecompany.it/root
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3
+
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://ca.somecompany.it/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+         3d:10:34:47:19:6e:b0:d6:ac:ce:3a:fb:df:35:2e:60:d6:d8:
+         0b:c2:bb:17:49:3c:92:23:af:98:d6:69:ec:fc:c0:ee:58:91:
+         4d:08:c6:ed:d0:20:f2:23:d6:e3:dc:62:11:38:83:48:0b:c7:
+         c5:7f:3b:58:f6:f6:e7:8b:b7:a6:67:e5:a7:c2:44:e1:0d:56:
+         b1:ff:94:0e:90:4c:5a:21:35:f8:74:9e:5d:0e:08:00:43:a6:
+         17:f7:a0:e7:04:3d:f7:25:20:f9:cf:07:4a:87:1d:46:0a:8c:
+         66:1a:3e:88:f6:bb:f3:68:a8:de:76:50:d8:79:e9:3d:32:89:
+         fb:c8:fa:4c:5c:4c:c3:c5:6c:47:76:54:45:1c:93:5d:26:79:
+         ee:95:af:9a:8e:26:8e:e3:4b:6f:5a:2b:12:96:84:4f:a7:06:
+         25:65:1e:4f:97:60:17:fa:b1:32:8a:3c:94:d9:e4:29:6c:85:
+         94:82:33:48:10:b3:b5:80:c6:2c:3d:f3:86:c5:fc:74:62:3c:
+         d0:c9:1e:5d:a2:55:2a:70:5c:de:15:f4:79:86:dd:be:35:9b:
+         61:92:53:a6:53:23:37:23:ea:83:93:f3:20:e2:f3:3c:93:83:
+         c4:3a:69:bb:0f:12:11:6f:38:36:52:3c:3b:dc:3d:94:f3:66:
+         79:af:01:60:4d:81:64:31:78:e9:89:f1:75:15:29:23:f4:a2:
+         cf:64:63:68:12:00:99:d0:ac:16:ea:8e:ca:4a:57:1f:ae:1e:
+         a0:6f:aa:ed:6a:60:68:9e:6a:3c:8f:5b:3e:6a:0e:78:28:2b:
+         b9:b6:cb:13:59:db:47:6f:26:10:4a:f1:46:1a:84:ca:89:40:
+         c1:1d:1e:ac:4f:99:c6:0a:58:b9:8a:a0:d2:7a:2e:0f:0d:e4:
+         ed:ea:b1:bd:50:53:d3:7a:de:9a:5e:31:d7:0c:f8:28:0b:18:
+         93:59:15:ed:63:f4:01:dd:87:7c:a7:f0:c9:ef:33:d4:d4:2a:
+         90:a1:79:74:c9:3f:9b:54:fc:60:9d:16:b9:e4:7b:79:9a:9d:
+         d3:e6:cb:48:c0:17:e2:8e:84:5d:79:38:e2:10:6e:fc:26:21:
+         94:f3:47:26:05:fa:46:3a:a2:67:5b:29:a4:3e:2c:c4:02:b2:
+         4a:73:43:85:c9:03:5b:44:27:c7:5a:4d:5c:e3:44:8a:f6:0a:
+         7d:8d:b8:f3:65:88:e3:63:c6:30:6d:34:c9:6a:7d:3c:88:8d:
+         4c:7f:d4:d1:a7:15:16:28:3e:79:36:eb:82:19:44:a0:e6:b1:
+         04:be:8d:73:6d:8e:d1:5b:42:59:e1:ca:48:9d:c4:8e:0f:77:
+         db:aa:44:dd:c7:52:76:12
+-----BEGIN CERTIFICATE-----
+MIIGXzCCBEegAwIBAgIQTVdDYaENAp4+fx2UkffW6TANBgkqhkiG9w0BAQsFADBR
+MQswCQYDVQQGEwJJVDEZMBcGA1UEChMQU29tZSBDb21wYW55IFNwQTEnMCUGA1UE
+AxMeRmFrZSBSb290IENBIGZvciB6bGludCB0ZXN0aW5nMB4XDTIxMDYyNjE0NTI1
+MFoXDTMxMDYyNzAwNTI1MFowWDELMAkGA1UEBhMCSVQxGTAXBgNVBAoTEFNvbWUg
+Q29tcGFueSBTcEExLjAsBgNVBAMTJUZha2UgU3Vib3JkaW5hdGUgQ0EgZm9yIHps
+aW50IHRlc3RpbmcwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDUIA0D
+o594ENUnkKF8JBKnFOsv+V5Dc4mpsc2UAJqrbvK4o7ESmzf3a7CB6ElS/6z2+HJ1
+ODWEJifr9eBYnUc2xi8shPgqY/KCX1n8iAUDCEa99v09F4S20yCdNGfxPpP44VkW
+0imAEdOslOjCYAabRbpvmiB5IaZHFMNEpFajOjqCW2W5hyx6O+octOgiowsNYPLv
+3IZzb2DzTsPuSE2rCgbM4soEWAIvwGDFRhqdbJUbG0qWkHUHijZYynM2cqmU9wAH
+3XPBCZUgkscuBKjdn0Q0l0q5yPOvlt7nW+g1HszQiRf6kbClOznN4q2ub38rEK/2
+paa9UM1ggqojO41Ycl8n+9UOnQWMZRVBTiOUke7xgIw35Uq8s9My077rLsRR8pqP
+63INU+3A8b+m2VTMFEtMdgRx+tKluwwGaXjkRP7CxkAqZNOroUspRAK9zCv9L7bz
+s6VUd2fDK+J7kopHt72jKp2CWp1GjdYwX8S+9isFtYKggHqaXwl779BSfDg61zwt
+W2fBHmWMM3A4dbYKyVm6naWOVOm6HJ53Q07Ugqc4FCiv4jCAEPavJzETh/h746N+
+qpx1QCRHrGSgArXBSh9liCWbPpOVI0yTdqhRkyQ2slJLNLkr/RrWiG/FJU14w3is
+isYcGh++uZLu9+YELrnVweBE3eqLzlvQIrkiowIDAQABo4IBKjCCASYwDgYDVR0P
+AQH/BAQDAgEGMB0GA1UdJQQWMBQGCCsGAQUFBwMDBggrBgEFBQcDATAPBgNVHRMB
+Af8EBTADAQH/MB0GA1UdDgQWBBQFqkwU1hxCIaaK2UPoFyrjqT+ppDAfBgNVHSME
+GDAWgBTotvZ2S9A75Ual+VTUfgez3g1gPjBkBggrBgEFBQcBAQRYMFYwKQYIKwYB
+BQUHMAGGHWh0dHA6Ly9jYS5zb21lY29tcGFueS5pdC9vY3NwMCkGCCsGAQUFBzAC
+hh1odHRwOi8vY2Euc29tZWNvbXBhbnkuaXQvcm9vdDAPBgNVHSAECDAGMAQGAioD
+MC0GA1UdHwQmMCQwIqAgoB6GHGh0dHA6Ly9jYS5zb21lY29tcGFueS5pdC9jcmww
+DQYJKoZIhvcNAQELBQADggIBAD0QNEcZbrDWrM46+981LmDW2AvCuxdJPJIjr5jW
+aez8wO5YkU0Ixu3QIPIj1uPcYhE4g0gLx8V/O1j29ueLt6Zn5afCROENVrH/lA6Q
+TFohNfh0nl0OCABDphf3oOcEPfclIPnPB0qHHUYKjGYaPoj2u/NoqN52UNh56T0y
+ifvI+kxcTMPFbEd2VEUck10mee6Vr5qOJo7jS29aKxKWhE+nBiVlHk+XYBf6sTKK
+PJTZ5ClshZSCM0gQs7WAxiw984bF/HRiPNDJHl2iVSpwXN4V9HmG3b41m2GSU6ZT
+Izcj6oOT8yDi8zyTg8Q6absPEhFvODZSPDvcPZTzZnmvAWBNgWQxeOmJ8XUVKSP0
+os9kY2gSAJnQrBbqjspKVx+uHqBvqu1qYGieajyPWz5qDngoK7m2yxNZ20dvJhBK
+8UYahMqJQMEdHqxPmcYKWLmKoNJ6Lg8N5O3qsb1QU9N63ppeMdcM+CgLGJNZFe1j
+9AHdh3yn8MnvM9TUKpCheXTJP5tU/GCdFrnke3mandPmy0jAF+KOhF15OOIQbvwm
+IZTzRyYF+kY6omdbKaQ+LMQCskpzQ4XJA1tEJ8daTVzjRIr2Cn2NuPNliONjxjBt
+NMlqfTyIjUx/1NGnFRYoPnk264IZRKDmsQS+jXNtjtFbQlnhykidxI4Pd9uqRN3H
+UnYS
+-----END CERTIFICATE-----

--- a/v3/testdata/SubCAEkuServerAndEmail.pem
+++ b/v3/testdata/SubCAEkuServerAndEmail.pem
@@ -1,0 +1,142 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            e4:de:40:b7:32:5b:8c:a2:7a:78:2c:46:43:b5:1d:9b
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = IT, O = Some Company SpA, CN = Fake Root CA for zlint testing
+        Validity
+            Not Before: Jun 26 14:51:05 2021 GMT
+            Not After : Jun 27 00:51:05 2031 GMT
+        Subject: C = IT, O = Some Company SpA, CN = Fake Subordinate CA for zlint testing
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:c9:5d:d9:6c:ef:88:36:a2:76:5a:be:70:d8:dc:
+                    4b:7b:94:5a:ca:38:69:6e:2c:f7:11:17:2c:6d:77:
+                    f6:1f:17:0f:3e:84:fc:4b:45:49:5b:63:4f:90:59:
+                    a9:9d:e8:dc:e4:be:2f:4b:b4:82:27:1c:76:54:c5:
+                    f5:ef:ff:67:90:ea:74:db:2b:17:1f:56:7f:95:d3:
+                    ad:b4:45:3a:0a:75:d4:72:9c:3d:6e:be:2e:44:ad:
+                    c7:1e:6b:3f:75:77:c8:50:d1:d5:fc:f2:ef:12:ab:
+                    91:15:d7:33:34:e2:70:bd:cb:7b:ee:66:7c:a4:30:
+                    51:3b:5c:40:33:96:b1:b6:c8:04:28:0b:e1:75:f5:
+                    eb:d3:f3:49:21:85:b3:26:cf:24:4c:8d:95:6e:f3:
+                    87:3a:79:af:7b:c8:e0:43:db:94:61:0a:93:91:99:
+                    69:93:76:6f:d9:80:60:fe:4d:7d:e4:06:a6:fb:2f:
+                    f9:29:27:56:24:cb:78:c8:ee:44:a4:31:75:7e:48:
+                    39:a3:ff:96:0f:01:11:b8:c4:05:5b:95:37:d6:d9:
+                    63:4d:95:b8:cf:b6:c8:77:9d:8b:65:b8:a4:3b:ab:
+                    7e:85:9f:cb:42:99:bb:e3:84:90:b5:dc:88:f6:57:
+                    0f:31:52:ff:da:a9:c0:4d:b9:6a:55:33:55:d9:5c:
+                    de:f6:c7:fb:d9:fa:85:f4:e5:50:53:a0:42:bb:78:
+                    83:da:91:ac:ba:6c:0a:ef:28:fd:23:09:2d:aa:b3:
+                    27:83:ea:d7:5b:45:43:20:54:19:89:82:ab:15:4e:
+                    11:4b:29:e8:44:df:84:57:89:f3:8a:0d:b2:b3:25:
+                    7c:7e:de:8b:39:ac:00:ea:e5:fb:8f:90:76:34:ad:
+                    aa:b9:7e:65:4a:2e:af:18:04:86:27:81:9a:6c:3a:
+                    7f:14:ba:1f:cd:aa:e3:af:e4:d0:93:31:18:5b:f0:
+                    50:59:b5:92:46:ec:9d:d0:39:76:19:70:45:18:8d:
+                    ed:bb:99:ae:5a:a9:37:c6:ea:b2:1c:61:e3:37:0b:
+                    96:19:10:57:0a:5c:1c:2c:6d:a2:43:99:2c:4c:d2:
+                    3d:79:e6:c1:66:5b:2e:eb:13:16:0d:f6:9c:d6:0a:
+                    b4:29:c5:38:19:5f:19:10:5f:a9:bf:c1:da:63:40:
+                    cd:26:f7:97:4b:fe:75:81:9a:67:96:cf:15:bf:5c:
+                    2a:96:00:bf:ed:85:3c:43:a6:9a:34:77:74:84:20:
+                    f9:ef:66:6d:50:82:87:10:28:8d:25:82:fc:73:3a:
+                    03:93:90:5b:ad:28:f6:dd:e3:d8:c6:ac:54:92:08:
+                    bd:e9:c5:8e:45:86:61:0f:58:93:8a:24:49:58:5f:
+                    17:e7:2d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Extended Key Usage: 
+                E-mail Protection, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier: 
+                3B:CB:28:37:47:2C:87:40:60:7B:16:0E:C5:08:B9:06:7D:AC:80:D0
+            X509v3 Authority Key Identifier: 
+                keyid:E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+
+            Authority Information Access: 
+                OCSP - URI:http://ca.somecompany.it/ocsp
+                CA Issuers - URI:http://ca.somecompany.it/root
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3
+
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://ca.somecompany.it/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+         21:7f:19:af:6b:8e:ee:32:78:1b:94:8f:66:9e:dc:f3:ce:91:
+         6c:7d:9b:11:c9:14:49:60:5c:9e:c0:03:ca:15:47:5b:32:62:
+         5e:f3:d8:3d:64:c7:4e:4b:7d:9c:5f:01:52:42:eb:c9:eb:26:
+         ce:55:bc:85:0a:b1:21:02:2b:64:62:47:ab:05:1d:ee:97:25:
+         b7:8c:6d:57:1b:02:a6:8b:b2:8c:9d:2c:c8:52:8f:d0:de:46:
+         5f:f1:ab:43:60:17:15:83:e1:b2:ec:0e:9c:bb:03:48:4b:ed:
+         4e:dc:05:44:71:10:67:9a:c0:f2:8c:39:a7:fa:67:d1:20:e4:
+         0a:a9:d5:5c:2d:de:b3:2b:50:9a:c3:9b:a3:8a:e3:4d:79:2b:
+         ca:e9:b6:42:41:9d:63:17:ea:13:60:f3:9f:6c:d2:9a:cd:1e:
+         40:6c:75:cd:8f:3e:35:74:6f:96:69:ee:1a:cb:c7:88:f2:aa:
+         71:df:24:91:66:72:aa:d2:ae:c3:df:9a:e7:92:c1:cc:dc:91:
+         31:84:75:ba:80:75:cd:c7:c0:09:9e:63:97:d1:5d:29:8c:51:
+         ed:db:6a:c1:ec:48:5d:27:aa:4d:63:5b:f2:f5:f0:d5:de:75:
+         99:f8:3e:37:8c:5a:32:83:63:b0:f9:ad:30:e5:25:3d:dd:fe:
+         d2:bb:c8:80:92:44:24:ee:57:f3:05:0d:92:8a:b9:a6:bf:32:
+         67:0d:5e:be:f8:e5:d2:d9:a0:16:f8:ea:9d:25:4e:5d:b6:e4:
+         00:12:82:59:32:8e:45:f0:8a:ff:a6:27:b1:98:b7:a9:29:8e:
+         d8:c0:77:e2:8c:00:ae:54:5f:42:67:98:94:b0:a1:27:4c:4e:
+         4f:df:44:2f:59:f7:26:43:cf:21:98:26:bb:5b:d3:37:55:ec:
+         5d:44:e2:60:08:8a:b5:04:08:a0:fb:54:68:6a:9a:19:80:34:
+         d3:f5:e1:6a:94:93:c4:4b:34:f0:fe:4c:6b:6b:ef:54:62:8a:
+         b4:db:0d:95:76:04:a8:c0:31:ce:dd:07:35:dc:59:bd:92:9c:
+         fd:b0:36:ab:f7:d5:f6:a1:0f:b2:16:11:c2:8d:f0:55:18:33:
+         a6:67:68:94:e2:b2:a0:7a:11:6c:28:71:57:1b:b0:e0:fe:73:
+         a2:4d:24:45:66:d9:a2:f9:6b:ad:10:06:d4:2e:e2:9e:27:b5:
+         f9:13:bf:11:fb:45:b4:f8:8c:fe:86:09:de:70:9e:09:bd:c0:
+         90:e5:cd:eb:52:a4:40:b0:b8:61:25:0b:25:40:d0:27:f4:43:
+         fb:74:45:1d:fd:1d:44:1f:eb:6d:70:28:66:bc:7e:ad:56:36:
+         5f:37:1f:cf:76:2e:88:3a
+-----BEGIN CERTIFICATE-----
+MIIGYDCCBEigAwIBAgIRAOTeQLcyW4yiengsRkO1HZswDQYJKoZIhvcNAQELBQAw
+UTELMAkGA1UEBhMCSVQxGTAXBgNVBAoTEFNvbWUgQ29tcGFueSBTcEExJzAlBgNV
+BAMTHkZha2UgUm9vdCBDQSBmb3IgemxpbnQgdGVzdGluZzAeFw0yMTA2MjYxNDUx
+MDVaFw0zMTA2MjcwMDUxMDVaMFgxCzAJBgNVBAYTAklUMRkwFwYDVQQKExBTb21l
+IENvbXBhbnkgU3BBMS4wLAYDVQQDEyVGYWtlIFN1Ym9yZGluYXRlIENBIGZvciB6
+bGludCB0ZXN0aW5nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAyV3Z
+bO+INqJ2Wr5w2NxLe5Rayjhpbiz3ERcsbXf2HxcPPoT8S0VJW2NPkFmpnejc5L4v
+S7SCJxx2VMX17/9nkOp02ysXH1Z/ldOttEU6CnXUcpw9br4uRK3HHms/dXfIUNHV
+/PLvEquRFdczNOJwvct77mZ8pDBRO1xAM5axtsgEKAvhdfXr0/NJIYWzJs8kTI2V
+bvOHOnmve8jgQ9uUYQqTkZlpk3Zv2YBg/k195Aam+y/5KSdWJMt4yO5EpDF1fkg5
+o/+WDwERuMQFW5U31tljTZW4z7bId52LZbikO6t+hZ/LQpm744SQtdyI9lcPMVL/
+2qnATblqVTNV2Vze9sf72fqF9OVQU6BCu3iD2pGsumwK7yj9IwktqrMng+rXW0VD
+IFQZiYKrFU4RSynoRN+EV4nzig2ysyV8ft6LOawA6uX7j5B2NK2quX5lSi6vGASG
+J4GabDp/FLofzarjr+TQkzEYW/BQWbWSRuyd0Dl2GXBFGI3tu5muWqk3xuqyHGHj
+NwuWGRBXClwcLG2iQ5ksTNI9eebBZlsu6xMWDfac1gq0KcU4GV8ZEF+pv8HaY0DN
+JveXS/51gZpnls8Vv1wqlgC/7YU8Q6aaNHd0hCD572ZtUIKHECiNJYL8czoDk5Bb
+rSj23ePYxqxUkgi96cWORYZhD1iTiiRJWF8X5y0CAwEAAaOCASowggEmMA4GA1Ud
+DwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEFBQcDBAYIKwYBBQUHAwEwDwYDVR0T
+AQH/BAUwAwEB/zAdBgNVHQ4EFgQUO8soN0csh0BgexYOxQi5Bn2sgNAwHwYDVR0j
+BBgwFoAU6Lb2dkvQO+VGpflU1H4Hs94NYD4wZAYIKwYBBQUHAQEEWDBWMCkGCCsG
+AQUFBzABhh1odHRwOi8vY2Euc29tZWNvbXBhbnkuaXQvb2NzcDApBggrBgEFBQcw
+AoYdaHR0cDovL2NhLnNvbWVjb21wYW55Lml0L3Jvb3QwDwYDVR0gBAgwBjAEBgIq
+AzAtBgNVHR8EJjAkMCKgIKAehhxodHRwOi8vY2Euc29tZWNvbXBhbnkuaXQvY3Js
+MA0GCSqGSIb3DQEBCwUAA4ICAQAhfxmva47uMngblI9mntzzzpFsfZsRyRRJYFye
+wAPKFUdbMmJe89g9ZMdOS32cXwFSQuvJ6ybOVbyFCrEhAitkYkerBR3ulyW3jG1X
+GwKmi7KMnSzIUo/Q3kZf8atDYBcVg+Gy7A6cuwNIS+1O3AVEcRBnmsDyjDmn+mfR
+IOQKqdVcLd6zK1Caw5ujiuNNeSvK6bZCQZ1jF+oTYPOfbNKazR5AbHXNjz41dG+W
+ae4ay8eI8qpx3ySRZnKq0q7D35rnksHM3JExhHW6gHXNx8AJnmOX0V0pjFHt22rB
+7EhdJ6pNY1vy9fDV3nWZ+D43jFoyg2Ow+a0w5SU93f7Su8iAkkQk7lfzBQ2Sirmm
+vzJnDV6++OXS2aAW+OqdJU5dtuQAEoJZMo5F8Ir/piexmLepKY7YwHfijACuVF9C
+Z5iUsKEnTE5P30QvWfcmQ88hmCa7W9M3VexdROJgCIq1BAig+1RoapoZgDTT9eFq
+lJPESzTw/kxra+9UYoq02w2VdgSowDHO3Qc13Fm9kpz9sDar99X2oQ+yFhHCjfBV
+GDOmZ2iU4rKgehFsKHFXG7Dg/nOiTSRFZtmi+WutEAbULuKeJ7X5E78R+0W0+Iz+
+hgnecJ4JvcCQ5c3rUqRAsLhhJQslQNAn9EP7dEUd/R1EH+ttcChmvH6tVjZfNx/P
+di6IOg==
+-----END CERTIFICATE-----

--- a/v3/testdata/SubCAEkuServerAndTime.pem
+++ b/v3/testdata/SubCAEkuServerAndTime.pem
@@ -1,0 +1,142 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            ef:cd:41:98:65:fd:0b:75:ad:ec:21:64:6a:ec:e3:eb
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = IT, O = Some Company SpA, CN = Fake Root CA for zlint testing
+        Validity
+            Not Before: Jun 27 08:36:21 2021 GMT
+            Not After : Jun 27 18:36:21 2031 GMT
+        Subject: C = IT, O = Some Company SpA, CN = Fake Subordinate CA for zlint testing
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (4096 bit)
+                Modulus:
+                    00:de:5d:87:63:ba:36:ca:ff:4f:cf:4a:bd:5f:62:
+                    80:63:38:46:20:6d:9d:c0:80:9c:d8:b5:6a:2a:bc:
+                    01:26:04:ea:a9:cd:23:55:64:3c:ad:b2:77:aa:98:
+                    85:69:dc:78:ca:08:33:d1:09:46:27:a2:57:f3:f9:
+                    bb:87:7b:3c:fc:06:d6:a4:d1:3c:30:fd:9a:3a:60:
+                    90:3b:9c:5c:43:5d:81:8b:d6:41:9e:e7:cc:b8:55:
+                    34:e3:e3:65:6c:5a:ac:a3:94:b4:a6:2b:b7:83:e5:
+                    a9:81:87:b5:52:da:03:c2:ef:4e:4a:92:29:16:58:
+                    82:64:ee:fc:d9:5c:e6:f7:27:47:0e:59:0b:68:ab:
+                    d0:2d:c1:85:9f:54:07:de:8d:60:da:26:4e:cb:63:
+                    ac:0d:cf:c6:10:28:7e:0e:1e:f0:88:5e:c3:b2:14:
+                    23:e3:0a:d7:39:2b:c3:cb:8f:14:1e:57:03:77:c4:
+                    7f:18:e4:c7:0c:6d:0b:fe:3a:05:e1:e7:2c:9e:42:
+                    b5:cd:41:35:8f:16:05:4f:c2:14:73:3c:ce:61:82:
+                    70:98:0d:71:9c:d5:37:7f:0e:48:31:0a:2e:63:04:
+                    80:43:06:42:d0:db:be:5a:4e:5e:f1:d2:25:83:88:
+                    00:fd:b8:ca:df:5c:9b:e7:53:a9:8d:72:c8:fe:e0:
+                    84:2b:9f:db:86:f3:39:da:65:c9:64:90:c9:1a:54:
+                    dd:02:08:f5:f3:c0:28:66:4a:b6:24:3b:16:e1:6b:
+                    51:c4:61:62:80:5f:92:f7:a7:ac:63:73:2d:48:f5:
+                    f1:d0:2d:03:d7:f7:e7:a3:7c:34:5a:dc:cc:dc:c7:
+                    1e:35:95:68:f9:8d:fc:05:7f:6d:32:5e:2f:fb:47:
+                    c3:d5:ec:a7:c3:22:44:28:b1:78:db:43:9c:60:e4:
+                    bd:78:49:fe:73:85:d5:78:b6:81:0d:7e:bd:e2:19:
+                    d7:e9:46:d9:8b:60:99:00:c8:1c:7d:74:bc:38:40:
+                    aa:71:a7:49:a9:d6:4b:a7:0c:a5:de:b9:6f:16:3b:
+                    1b:d2:80:48:2d:49:be:50:25:11:47:83:b4:38:ce:
+                    5c:47:10:bb:24:54:ea:c8:c8:7d:e2:fa:ac:c1:0e:
+                    d6:ca:56:72:b0:7e:38:e8:87:85:b1:43:85:68:e6:
+                    65:06:d8:4a:21:bf:a6:a3:e9:e3:99:08:98:2d:e6:
+                    0c:0c:af:f0:e5:f3:0b:38:38:e7:b1:96:8d:eb:2a:
+                    c8:30:e4:2c:9e:0d:1e:23:a9:6a:09:98:9d:dd:34:
+                    9a:ba:d8:01:7c:8f:c8:86:ec:07:43:11:00:37:16:
+                    71:6a:65:54:b0:9f:50:43:5f:2d:69:5d:8a:da:e3:
+                    e1:66:3b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Extended Key Usage: 
+                Time Stamping, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier: 
+                C3:37:B6:77:B5:BF:92:A9:AC:8A:2E:9A:67:56:77:0C:4B:91:C7:90
+            X509v3 Authority Key Identifier: 
+                keyid:E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+
+            Authority Information Access: 
+                OCSP - URI:http://ca.somecompany.it/ocsp
+                CA Issuers - URI:http://ca.somecompany.it/root
+
+            X509v3 Certificate Policies: 
+                Policy: 1.2.3
+
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://ca.somecompany.it/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+         bd:07:0c:34:96:3e:c6:8a:d7:dc:0a:77:88:be:60:9e:9f:e4:
+         09:db:e1:61:79:d6:5a:08:61:ea:ff:86:fc:4c:ab:4c:c1:c3:
+         e9:fe:22:63:64:e7:d5:c8:06:90:bc:e1:1e:35:2d:65:bc:af:
+         35:56:a2:54:3e:f6:ba:b7:d2:96:95:88:1e:3c:8b:d0:51:34:
+         9f:15:e5:30:42:f3:1f:e3:34:f5:92:b2:49:cf:c7:5c:95:a0:
+         bf:a9:29:4a:2e:df:18:2f:8e:58:1a:88:16:18:42:d6:09:de:
+         c1:8b:19:27:6d:40:57:21:28:29:58:24:95:71:78:be:86:e0:
+         77:70:91:aa:70:52:9a:d3:1c:d8:b3:a8:6a:8a:f8:77:52:c9:
+         0c:e4:c5:76:49:3a:df:26:90:56:7b:97:b7:c4:6b:2f:b0:e1:
+         fe:70:06:39:2e:ec:cb:6d:99:64:cb:7a:23:36:5a:52:73:03:
+         e2:b6:52:eb:27:77:62:75:dc:a5:54:aa:85:b7:72:a2:7c:cf:
+         87:94:bd:63:ae:d0:65:59:b3:2a:4c:b9:5c:44:5b:c0:67:f2:
+         73:1a:1d:0f:35:62:2c:65:2f:83:b7:ce:9c:4a:01:bb:c4:45:
+         b2:a2:de:59:b2:2b:1e:2e:f2:fa:42:97:06:7f:85:70:5e:19:
+         86:f0:7b:21:f8:8f:ea:53:b7:be:95:3e:db:27:08:1c:36:e7:
+         ac:6d:9d:2c:b3:b3:f6:4a:c3:79:df:bc:72:cf:20:74:ab:1d:
+         91:4d:4f:4b:03:46:03:78:0a:c7:b0:08:81:09:3a:6e:27:0a:
+         45:e5:58:fd:97:9b:8f:e3:99:1c:d6:37:d4:f7:91:6e:42:e3:
+         1a:5b:33:86:49:ee:78:3e:fe:ea:90:95:97:15:d9:57:f0:ca:
+         b7:88:7e:71:60:8b:0d:c7:ab:43:2b:ea:52:93:73:e7:48:3c:
+         30:de:d8:d8:ec:ee:6d:fe:fc:d2:4f:c3:f1:1e:a3:21:53:a5:
+         cd:f9:fb:49:d7:9e:83:c2:58:a6:73:c7:dc:b9:6c:76:43:e7:
+         a1:9a:40:32:73:9c:b0:52:e1:8c:22:a6:6e:62:87:15:b1:be:
+         fe:ea:86:76:33:32:a7:05:fe:2c:87:c3:b5:c6:e6:f5:ac:21:
+         57:1e:54:5f:6c:67:ba:2a:eb:b6:5e:5e:dc:42:9f:c9:5e:69:
+         fe:76:ca:2d:9c:26:26:25:f6:16:cd:89:4a:b4:bc:15:b2:e9:
+         fd:fc:23:0c:fa:40:97:c6:80:c8:fc:83:16:cf:71:cf:2b:29:
+         fc:9b:07:2a:06:61:d7:5d:13:86:3f:36:91:5e:00:fb:ba:a1:
+         ee:5b:c6:79:2c:42:bb:be
+-----BEGIN CERTIFICATE-----
+MIIGYDCCBEigAwIBAgIRAO/NQZhl/Qt1rewhZGrs4+swDQYJKoZIhvcNAQELBQAw
+UTELMAkGA1UEBhMCSVQxGTAXBgNVBAoTEFNvbWUgQ29tcGFueSBTcEExJzAlBgNV
+BAMTHkZha2UgUm9vdCBDQSBmb3IgemxpbnQgdGVzdGluZzAeFw0yMTA2MjcwODM2
+MjFaFw0zMTA2MjcxODM2MjFaMFgxCzAJBgNVBAYTAklUMRkwFwYDVQQKExBTb21l
+IENvbXBhbnkgU3BBMS4wLAYDVQQDEyVGYWtlIFN1Ym9yZGluYXRlIENBIGZvciB6
+bGludCB0ZXN0aW5nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA3l2H
+Y7o2yv9Pz0q9X2KAYzhGIG2dwICc2LVqKrwBJgTqqc0jVWQ8rbJ3qpiFadx4yggz
+0QlGJ6JX8/m7h3s8/AbWpNE8MP2aOmCQO5xcQ12Bi9ZBnufMuFU04+NlbFqso5S0
+piu3g+WpgYe1UtoDwu9OSpIpFliCZO782Vzm9ydHDlkLaKvQLcGFn1QH3o1g2iZO
+y2OsDc/GECh+Dh7wiF7DshQj4wrXOSvDy48UHlcDd8R/GOTHDG0L/joF4ecsnkK1
+zUE1jxYFT8IUczzOYYJwmA1xnNU3fw5IMQouYwSAQwZC0Nu+Wk5e8dIlg4gA/bjK
+31yb51OpjXLI/uCEK5/bhvM52mXJZJDJGlTdAgj188AoZkq2JDsW4WtRxGFigF+S
+96esY3MtSPXx0C0D1/fno3w0WtzM3MceNZVo+Y38BX9tMl4v+0fD1eynwyJEKLF4
+20OcYOS9eEn+c4XVeLaBDX694hnX6UbZi2CZAMgcfXS8OECqcadJqdZLpwyl3rlv
+Fjsb0oBILUm+UCURR4O0OM5cRxC7JFTqyMh94vqswQ7WylZysH446IeFsUOFaOZl
+BthKIb+mo+njmQiYLeYMDK/w5fMLODjnsZaN6yrIMOQsng0eI6lqCZid3TSautgB
+fI/IhuwHQxEANxZxamVUsJ9QQ18taV2K2uPhZjsCAwEAAaOCASowggEmMA4GA1Ud
+DwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEFBQcDCAYIKwYBBQUHAwEwDwYDVR0T
+AQH/BAUwAwEB/zAdBgNVHQ4EFgQUwze2d7W/kqmsii6aZ1Z3DEuRx5AwHwYDVR0j
+BBgwFoAU6Lb2dkvQO+VGpflU1H4Hs94NYD4wZAYIKwYBBQUHAQEEWDBWMCkGCCsG
+AQUFBzABhh1odHRwOi8vY2Euc29tZWNvbXBhbnkuaXQvb2NzcDApBggrBgEFBQcw
+AoYdaHR0cDovL2NhLnNvbWVjb21wYW55Lml0L3Jvb3QwDwYDVR0gBAgwBjAEBgIq
+AzAtBgNVHR8EJjAkMCKgIKAehhxodHRwOi8vY2Euc29tZWNvbXBhbnkuaXQvY3Js
+MA0GCSqGSIb3DQEBCwUAA4ICAQC9Bww0lj7GitfcCneIvmCen+QJ2+FhedZaCGHq
+/4b8TKtMwcPp/iJjZOfVyAaQvOEeNS1lvK81VqJUPva6t9KWlYgePIvQUTSfFeUw
+QvMf4zT1krJJz8dclaC/qSlKLt8YL45YGogWGELWCd7BixknbUBXISgpWCSVcXi+
+huB3cJGqcFKa0xzYs6hqivh3UskM5MV2STrfJpBWe5e3xGsvsOH+cAY5LuzLbZlk
+y3ojNlpScwPitlLrJ3diddylVKqFt3KifM+HlL1jrtBlWbMqTLlcRFvAZ/JzGh0P
+NWIsZS+Dt86cSgG7xEWyot5ZsiseLvL6QpcGf4VwXhmG8Hsh+I/qU7e+lT7bJwgc
+NuesbZ0ss7P2SsN537xyzyB0qx2RTU9LA0YDeArHsAiBCTpuJwpF5Vj9l5uP45kc
+1jfU95FuQuMaWzOGSe54Pv7qkJWXFdlX8Mq3iH5xYIsNx6tDK+pSk3PnSDww3tjY
+7O5t/vzST8PxHqMhU6XN+ftJ156Dwlimc8fcuWx2Q+ehmkAyc5ywUuGMIqZuYocV
+sb7+6oZ2MzKnBf4sh8O1xub1rCFXHlRfbGe6Kuu2Xl7cQp/JXmn+dsotnCYmJfYW
+zYlKtLwVsun9/CMM+kCXxoDI/IMWz3HPKyn8mwcqBmHXXROGPzaRXgD7uqHuW8Z5
+LEK7vg==
+-----END CERTIFICATE-----


### PR DESCRIPTION
Adds a new lint, identified as e_sub_ca_eku_incmpatible_values,
to check that the EKU values within a Subordinate CA certificate meet the 
MUST NOT requirement of CABF Baseline Requirements 7.1.2.2, letter g).
