### PR TITLE
Add BeforeOrOn and OnOrAfter util functions

### DIFF
--- a/v3/lint/base.go
+++ b/v3/lint/base.go
@@ -77,12 +77,9 @@ type Lint struct {
 // if IneffectiveDate is zero then only EffectiveDate is checked. If both EffectiveDate
 // and IneffectiveDate are zero then CheckEffective always returns true.
 func (l *Lint) CheckEffective(c *x509.Certificate) bool {
-	afterOrOnEffective := l.EffectiveDate.IsZero() ||
-		c.NotBefore.After(l.EffectiveDate) ||
-		c.NotBefore.Equal(l.EffectiveDate)
-	beforeIneffective := l.IneffectiveDate.IsZero() ||
-		c.NotBefore.Before(l.IneffectiveDate)
-	return afterOrOnEffective && beforeIneffective
+	onOrAfterEffective := l.EffectiveDate.IsZero() || util.OnOrAfter(c.NotBefore, l.EffectiveDate)
+	strictlyBeforeIneffective := l.IneffectiveDate.IsZero() || c.NotBefore.Before(l.IneffectiveDate)
+	return onOrAfterEffective && strictlyBeforeIneffective
 }
 
 // Execute runs the lint against a certificate. For lints that are

--- a/v3/lints/cabf_br/lint_rsa_mod_less_than_2048_bits.go
+++ b/v3/lints/cabf_br/lint_rsa_mod_less_than_2048_bits.go
@@ -41,7 +41,7 @@ func NewRsaParsedTestsKeySize() lint.LintInterface {
 
 func (l *rsaParsedTestsKeySize) CheckApplies(c *x509.Certificate) bool {
 	_, ok := c.PublicKey.(*rsa.PublicKey)
-	return ok && c.PublicKeyAlgorithm == x509.RSA && c.NotAfter.After(util.NoRSA1024Date.Add(-1))
+	return ok && c.PublicKeyAlgorithm == x509.RSA && util.OnOrAfter(c.NotAfter, util.NoRSA1024Date)
 }
 
 func (l *rsaParsedTestsKeySize) Execute(c *x509.Certificate) *lint.LintResult {

--- a/v3/lints/cabf_br/lint_sub_cert_sha1_expiration_too_long.go
+++ b/v3/lints/cabf_br/lint_sub_cert_sha1_expiration_too_long.go
@@ -37,7 +37,7 @@ func init() {
 		Description:   "Subscriber certificates using the SHA-1 algorithm SHOULD NOT have an expiration date later than 1 Jan 2017",
 		Citation:      "BRs: 7.1.3",
 		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: time.Date(2015, time.January, 16, 0, 0, 0, 0, time.UTC),
+		EffectiveDate: util.CABFBRs_1_2_1_Date,
 		Lint:          NewSha1ExpireLong,
 	})
 }
@@ -52,8 +52,10 @@ func (l *sha1ExpireLong) CheckApplies(c *x509.Certificate) bool {
 		c.SignatureAlgorithm == x509.ECDSAWithSHA1)
 }
 
+var sha1SunsetDate = time.Date(2017, time.January, 1, 0, 0, 0, 0, time.UTC)
+
 func (l *sha1ExpireLong) Execute(c *x509.Certificate) *lint.LintResult {
-	if c.NotAfter.After(time.Date(2017, time.January, 1, 0, 0, 0, 0, time.UTC)) {
+	if c.NotAfter.After(sha1SunsetDate) {
 		return &lint.LintResult{Status: lint.Warn}
 	} else {
 		return &lint.LintResult{Status: lint.Pass}

--- a/v3/util/time.go
+++ b/v3/util/time.go
@@ -60,6 +60,7 @@ var (
 	MozillaPolicy24Date         = time.Date(2017, time.February, 28, 0, 0, 0, 0, time.UTC)
 	MozillaPolicy241Date        = time.Date(2017, time.March, 31, 0, 0, 0, 0, time.UTC)
 	MozillaPolicy27Date         = time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)
+	CABFBRs_1_2_1_Date          = time.Date(2015, time.January, 16, 0, 0, 0, 0, time.UTC)
 	CABFBRs_1_6_9_Date          = time.Date(2020, time.March, 27, 0, 0, 0, 0, time.UTC)
 	CABFBRs_1_7_1_Date          = time.Date(2020, time.August, 20, 0, 0, 0, 0, time.UTC)
 	AppleReducedLifetimeDate    = time.Date(2020, time.September, 1, 0, 0, 0, 0, time.UTC)
@@ -119,4 +120,14 @@ func GetTimes(cert *x509.Certificate) (asn1.RawValue, asn1.RawValue) {
 		return asn1.RawValue{}, asn1.RawValue{}
 	}
 	return firstDate, secondDate
+}
+
+// BeforeOrOn returns whether left is before or strictly equal to right.
+func BeforeOrOn(left, right time.Time) bool {
+	return !left.After(right)
+}
+
+// OnOrAfter returns whether left is after or strictly equal to right.
+func OnOrAfter(left, right time.Time) bool {
+	return !left.Before(right)
 }

--- a/v3/util/time_test.go
+++ b/v3/util/time_test.go
@@ -1,0 +1,62 @@
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBeforeOrOn(t *testing.T) {
+	data := []struct {
+		left  time.Time
+		right time.Time
+		want  bool
+	}{
+		{
+			time.Date(2021, time.February, 1, 1, 1, 58, 0, time.UTC),
+			time.Date(2021, time.February, 1, 1, 1, 59, 0, time.UTC),
+			true,
+		},
+		{
+			time.Date(2021, time.February, 1, 1, 1, 59, 0, time.UTC),
+			time.Date(2021, time.February, 1, 1, 1, 59, 0, time.UTC),
+			true,
+		}, {
+			time.Date(2021, time.February, 1, 1, 2, 0, 0, time.UTC),
+			time.Date(2021, time.February, 1, 1, 1, 59, 0, time.UTC),
+			false,
+		}}
+	for _, test := range data {
+		got := BeforeOrOn(test.left, test.right)
+		if got != test.want {
+			t.Errorf("Got %v from %v", got, test)
+		}
+	}
+}
+
+func TestOnOrAfter(t *testing.T) {
+	data := []struct {
+		left  time.Time
+		right time.Time
+		want  bool
+	}{
+		{
+			time.Date(2021, time.February, 1, 1, 1, 58, 0, time.UTC),
+			time.Date(2021, time.February, 1, 1, 1, 59, 0, time.UTC),
+			false,
+		},
+		{
+			time.Date(2021, time.February, 1, 1, 1, 59, 0, time.UTC),
+			time.Date(2021, time.February, 1, 1, 1, 59, 0, time.UTC),
+			true,
+		}, {
+			time.Date(2021, time.February, 1, 1, 2, 0, 0, time.UTC),
+			time.Date(2021, time.February, 1, 1, 1, 59, 0, time.UTC),
+			true,
+		}}
+	for _, test := range data {
+		got := OnOrAfter(test.left, test.right)
+		if got != test.want {
+			t.Errorf("Got %v from %v", got, test)
+		}
+	}
+}


### PR DESCRIPTION
The standard library does not offer functions such as these and reading...

`!c.NotBefore.Before(date)` -> On or after
`!c.NotBefore.After(date)` -> Before or on

...is difficult to keep in your head straight while also comparing it with source requirements.

While I was grepping around for `.After` calls I also found some opportunities for datetime cleanups.