### PR TITLE
Add Microsoft to the known-ZLint users

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Here are some projects/CAs known to integrate with ZLint in some fashion:
 * [Izenpe](https://www.izenpe.eus/)
 * [Let's Encrypt](https://letsencrypt.org) and [Boulder](https://github.com/letsencrypt/boulder)
 * [Microsec](https://www.microsec.com/)
+* [Microsoft](https://www.microsoft.com)
 * [Nexus Certificate Manager](https://doc.nexusgroup.com/display/PUB/Smart+ID+Certificate+Manager)
 * [QuoVadis](https://www.quovadisglobal.com/)
 * [Sectigo](https://sectigo.com/) and [crt.sh](https://crt.sh)


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1705419#c6

> Additionally, we have already started using ZLint at the end of our issuance process, so that we will fail fast and identify any additional cert mis-issuances as we work through our remediation list.