### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/v3/cmd/zlint-gtld-update/main.go
+++ b/v3/cmd/zlint-gtld-update/main.go
@@ -23,7 +23,6 @@ import (
 	"go/format"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -138,7 +137,7 @@ func getData(url string) ([]byte, error) {
 			url, http.StatusOK, resp.StatusCode)
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error reading response "+
 			"body from %q : %s",

--- a/v3/cmd/zlint/main.go
+++ b/v3/cmd/zlint/main.go
@@ -21,7 +21,7 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"sort"
@@ -130,7 +130,7 @@ func main() {
 }
 
 func doLint(inputFile *os.File, inform string, registry lint.Registry) {
-	fileBytes, err := ioutil.ReadAll(inputFile)
+	fileBytes, err := io.ReadAll(inputFile)
 	if err != nil {
 		log.Fatalf("unable to read file %s: %s", inputFile.Name(), err)
 	}

--- a/v3/integration/config.go
+++ b/v3/integration/config.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -74,12 +73,12 @@ func (f dataFile) DownloadTo(dir string) error {
 		reader = bzip2.NewReader(reader)
 	}
 
-	dataBytes, err := ioutil.ReadAll(reader)
+	dataBytes, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}
 
-	if err := ioutil.WriteFile(p, dataBytes, 0644); err != nil {
+	if err := os.WriteFile(p, dataBytes, 0644); err != nil {
 		return err
 	}
 
@@ -97,7 +96,7 @@ type config struct {
 // the given file or returns an error if reading or unmarshaling the config file
 // fails.
 func loadConfig(file string) (*config, error) {
-	jsonBytes, err := ioutil.ReadFile(file)
+	jsonBytes, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +150,7 @@ func (c *config) Save(file string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(file, jsonBytes, 0644)
+	return os.WriteFile(file, jsonBytes, 0644)
 }
 
 // Valid returns an error if the config has an empty CacheDir, no Files, or if

--- a/v3/integration/lints/lint/lint.go
+++ b/v3/integration/lints/lint/lint.go
@@ -19,7 +19,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -161,7 +161,7 @@ func Parse(path string) (*ast.File, *File, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/v3/integration/lints/lints/not_committing_genTestCerts.go
+++ b/v3/integration/lints/lints/not_committing_genTestCerts.go
@@ -18,7 +18,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"go/ast"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/zmap/zlint/v3/integration/lints/lint"
@@ -33,7 +33,7 @@ func (i *NotCommittingGenTestCerts) CheckApplies(tree *ast.File, file *lint.File
 }
 
 func (i *NotCommittingGenTestCerts) Lint(tree *ast.File, file *lint.File) *lint.Result {
-	contents, err := ioutil.ReadFile(file.Path)
+	contents, err := os.ReadFile(file.Path)
 	if err != nil {
 		return lint.NewResult(fmt.Sprintf("failed to open %s", file.Name))
 	}

--- a/v3/lints/template_test.go
+++ b/v3/lints/template_test.go
@@ -3,7 +3,6 @@ package lints
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +31,7 @@ func checkForLeftovers(filename string) error {
 		"Change this to match source TEXT",
 	}
 
-	src, err := ioutil.ReadFile(filename)
+	src, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}

--- a/v3/test/helpers.go
+++ b/v3/test/helpers.go
@@ -19,7 +19,7 @@ package test
 import (
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/zmap/zcrypto/x509"
@@ -70,7 +70,7 @@ func TestLintCert(lintName string, cert *x509.Certificate) *lint.LintResult {
 func ReadTestCert(inPath string) *x509.Certificate {
 	fullPath := fmt.Sprintf("../../testdata/%s", inPath)
 
-	data, err := ioutil.ReadFile(fullPath)
+	data, err := os.ReadFile(fullPath)
 	if err != nil {
 		panic(fmt.Sprintf(
 			"Unable to read test certificate from %q - %q "+


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.