### PR TITLE
Code clarification to match BRs wording around RSA public exponent lower bound

### DIFF
--- a/v3/lints/cabf_br/lint_rsa_public_exponent_not_in_range.go
+++ b/v3/lints/cabf_br/lint_rsa_public_exponent_not_in_range.go
@@ -58,8 +58,8 @@ func (l *rsaParsedTestsExpInRange) CheckApplies(c *x509.Certificate) bool {
 func (l *rsaParsedTestsExpInRange) Execute(c *x509.Certificate) *lint.LintResult {
 	key := c.PublicKey.(*rsa.PublicKey)
 	exponent := key.E
-	const lowerBound = 65536 // 2^16 + 1
-	if exponent > lowerBound && l.upperBound.Cmp(big.NewInt(int64(exponent))) == 1 {
+	const lowerBound = 65537 // 2^16 + 1
+	if exponent >= lowerBound && l.upperBound.Cmp(big.NewInt(int64(exponent))) == 1 {
 		return &lint.LintResult{Status: lint.Pass}
 	}
 	return &lint.LintResult{Status: lint.Warn}


### PR DESCRIPTION
This makes the existing comment ("2^16 + 1") to match the value next to it.