### PR TITLE
Detect XN-Labels case-insensitively

### DIFF
--- a/v3/lints/rfc/lint_idn_dnsname_malformed_unicode.go
+++ b/v3/lints/rfc/lint_idn_dnsname_malformed_unicode.go
@@ -48,8 +48,12 @@ func (l *IDNMalformedUnicode) Execute(c *x509.Certificate) *lint.LintResult {
 	for _, dns := range c.DNSNames {
 		labels := strings.Split(dns, ".")
 		for _, label := range labels {
-			if strings.HasPrefix(label, "xn--") {
-				_, err := idna.ToUnicode(label)
+			labelLower := strings.ToLower((label))
+
+			if strings.HasPrefix(labelLower, "xn--") {
+				// We need to use the lowercase label due to a bug in idna
+				// See: https://github.com/golang/go/issues/48778
+				_, err := idna.ToUnicode(labelLower)
 				if err != nil {
 					return &lint.LintResult{Status: lint.Error}
 				}

--- a/v3/lints/rfc/lint_idn_dnsname_must_be_nfc.go
+++ b/v3/lints/rfc/lint_idn_dnsname_must_be_nfc.go
@@ -49,8 +49,12 @@ func (l *IDNNotNFC) Execute(c *x509.Certificate) *lint.LintResult {
 	for _, dns := range c.DNSNames {
 		labels := strings.Split(dns, ".")
 		for _, label := range labels {
-			if strings.HasPrefix(label, "xn--") {
-				unicodeLabel, err := idna.ToUnicode(label)
+			labelLower := strings.ToLower((label))
+
+			if strings.HasPrefix(labelLower, "xn--") {
+				// We need to use the lowercase label due to a bug in idna
+				// See: https://github.com/golang/go/issues/48778
+				unicodeLabel, err := idna.ToUnicode(labelLower)
 				if err != nil {
 					return &lint.LintResult{Status: lint.NA}
 				}

--- a/v3/testdata/dnsNamesNotNFC.pem
+++ b/v3/testdata/dnsNamesNotNFC.pem
@@ -2,165 +2,38 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number:
-            bb:30:ab:73:98:9b:23:0d
-    Signature Algorithm: sha256WithRSAEncryption
-        Issuer: C=US, ST=AZ, L=Scottsdale, O=GoDaddy, OU=PKI, CN=xn--80aqafgnbi.xn--b1addckdrqizje4a.xn--p1ai/emailAddress=schang@godaddy.com
+            5b:c9:9d:ea:2d:9e:5a:d3:ba:80:06:63:b6:56:c8:96:76:a4:9b:62
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Bar
         Validity
-            Not Before: Jun 28 23:50:46 2018 GMT
-            Not After : Mar 24 23:50:46 2021 GMT
-        Subject: C=US, ST=AZ, L=Scottsdale, O=GoDaddy, OU=PKI, CN=xn--80aqafgnbi.xn--b1addckdrqizje4a.xn--p1ai/emailAddress=schang@godaddy.com
+            Not Before: Oct  1 00:00:00 2021 GMT
+            Not After : Oct  1 00:00:00 2022 GMT
+        Subject: CN = Foo
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (3072 bit)
+                RSA Public-Key: (512 bit)
                 Modulus:
-                    00:f5:3f:f2:62:50:3c:30:2a:12:0e:38:c0:20:e9:
-                    1c:dc:a7:96:07:75:c4:12:af:6b:1a:42:72:ff:63:
-                    bf:3e:85:cc:48:7c:26:92:4b:d2:6c:c5:96:d8:b8:
-                    cf:d3:a4:f6:d2:2b:36:af:e0:06:90:0e:8f:26:63:
-                    88:d9:18:71:a6:90:01:04:53:e5:4a:cd:dc:15:23:
-                    77:b2:e7:f9:45:fc:2c:97:7c:7f:d7:18:c2:fb:90:
-                    75:a8:0e:f3:c3:5c:ce:bc:7f:de:84:1e:74:69:1b:
-                    29:88:d6:6b:c5:20:a4:8f:17:66:7c:dd:71:37:5b:
-                    fb:b6:49:07:52:00:bb:26:13:20:60:07:97:c8:d4:
-                    ce:9d:d4:ac:22:b9:1f:fb:11:1d:2c:ef:f2:95:d0:
-                    b0:ee:49:4c:eb:0c:9d:45:4e:fe:6a:61:72:66:bb:
-                    a2:cf:63:20:7c:27:c8:9f:4c:2c:5f:75:2c:6f:84:
-                    cb:f3:16:a1:c6:71:94:f4:6d:45:19:40:86:e2:ed:
-                    b5:95:33:c8:8e:5f:cd:46:78:b3:04:5b:46:93:c5:
-                    0e:93:f8:15:6e:7b:0a:41:6d:d5:1e:93:5f:19:af:
-                    07:e4:3e:07:13:b0:be:0b:d6:21:cc:bf:0d:6b:af:
-                    39:76:76:bf:24:96:f8:2a:57:ef:c7:74:d7:05:9e:
-                    61:3e:d7:17:54:66:0b:8f:b9:b2:dd:c6:82:7b:19:
-                    ac:92:a6:ec:65:21:4c:44:2d:d5:96:f4:7f:38:27:
-                    10:e5:15:c1:87:84:fa:15:0f:98:1d:72:c2:b4:38:
-                    a2:fe:41:60:e6:3a:4b:13:0d:d5:f0:03:16:25:34:
-                    87:67:2a:e2:e6:aa:8a:67:34:fe:c0:4a:d0:7c:12:
-                    a4:68:2e:0c:90:7e:bf:87:d5:81:a7:08:4a:6d:2b:
-                    c7:c0:72:ee:5c:0c:76:40:53:ca:de:bd:87:b9:bb:
-                    3e:04:c8:0c:a8:d4:94:0b:39:bc:6e:66:ae:79:1d:
-                    88:f2:d7:37:ea:4d:e5:85:61:21
+                    00:dd:c8:7d:83:a5:9d:f2:1c:af:64:e6:8b:3a:87:
+                    06:28:d8:2a:41:9f:76:6d:43:9e:81:76:4b:06:8c:
+                    f3:7a:3d:fb:88:93:3d:ff:72:9f:19:8f:19:93:22:
+                    61:ee:62:09:5e:3b:76:57:7b:c9:8d:a6:9d:b4:90:
+                    0b:c4:65:ec:33
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
-                DNS:xn----stbbzbh.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn---26-eddosn7a0ak4c.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--107-5cdaa2chp5aetkelu1c3g.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--109-3veba6djs1bfxlfmx6c9g.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--14-9kciiba3aqubi7af8gzc.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--178-5cdal0dh0aakkkhh1o3b.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--21-6kchp4azaxdj0m.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--43-6kcax4ab9bla4dyf.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--45-mlcapln4a3a9aq.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--46-mlcapln4a3a9aq.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--53-6kcax4ab9bla4dyf.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--79-6kcaa5bgn2aerjekt8bxg.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aa0ae6d.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aa2agjmejdq8j.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aae5ai2ao.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aaid2am2aa3a.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aalfubeujccihfbdgksb.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aalwqglfe.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aamvb5b.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aaprggi2f8a.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aaxgcd7ba.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80ab0ao1a1d.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80ab0aoui0e.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80abehftithlykeq2l.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80acvfdesq.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80afhlnque.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80ajjheoz9b0d.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80akigivw6f.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80akjla6aie.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80apatkjk7a7ea.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80aqafgnbi.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--80atubbebi.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--87-6kcden2ebx.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--90aeebatcosbh5acc0a6e7c.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--90aeebavmqbg3ad6ftc.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--90afcnzgq4e.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1acfsu9c.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1aebnvlkge.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1afkbfmlcogdgec.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1afkfklbqbiegx.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1afmgkbdfatdhn9d1c.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--b1ag8ag.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--c1akecd2av.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--e1aajhjwx1ao.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--e1aaqibces2d.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--e1agf3afz.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--g1ani7c.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--h1aaeyfh.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--h1aajcffjkhy9ij.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--h1adbc4dyb.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--i1ajfdfdg2g.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--j1aa0a.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--j1aacdjbokgr8i.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--j1acchbggkgr9i.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--j1ak.xn--b1addckdrqixje4a.xn--p1ai, DNS:xn--j1ao.xn--b1addckdrqixje4a.xn--p1ai
-            X509v3 Key Usage: 
-                Digital Signature, Key Encipherment
-            X509v3 Subject Key Identifier: 
-                55:36:C6:2B:01:9B:F4:55:8E:8D:B3:35:E0:B3:40:AD:8D:EF:C0:10
-            X509v3 Authority Key Identifier: 
-                keyid:55:36:C6:2B:01:9B:F4:55:8E:8D:B3:35:E0:B3:40:AD:8D:EF:C0:10
-
-            X509v3 Basic Constraints: critical
-                CA:TRUE
+                DNS:xN--109-3veba6djs1bfxlfmx6c9g.xn--f1awi.xn--p1ai
     Signature Algorithm: sha256WithRSAEncryption
-         77:c8:09:35:0e:88:cc:47:d8:42:2d:c6:17:97:40:ae:c0:9b:
-         bf:9b:c4:54:41:59:79:3e:04:7a:ce:2f:ef:12:b2:4b:2e:04:
-         1f:8c:b2:77:ba:01:19:c8:3a:4e:e7:a3:51:a7:0c:6c:30:4f:
-         7c:51:91:26:1c:73:c2:d1:20:54:41:c1:e1:0c:dc:34:26:26:
-         80:59:22:8f:d3:aa:18:a9:b2:c8:bd:86:d7:55:c4:83:b6:96:
-         6b:db:84:1c:5f:b9:1f:9b:d8:a2:63:3f:dc:e8:d9:f5:a3:a9:
-         f7:23:96:0d:db:c5:f6:e5:57:e8:8a:5a:67:4b:a7:a3:9f:e7:
-         7f:8d:02:15:3d:53:57:01:93:61:54:53:7d:d4:12:26:e6:77:
-         86:c4:58:16:ce:72:b6:04:03:6f:c2:17:25:89:ab:70:ff:4b:
-         9e:f3:9b:70:d4:5e:87:da:1f:19:fc:2a:31:ab:f4:7c:ee:e0:
-         00:e1:45:44:3d:5f:02:92:7f:7c:15:e4:e3:d7:47:3a:03:ce:
-         5d:55:40:bb:74:b4:73:d5:7f:38:a2:60:d2:88:4c:0f:f3:5d:
-         d5:8f:1b:30:04:6f:26:15:b6:02:e0:30:da:72:fe:73:7f:f6:
-         27:9d:f7:79:49:3b:32:fb:72:55:ac:06:60:0c:18:0e:a6:fe:
-         b8:77:da:bc:18:70:8e:63:15:11:b5:16:ec:ca:5c:97:ae:49:
-         0d:e5:fc:52:e0:ae:e6:e2:fc:f4:ef:5e:e4:43:c4:5b:51:e2:
-         ca:dc:46:27:1a:c1:1c:47:aa:32:ea:ab:c1:77:73:50:6f:b7:
-         f7:c9:06:3e:24:62:de:81:d5:fb:98:78:b6:67:19:66:98:40:
-         86:2d:42:81:b0:f6:ae:fb:a2:a5:4d:5c:1c:53:02:0d:2c:06:
-         14:c1:3e:ea:3e:4d:f0:d3:bb:ce:0c:84:85:6e:a3:2a:0f:36:
-         93:34:8e:fe:6a:f4:86:ee:0c:b5:57:5e:79:9e:7e:ee:57:fa:
-         c6:a5:6a:0b:c7:ac
+         2b:72:01:ff:0b:05:6a:f7:27:e7:28:24:9e:25:bc:0a:f0:b1:
+         c5:8f:19:e1:c4:b9:e1:d6:38:3a:74:0e:f9:d6:52:93:41:43:
+         49:80:25:d1:d1:d4:ad:e5:ba:34:9c:6b:cb:57:7c:79:6c:ee:
+         f6:02:aa:67:62:97:da:1a:d6:5c
 -----BEGIN CERTIFICATE-----
-MIIQIzCCDougAwIBAgIJALswq3OYmyMNMA0GCSqGSIb3DQEBCwUAMIGpMQswCQYD
-VQQGEwJVUzELMAkGA1UECAwCQVoxEzARBgNVBAcMClNjb3R0c2RhbGUxEDAOBgNV
-BAoMB0dvRGFkZHkxDDAKBgNVBAsMA1BLSTE1MDMGA1UEAwwseG4tLTgwYXFhZmdu
-YmkueG4tLWIxYWRkY2tkcnFpemplNGEueG4tLXAxYWkxITAfBgkqhkiG9w0BCQEW
-EnNjaGFuZ0Bnb2RhZGR5LmNvbTAeFw0xODA2MjgyMzUwNDZaFw0yMTAzMjQyMzUw
-NDZaMIGpMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQVoxEzARBgNVBAcMClNjb3R0
-c2RhbGUxEDAOBgNVBAoMB0dvRGFkZHkxDDAKBgNVBAsMA1BLSTE1MDMGA1UEAwws
-eG4tLTgwYXFhZmduYmkueG4tLWIxYWRkY2tkcnFpemplNGEueG4tLXAxYWkxITAf
-BgkqhkiG9w0BCQEWEnNjaGFuZ0Bnb2RhZGR5LmNvbTCCAaIwDQYJKoZIhvcNAQEB
-BQADggGPADCCAYoCggGBAPU/8mJQPDAqEg44wCDpHNynlgd1xBKvaxpCcv9jvz6F
-zEh8JpJL0mzFlti4z9Ok9tIrNq/gBpAOjyZjiNkYcaaQAQRT5UrN3BUjd7Ln+UX8
-LJd8f9cYwvuQdagO88Nczrx/3oQedGkbKYjWa8UgpI8XZnzdcTdb+7ZJB1IAuyYT
-IGAHl8jUzp3UrCK5H/sRHSzv8pXQsO5JTOsMnUVO/mphcma7os9jIHwnyJ9MLF91
-LG+Ey/MWocZxlPRtRRlAhuLttZUzyI5fzUZ4swRbRpPFDpP4FW57CkFt1R6TXxmv
-B+Q+BxOwvgvWIcy/DWuvOXZ2vySW+CpX78d01wWeYT7XF1RmC4+5st3GgnsZrJKm
-7GUhTEQt1Zb0fzgnEOUVwYeE+hUPmB1ywrQ4ov5BYOY6SxMN1fADFiU0h2cq4uaq
-imc0/sBK0HwSpGguDJB+v4fVgacISm0rx8By7lwMdkBTyt69h7m7PgTIDKjUlAs5
-vG5mrnkdiPLXN+pN5YVhIQIDAQABo4ILSjCCC0YwggrkBgNVHREEggrbMIIK14Ir
-eG4tLS0tc3RiYnpiaC54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFhaYIzeG4t
-LS0yNi1lZGRvc243YTBhazRjLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFp
-gjt4bi0tMTA3LTVjZGFhMmNocDVhZXRrZWx1MWMzZy54bi0tYjFhZGRja2RycWl4
-amU0YS54bi0tcDFhaYI7eG4tLTEwOS0zdmViYTZkanMxYmZ4bGZteDZjOWcueG4t
-LWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCOXhuLS0xNC05a2NpaWJhM2FxdWJp
-N2FmOGd6Yy54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFhaYI6eG4tLTE3OC01
-Y2RhbDBkaDBhYWtra2hoMW8zYi54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFh
-aYIzeG4tLTIxLTZrY2hwNGF6YXhkajBtLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhu
-LS1wMWFpgjV4bi0tNDMtNmtjYXg0YWI5YmxhNGR5Zi54bi0tYjFhZGRja2RycWl4
-amU0YS54bi0tcDFhaYIzeG4tLTQ1LW1sY2FwbG40YTNhOWFxLnhuLS1iMWFkZGNr
-ZHJxaXhqZTRhLnhuLS1wMWFpgjN4bi0tNDYtbWxjYXBsbjRhM2E5YXEueG4tLWIx
-YWRkY2tkcnFpeGplNGEueG4tLXAxYWmCNXhuLS01My02a2NheDRhYjlibGE0ZHlm
-LnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgjp4bi0tNzktNmtjYWE1Ymdu
-MmFlcmpla3Q4YnhnLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgit4bi0t
-ODBhYTBhZTZkLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgjF4bi0tODBh
-YTJhZ2ptZWpkcThqLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgi14bi0t
-ODBhYWU1YWkyYW8ueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCMHhuLS04
-MGFhaWQyYW0yYWEzYS54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFhaYI4eG4t
-LTgwYWFsZnViZXVqY2NpaGZiZGdrc2IueG4tLWIxYWRkY2tkcnFpeGplNGEueG4t
-LXAxYWmCLXhuLS04MGFhbHdxZ2xmZS54bi0tYjFhZGRja2RycWl4amU0YS54bi0t
-cDFhaYIreG4tLTgwYWFtdmI1Yi54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFh
-aYIveG4tLTgwYWFwcmdnaTJmOGEueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAx
-YWmCLXhuLS04MGFheGdjZDdiYS54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFh
-aYIteG4tLTgwYWIwYW8xYTFkLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFp
-gi14bi0tODBhYjBhb3VpMGUueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmC
-NHhuLS04MGFiZWhmdGl0aGx5a2VxMmwueG4tLWIxYWRkY2tkcnFpeGplNGEueG4t
-LXAxYWmCLHhuLS04MGFjdmZkZXNxLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1w
-MWFpgix4bi0tODBhZmhsbnF1ZS54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFh
-aYIveG4tLTgwYWpqaGVvejliMGQueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAx
-YWmCLXhuLS04MGFraWdpdnc2Zi54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFh
-aYIteG4tLTgwYWtqbGE2YWllLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFp
-gjB4bi0tODBhcGF0a2prN2E3ZWEueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAx
-YWmCLHhuLS04MGFxYWZnbmJpLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFp
-gix4bi0tODBhdHViYmViaS54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFhaYIv
-eG4tLTg3LTZrY2RlbjJlYngueG4tLWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmC
-OXhuLS05MGFlZWJhdGNvc2JoNWFjYzBhNmU3Yy54bi0tYjFhZGRja2RycWl4amU0
-YS54bi0tcDFhaYI1eG4tLTkwYWVlYmF2bXFiZzNhZDZmdGMueG4tLWIxYWRkY2tk
-cnFpeGplNGEueG4tLXAxYWmCLXhuLS05MGFmY256Z3E0ZS54bi0tYjFhZGRja2Ry
-cWl4amU0YS54bi0tcDFhaYIreG4tLWIxYWNmc3U5Yy54bi0tYjFhZGRja2RycWl4
-amU0YS54bi0tcDFhaYIteG4tLWIxYWVibnZsa2dlLnhuLS1iMWFkZGNrZHJxaXhq
-ZTRhLnhuLS1wMWFpgjJ4bi0tYjFhZmtiZm1sY29nZGdlYy54bi0tYjFhZGRja2Ry
-cWl4amU0YS54bi0tcDFhaYIxeG4tLWIxYWZrZmtsYnFiaWVneC54bi0tYjFhZGRj
-a2RycWl4amU0YS54bi0tcDFhaYI1eG4tLWIxYWZtZ2tiZGZhdGRobjlkMWMueG4t
-LWIxYWRkY2tkcnFpeGplNGEueG4tLXAxYWmCKXhuLS1iMWFnOGFnLnhuLS1iMWFk
-ZGNrZHJxaXhqZTRhLnhuLS1wMWFpgix4bi0tYzFha2VjZDJhdi54bi0tYjFhZGRj
-a2RycWl4amU0YS54bi0tcDFhaYIueG4tLWUxYWFqaGp3eDFhby54bi0tYjFhZGRj
-a2RycWl4amU0YS54bi0tcDFhaYIueG4tLWUxYWFxaWJjZXMyZC54bi0tYjFhZGRj
-a2RycWl4amU0YS54bi0tcDFhaYIreG4tLWUxYWdmM2Fmei54bi0tYjFhZGRja2Ry
-cWl4amU0YS54bi0tcDFhaYIpeG4tLWcxYW5pN2MueG4tLWIxYWRkY2tkcnFpeGpl
-NGEueG4tLXAxYWmCKnhuLS1oMWFhZXlmaC54bi0tYjFhZGRja2RycWl4amU0YS54
-bi0tcDFhaYIxeG4tLWgxYWFqY2ZmamtoeTlpai54bi0tYjFhZGRja2RycWl4amU0
-YS54bi0tcDFhaYIseG4tLWgxYWRiYzRkeWIueG4tLWIxYWRkY2tkcnFpeGplNGEu
-eG4tLXAxYWmCLXhuLS1pMWFqZmRmZGcyZy54bi0tYjFhZGRja2RycWl4amU0YS54
-bi0tcDFhaYIoeG4tLWoxYWEwYS54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFh
-aYIweG4tLWoxYWFjZGpib2tncjhpLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1w
-MWFpgjB4bi0tajFhY2NoYmdna2dyOWkueG4tLWIxYWRkY2tkcnFpeGplNGEueG4t
-LXAxYWmCJnhuLS1qMWFrLnhuLS1iMWFkZGNrZHJxaXhqZTRhLnhuLS1wMWFpgiZ4
-bi0tajFhby54bi0tYjFhZGRja2RycWl4amU0YS54bi0tcDFhaTALBgNVHQ8EBAMC
-BaAwHQYDVR0OBBYEFFU2xisBm/RVjo2zNeCzQK2N78AQMB8GA1UdIwQYMBaAFFU2
-xisBm/RVjo2zNeCzQK2N78AQMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL
-BQADggGBAHfICTUOiMxH2EItxheXQK7Am7+bxFRBWXk+BHrOL+8SsksuBB+Msne6
-ARnIOk7no1GnDGwwT3xRkSYcc8LRIFRBweEM3DQmJoBZIo/Tqhipssi9htdVxIO2
-lmvbhBxfuR+b2KJjP9zo2fWjqfcjlg3bxfblV+iKWmdLp6Of53+NAhU9U1cBk2FU
-U33UEibmd4bEWBbOcrYEA2/CFyWJq3D/S57zm3DUXofaHxn8KjGr9Hzu4ADhRUQ9
-XwKSf3wV5OPXRzoDzl1VQLt0tHPVfziiYNKITA/zXdWPGzAEbyYVtgLgMNpy/nN/
-9ied93lJOzL7clWsBmAMGA6m/rh32rwYcI5jFRG1FuzKXJeuSQ3l/FLgrubi/PTv
-XuRDxFtR4srcRicawRxHqjLqq8F3c1Bvt/fJBj4kYt6B1fuYeLZnGWaYQIYtQoGw
-9q77oqVNXBxTAg0sBhTBPuo+TfDTu84MhIVuoyoPNpM0jv5q9IbuDLVXXnmefu5X
-+salagvHrA==
+MIIBXzCCAQmgAwIBAgIUW8md6i2eWtO6gAZjtlbIlnakm2IwDQYJKoZIhvcNAQEL
+BQAwDjEMMAoGA1UEAwwDQmFyMB4XDTIxMTAwMTAwMDAwMFoXDTIyMTAwMTAwMDAw
+MFowDjEMMAoGA1UEAwwDRm9vMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAN3IfYOl
+nfIcr2TmizqHBijYKkGfdm1DnoF2SwaM83o9+4iTPf9ynxmPGZMiYe5iCV47dld7
+yY2mnbSQC8Rl7DMCAwEAAaM/MD0wOwYDVR0RBDQwMoIweE4tLTEwOS0zdmViYTZk
+anMxYmZ4bGZteDZjOWcueG4tLWYxYXdpLnhuLS1wMWFpMA0GCSqGSIb3DQEBCwUA
+A0EAK3IB/wsFavcn5ygkniW8CvCxxY8Z4cS54dY4OnQO+dZSk0FDSYAl0dHUreW6
+NJxry1d8eWzu9gKqZ2KX2hrWXA==
 -----END CERTIFICATE-----

--- a/v3/testdata/idnMalformedUnicode.pem
+++ b/v3/testdata/idnMalformedUnicode.pem
@@ -1,95 +1,38 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 1 (0x1)
-    Signature Algorithm: sha256WithRSAEncryption
-        Issuer: CN=Mother Nature, OU=Everything, O=Mother Nature/postalCode=postalcode, C=US, GN=givenname, SN=surname
+        Serial Number:
+            70:34:4b:81:54:e6:f8:c2:0c:f0:f9:c0:2e:8e:ba:7b:78:2e:bd:57
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN = Bar
         Validity
-            Not Before: Aug 25 14:52:58 2017 GMT
-            Not After : Nov  6 15:52:58 2017 GMT
-        Subject: CN=gov.us, OU=Chaos, O=org/street=3210 Holly Mill Run, ST=province/postalCode=30062, GN=hello, SN=surname
+            Not Before: Oct  1 00:00:00 2021 GMT
+            Not After : Oct  1 00:00:00 2022 GMT
+        Subject: CN = Foo
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (512 bit)
                 Modulus:
-                    00:9d:7c:89:cf:e3:7a:53:41:68:56:1f:d6:44:63:
-                    79:5b:a4:e6:14:bb:9b:03:3a:32:38:a8:e3:b7:24:
-                    f9:9a:bb:6d:3e:f3:4d:f9:13:12:70:ca:7e:90:00:
-                    97:7b:d0:68:cd:d0:c9:bd:e5:18:c8:12:07:65:99:
-                    b6:52:9d:0d:5f:38:19:d1:d6:ff:e9:ac:c7:25:5f:
-                    8b:ad:c5:6c:e6:3f:f1:1c:82:ff:c5:e0:7b:e0:69:
-                    05:59:0e:fc:47:e1:48:aa:1b:02:98:9d:a9:47:f7:
-                    05:25:33:96:89:d9:b7:14:f2:95:b7:62:78:8c:0d:
-                    75:88:35:71:e4:57:7f:6c:a7:b2:be:e8:64:dc:a4:
-                    91:01:ae:45:07:d7:95:3a:cb:88:42:cd:cb:0f:90:
-                    6b:93:82:ad:f5:78:0a:96:cf:60:a3:e7:5a:b1:20:
-                    f2:31:20:a9:8f:b6:52:ab:0d:f4:ca:bb:21:64:77:
-                    b5:8a:a4:f6:1c:43:3b:82:25:6a:b6:61:d4:6d:0d:
-                    25:88:11:8a:0c:ab:4b:18:25:85:40:f4:16:da:8f:
-                    6c:ad:6d:2e:52:9b:68:26:50:82:6c:5c:c9:26:ed:
-                    1a:ac:d1:55:3d:78:57:bd:43:19:11:02:29:ff:41:
-                    98:01:8c:f2:8a:82:35:3c:b9:8e:cd:79:76:f8:73:
-                    e6:2f
+                    00:90:4d:1f:99:6f:d0:42:63:26:db:1e:b5:ba:55:
+                    dd:e9:42:ec:d8:26:ed:fa:e8:21:8f:a1:64:5f:ee:
+                    14:e8:64:12:7e:b2:7f:57:a0:d6:1c:fb:d5:02:ff:
+                    89:7d:50:2b:a7:ca:7a:23:0c:56:42:33:38:46:69:
+                    ae:f6:63:c4:2f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
-            X509v3 Key Usage: critical
-                Digital Signature, Key Encipherment
-            X509v3 Extended Key Usage: 
-                TLS Web Client Authentication, TLS Web Server Authentication
-            X509v3 Basic Constraints: critical
-                CA:TRUE
-            X509v3 Authority Key Identifier: 
-                keyid:01:02:03
-
-            Authority Information Access: 
-                OCSP - URI:http://theca.net/ocsp
-                CA Issuers - URI:http://theca.net/totallythecert.crt
-
             X509v3 Subject Alternative Name: 
-                DNS:xn--12311613412431243.com
-            X509v3 Certificate Policies: 
-                Policy: X509v3 Any Policy
-
+                DNS:xN--12311613412431243.com
     Signature Algorithm: sha256WithRSAEncryption
-         89:91:9b:2d:3c:54:f6:f0:2d:1c:16:56:ec:b5:f1:4a:1c:9b:
-         a6:54:11:eb:2f:94:b9:f0:10:89:44:0e:87:8b:59:78:4a:ef:
-         9e:33:d2:e1:5e:9b:18:7f:2a:dd:09:d0:27:e7:e8:e2:69:dc:
-         cd:09:db:95:89:ca:0d:f7:52:84:b5:7e:56:d4:4d:85:19:e3:
-         50:21:11:73:99:c4:13:28:6b:66:2e:a5:76:f2:33:0e:19:e2:
-         8c:33:9c:f7:96:ec:5f:41:b4:7f:73:d4:24:60:f6:90:3a:50:
-         84:da:93:b0:36:69:6f:1c:7b:74:4f:59:65:d3:0d:b9:00:a2:
-         65:75:97:ad:82:39:f4:c1:bb:8e:b1:55:db:3d:79:65:32:31:
-         a6:22:de:e8:16:16:8b:c9:a9:28:3e:e9:c7:e9:4f:8f:ba:60:
-         39:1e:d5:ac:ce:7d:7e:92:43:86:ca:e6:cd:3c:d0:6d:bd:fd:
-         ec:d7:d6:d0:28:71:6a:f0:9b:98:39:8c:70:2e:f9:05:9e:01:
-         51:8c:a0:23:19:23:ef:fb:8f:0d:94:4c:e0:8e:ce:5b:14:e9:
-         e8:4a:51:a5:67:4c:bb:b3:fb:3a:b2:e7:f3:8a:2d:b7:fd:d9:
-         f7:06:11:91:35:78:f1:c9:4b:a7:77:cd:0d:80:80:63:f1:3d:
-         72:7d:90:a5
+         1b:1b:2c:9b:92:48:11:65:ba:d5:a9:ce:40:1b:11:49:a6:60:
+         5d:05:7d:04:5b:f4:a8:cf:38:7c:b8:67:68:6c:36:b8:ae:a0:
+         7f:89:f1:9d:b4:cc:64:e8:a9:1f:9b:6c:2b:d1:e4:4b:97:1b:
+         e3:9d:b0:5c:40:8a:c1:f7:e8:c4
 -----BEGIN CERTIFICATE-----
-MIIEjTCCA3egAwIBAgIBATALBgkqhkiG9w0BAQswgY8xFjAUBgNVBAMTDU1vdGhl
-ciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcxFjAUBgNVBAoTDU1vdGhlciBO
-YXR1cmUxEzARBgNVBBETCnBvc3RhbGNvZGUxCzAJBgNVBAYTAlVTMRIwEAYDVQQq
-EwlnaXZlbm5hbWUxEDAOBgNVBAQTB3N1cm5hbWUxADAeFw0xNzA4MjUxNDUyNTha
-Fw0xNzExMDYxNTUyNThaMIGUMQ8wDQYDVQQDEwZnb3YudXMxDjAMBgNVBAsTBUNo
-YW9zMQwwCgYDVQQKEwNvcmcxHDAaBgNVBAkTEzMyMTAgSG9sbHkgTWlsbCBSdW4x
-ETAPBgNVBAgTCHByb3ZpbmNlMQ4wDAYDVQQREwUzMDA2MjEOMAwGA1UEKhMFaGVs
-bG8xEDAOBgNVBAQTB3N1cm5hbWUxADCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
-AQoCggEBAJ18ic/jelNBaFYf1kRjeVuk5hS7mwM6Mjio47ck+Zq7bT7zTfkTEnDK
-fpAAl3vQaM3Qyb3lGMgSB2WZtlKdDV84GdHW/+msxyVfi63FbOY/8RyC/8Xge+Bp
-BVkO/EfhSKobApidqUf3BSUzlonZtxTylbdieIwNdYg1ceRXf2ynsr7oZNykkQGu
-RQfXlTrLiELNyw+Qa5OCrfV4CpbPYKPnWrEg8jEgqY+2UqsN9Mq7IWR3tYqk9hxD
-O4IlarZh1G0NJYgRigyrSxglhUD0FtqPbK1tLlKbaCZQgmxcySbtGqzRVT14V71D
-GRECKf9BmAGM8oqCNTy5js15dvhz5i8CAwEAAaOB8DCB7TAOBgNVHQ8BAf8EBAMC
-AKAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMB
-Af8wDgYDVR0jBAcwBYADAQIDMGIGCCsGAQUFBwEBBFYwVDAhBggrBgEFBQcwAYYV
-aHR0cDovL3RoZWNhLm5ldC9vY3NwMC8GCCsGAQUFBzAChiNodHRwOi8vdGhlY2Eu
-bmV0L3RvdGFsbHl0aGVjZXJ0LmNydDAkBgNVHREEHTAbghl4bi0tMTIzMTE2MTM0
-MTI0MzEyNDMuY29tMBEGA1UdIAQKMAgwBgYEVR0gADALBgkqhkiG9w0BAQsDggEB
-AImRmy08VPbwLRwWVuy18Uocm6ZUEesvlLnwEIlEDoeLWXhK754z0uFemxh/Kt0J
-0Cfn6OJp3M0J25WJyg33UoS1flbUTYUZ41AhEXOZxBMoa2YupXbyMw4Z4owznPeW
-7F9BtH9z1CRg9pA6UITak7A2aW8ce3RPWWXTDbkAomV1l62COfTBu46xVds9eWUy
-MaYi3ugWFovJqSg+6cfpT4+6YDke1azOfX6SQ4bK5s080G29/ezX1tAocWrwm5g5
-jHAu+QWeAVGMoCMZI+/7jw2UTOCOzlsU6ehKUaVnTLuz+zqy5/OKLbf92fcGEZE1
-ePHJS6d3zQ2AgGPxPXJ9kKU=
+MIIBRzCB8qADAgECAhRwNEuBVOb4wgzw+cAujrp7eC69VzANBgkqhkiG9w0BAQsF
+ADAOMQwwCgYDVQQDDANCYXIwHhcNMjExMDAxMDAwMDAwWhcNMjIxMDAxMDAwMDAw
+WjAOMQwwCgYDVQQDDANGb28wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAkE0fmW/Q
+QmMm2x61ulXd6ULs2Cbt+ughj6FkX+4U6GQSfrJ/V6DWHPvVAv+JfVArp8p6IwxW
+QjM4Rmmu9mPELwIDAQABoygwJjAkBgNVHREEHTAbghl4Ti0tMTIzMTE2MTM0MTI0
+MzEyNDMuY29tMA0GCSqGSIb3DQEBCwUAA0EAGxssm5JIEWW61anOQBsRSaZgXQV9
+BFv0qM84fLhnaGw2uK6gf4nxnbTMZOipH5tsK9HkS5cb452wXECKwffoxA==
 -----END CERTIFICATE-----


### PR DESCRIPTION
`lint_idn_dnsname_malformed_unicode` and `lint_idn_dnsname_must_be_nfc` detect XN-labels using a case-sensitive comparison of the IDNA ACE prefix ("xn--"). As a result, some "fake A labels" or labels that whose Unicode representation is not NFC-normalized may not be correctly detected.