### PR TITLE
Lint for RSA close prime Fermat factorization susceptibility

### DIFF
--- a/v3/lints/community/lint_rsa_fermat_factorization.go
+++ b/v3/lints/community/lint_rsa_fermat_factorization.go
@@ -1,0 +1,119 @@
+package community
+
+/*
+ * ZLint Copyright 2021 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"crypto/rsa"
+	"fmt"
+	"math/big"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+// @TODO this lint would benefit from https://github.com/zmap/zlint/pull/648 so that we can set custom rounds
+
+type fermatFactorization struct {
+	rounds int
+}
+
+func init() {
+	lint.RegisterLint(&lint.Lint{
+		Name: "e_rsa_fermat_factorization",
+		Description: "RSA key pairs that are too close to each other are susceptible to the Fermat Factorization " +
+			"Method (for more information please see https://en.wikipedia.org/wiki/Fermat%27s_factorization_method " +
+			"and https://fermatattack.secvuln.info/)",
+		Citation:      "Pierre de Fermat",
+		Source:        lint.Community,
+		EffectiveDate: util.ZeroDate,
+		Lint:          NewFermatFactorization,
+	})
+}
+
+func NewFermatFactorization() lint.LintInterface {
+	return &fermatFactorization{rounds: 1000}
+}
+
+func (l *fermatFactorization) CheckApplies(c *x509.Certificate) bool {
+	_, ok := c.PublicKey.(*rsa.PublicKey)
+	return ok && c.PublicKeyAlgorithm == x509.RSA
+}
+
+func (l *fermatFactorization) Execute(c *x509.Certificate) *lint.LintResult {
+	err := checkPrimeFactorsTooClose(c.PublicKey.(*rsa.PublicKey).N, l.rounds)
+	if err != nil {
+		return &lint.LintResult{
+			Status:  lint.Error,
+			Details: fmt.Sprintf("this certificate's RSA key pair is susceptible to Fermat factorization, %s", err.Error())}
+	} else {
+		return &lint.LintResult{Status: lint.Pass}
+	}
+}
+
+// Source: Let's Encrypt, Boulder
+// Author: Aaron Gable (https://github.com/aarongable)
+// Commit: https://github.com/letsencrypt/boulder/commit/89000bd61cfc6f373cb48b6f046d4fce7df5468e
+//
+// Returns an error if the modulus n is able to be factored into primes p and q
+// via Fermat's factorization method. This method relies on the two primes being
+// very close together, which means that they were almost certainly not picked
+// independently from a uniform random distribution. Basically, if we can factor
+// the key this easily, so can anyone else.
+func checkPrimeFactorsTooClose(n *big.Int, rounds int) error {
+	// Pre-allocate some big numbers that we'll use a lot down below.
+	one := big.NewInt(1)
+	bb := new(big.Int)
+
+	// Any odd integer is equal to a difference of squares of integers:
+	//   n = a^2 - b^2 = (a + b)(a - b)
+	// Any RSA public key modulus is equal to a product of two primes:
+	//   n = pq
+	// Here we try to find values for a and b, since doing so also gives us the
+	// prime factors p = (a + b) and q = (a - b).
+
+	// We start with a close to the square root of the modulus n, to start with
+	// two candidate prime factors that are as close together as possible and
+	// work our way out from there. Specifically, we set a = ceil(sqrt(n)), the
+	// first integer greater than the square root of n. Unfortunately, big.Int's
+	// built-in square root function takes the floor, so we have to add one to get
+	// the ceil.
+	a := new(big.Int)
+	a.Sqrt(n).Add(a, one)
+
+	// We calculate b2 to see if it is a perfect square (i.e. b^2), and therefore
+	// b is an integer. Specifically, b2 = a^2 - n.
+	b2 := new(big.Int)
+	b2.Mul(a, a).Sub(b2, n)
+
+	for i := 0; i < rounds; i++ {
+		// To see if b2 is a perfect square, we take its square root, square that,
+		// and check to see if we got the same result back.
+		bb.Sqrt(b2).Mul(bb, bb)
+		if b2.Cmp(bb) == 0 {
+			// b2 is a perfect square, so we've found integer values of a and b,
+			// and can easily compute p and q as their sum and difference.
+			bb.Sqrt(bb)
+			p := new(big.Int).Add(a, bb)
+			q := new(big.Int).Sub(a, bb)
+			return fmt.Errorf("public modulus n = pq factored into p: %s; q: %s", p, q)
+		}
+
+		// Set up the next iteration by incrementing a by one and recalculating b2.
+		a.Add(a, one)
+		b2.Mul(a, a).Sub(b2, n)
+	}
+	return nil
+}

--- a/v3/lints/community/lint_rsa_fermat_factorization.go
+++ b/v3/lints/community/lint_rsa_fermat_factorization.go
@@ -24,10 +24,8 @@ import (
 	"github.com/zmap/zlint/v3/util"
 )
 
-// @TODO this lint would benefit from https://github.com/zmap/zlint/pull/648 so that we can set custom rounds
-
 type fermatFactorization struct {
-	rounds int
+	Rounds int `comment:"The number of iterations to attempt Fermat factorization. Note that when executing this lint against many (tens of thousands of certificates) that this configuration may have a profound affect on performance. For more information, please see https://fermatattack.secvuln.info/"`
 }
 
 func init() {
@@ -44,7 +42,11 @@ func init() {
 }
 
 func NewFermatFactorization() lint.LintInterface {
-	return &fermatFactorization{rounds: 100}
+	return &fermatFactorization{}
+}
+
+func (l *fermatFactorization) Configure() interface{} {
+	return l
 }
 
 func (l *fermatFactorization) CheckApplies(c *x509.Certificate) bool {
@@ -53,7 +55,7 @@ func (l *fermatFactorization) CheckApplies(c *x509.Certificate) bool {
 }
 
 func (l *fermatFactorization) Execute(c *x509.Certificate) *lint.LintResult {
-	err := checkPrimeFactorsTooClose(c.PublicKey.(*rsa.PublicKey).N, l.rounds)
+	err := checkPrimeFactorsTooClose(c.PublicKey.(*rsa.PublicKey).N, l.Rounds)
 	if err != nil {
 		return &lint.LintResult{
 			Status:  lint.Error,

--- a/v3/lints/community/lint_rsa_fermat_factorization.go
+++ b/v3/lints/community/lint_rsa_fermat_factorization.go
@@ -42,7 +42,7 @@ func init() {
 }
 
 func NewFermatFactorization() lint.LintInterface {
-	return &fermatFactorization{}
+	return &fermatFactorization{Rounds: 100}
 }
 
 func (l *fermatFactorization) Configure() interface{} {

--- a/v3/lints/community/lint_rsa_fermat_factorization.go
+++ b/v3/lints/community/lint_rsa_fermat_factorization.go
@@ -48,9 +48,8 @@ func NewFermatFactorization() lint.LintInterface {
 }
 
 func (l *fermatFactorization) CheckApplies(c *x509.Certificate) bool {
-	return false
-	//_, ok := c.PublicKey.(*rsa.PublicKey)
-	//return ok && c.PublicKeyAlgorithm == x509.RSA
+	_, ok := c.PublicKey.(*rsa.PublicKey)
+	return ok && c.PublicKeyAlgorithm == x509.RSA
 }
 
 func (l *fermatFactorization) Execute(c *x509.Certificate) *lint.LintResult {

--- a/v3/lints/community/lint_rsa_fermat_factorization.go
+++ b/v3/lints/community/lint_rsa_fermat_factorization.go
@@ -44,12 +44,13 @@ func init() {
 }
 
 func NewFermatFactorization() lint.LintInterface {
-	return &fermatFactorization{rounds: 1000}
+	return &fermatFactorization{rounds: 100}
 }
 
 func (l *fermatFactorization) CheckApplies(c *x509.Certificate) bool {
-	_, ok := c.PublicKey.(*rsa.PublicKey)
-	return ok && c.PublicKeyAlgorithm == x509.RSA
+	return false
+	//_, ok := c.PublicKey.(*rsa.PublicKey)
+	//return ok && c.PublicKeyAlgorithm == x509.RSA
 }
 
 func (l *fermatFactorization) Execute(c *x509.Certificate) *lint.LintResult {

--- a/v3/lints/community/lint_rsa_fermat_factorization_test.go
+++ b/v3/lints/community/lint_rsa_fermat_factorization_test.go
@@ -3,6 +3,7 @@ package community
 import (
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -95,5 +96,25 @@ func TestPassFermatFactorizationWithCert(t *testing.T) {
 	out := test.TestLint("e_rsa_fermat_factorization", inputPath)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func BenchmarkFermatFactorization_Execute(b *testing.B) {
+	//	cpu: Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz
+	//	BenchmarkFermatFactorization_Execute
+	//	BenchmarkFermatFactorization_Execute/0
+	//	BenchmarkFermatFactorization_Execute/0-8 	1000000000	         0.0005302 ns/o
+	cert := test.ReadTestCert("rsassapssWithSHA512.pem")
+	config, err := lint.NewConfigFromString(`
+[e_rsa_fermat_factorization]
+Rounds = 100
+`)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		b.Run(strconv.FormatInt(int64(i), 10), func(b *testing.B) {
+			test.TestLintCert("e_rsa_fermat_factorization", cert, config)
+		})
 	}
 }

--- a/v3/lints/community/lint_rsa_fermat_factorization_test.go
+++ b/v3/lints/community/lint_rsa_fermat_factorization_test.go
@@ -1,0 +1,99 @@
+package community
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestCheckPrimeFactorsTooClose(t *testing.T) {
+	data := []struct {
+		p          *big.Int
+		q          *big.Int
+		n          *big.Int
+		roundsLow  int
+		roundsHigh int
+	}{
+		{
+			p:          big.NewInt(101),
+			q:          big.NewInt(59),
+			n:          big.NewInt(5959),
+			roundsLow:  2,
+			roundsHigh: 3,
+		},
+		{
+			p: bigIntOrDie("12451309173743450529024753538187635497858772172998414407116324997634262083672423797183640278969532658774374576700091736519352600717664126766443002156788367"),
+			q: bigIntOrDie("12451309173743450529024753538187635497858772172998414407116324997634262083672423797183640278969532658774374576700091736519352600717664126766443002156788337"),
+			n: big.NewInt(0).Mul(
+				bigIntOrDie("12451309173743450529024753538187635497858772172998414407116324997634262083672423797183640278969532658774374576700091736519352600717664126766443002156788367"),
+				bigIntOrDie("12451309173743450529024753538187635497858772172998414407116324997634262083672423797183640278969532658774374576700091736519352600717664126766443002156788337")),
+			roundsLow:  0,
+			roundsHigh: 1,
+		},
+		{
+			p: bigIntOrDie("11779932606551869095289494662458707049283241949932278009554252037480401854504909149712949171865707598142483830639739537075502512627849249573564209082969463"),
+			q: bigIntOrDie("11779932606551869095289494662458707049283241949932278009554252037480401854503793357623711855670284027157475142731886267090836872063809791989556295953329083"),
+			n: big.NewInt(0).Mul(
+				bigIntOrDie("11779932606551869095289494662458707049283241949932278009554252037480401854504909149712949171865707598142483830639739537075502512627849249573564209082969463"),
+				bigIntOrDie("11779932606551869095289494662458707049283241949932278009554252037480401854503793357623711855670284027157475142731886267090836872063809791989556295953329083")),
+			roundsLow:  13,
+			roundsHigh: 14,
+		},
+	}
+	for _, test := range data {
+		test := test
+		t.Run(test.n.String(), func(t *testing.T) {
+			err := checkPrimeFactorsTooClose(test.n, test.roundsLow)
+			if err != nil {
+				t.Fatalf("factored n = %s in too few iterations, factored in %d", test.n, test.roundsLow)
+			}
+			err = checkPrimeFactorsTooClose(test.n, test.roundsHigh)
+			if err == nil {
+				t.Fatalf("failed to factor %s in %d rounds", test.n, test.roundsHigh)
+			}
+			errString := err.Error()
+			wantP := fmt.Sprintf("p: %s", test.p)
+			wantQ := fmt.Sprintf("q: %s", test.q)
+			if !strings.Contains(errString, wantP) {
+				t.Fatalf("unexpected p for n = %s, wanted '%s' but got %s", test.n, wantP, errString)
+			}
+			if !strings.Contains(errString, wantQ) {
+				t.Fatalf("unexpected q for n = %s, wanted '%s' but got %s", test.n, wantQ, errString)
+			}
+		})
+	}
+}
+
+func bigIntOrDie(from string) *big.Int {
+	b, ok := big.NewInt(0).SetString(from, 10)
+	if !ok {
+		panic(fmt.Sprintf("failed to construct prime from string '%s'", from))
+	}
+	return b
+}
+
+func TestFailFermatFactorizationWithCert(t *testing.T) {
+	// p: 12451309173743450529024753538187635497858772172998414407116324997634262083672423797183640278969532658774374576700091736519352600717664126766443002156788367
+	// q: 12451309173743450529024753538187635497858772172998414407116324997634262083672423797183640278969532658774374576700091736519352600717664126766443002156788337
+	inputPath := "rsaFermatFactorizationSusceptible.pem"
+	expected := lint.Error
+	out := test.TestLint("e_rsa_fermat_factorization", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestPassFermatFactorizationWithCert(t *testing.T) {
+	// This is actually most useful as a benchmark to tune rounds.
+	// Any RSA cert was randomly chosen.
+	inputPath := "rsassapssWithSHA512.pem"
+	expected := lint.Pass
+	out := test.TestLint("e_rsa_fermat_factorization", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/v3/testdata/rsaFermatFactorizationSusceptible.pem
+++ b/v3/testdata/rsaFermatFactorizationSusceptible.pem
@@ -1,0 +1,38 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer:
+        Validity
+            Not Before: May  1 00:00:00 2008 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject:
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (1024 bit)
+                Modulus:
+                    00:dc:c6:fd:da:ed:19:03:e5:6e:36:13:c6:39:bf:
+                    85:5a:d8:c0:34:d9:67:36:32:20:78:03:01:73:6b:
+                    e6:40:da:25:8e:ae:2c:29:81:7a:77:d8:22:16:9c:
+                    a0:8c:47:e9:67:45:5c:95:42:d1:8c:1c:cc:87:31:
+                    7c:43:09:75:f8:9e:96:dc:e7:5e:44:29:4c:6d:28:
+                    5c:96:75:aa:b0:98:07:a9:53:9f:dd:d1:a4:68:af:
+                    ba:08:a2:23:f1:0d:c5:1f:c0:09:62:5a:9b:c6:ef:
+                    43:b0:65:6f:8c:2a:75:e6:66:61:93:2a:29:04:a3:
+                    c3:9d:f8:63:d1:a8:8e:3f:1f
+                Exponent: 65537 (0x10001)
+    Signature Algorithm: ecdsa-with-SHA256
+         30:44:02:20:3b:3e:1b:e0:49:9b:f6:23:7d:a6:ee:9c:f8:45:
+         97:89:a2:9c:cb:2d:e9:09:73:70:52:df:c4:a2:a9:df:f9:8f:
+         02:20:14:b2:1a:2e:f3:a2:f3:ae:27:4d:41:51:91:f7:e9:f0:
+         01:db:bf:63:6d:31:49:7a:c0:49:7d:bd:d6:cf:f3:51
+-----BEGIN CERTIFICATE-----
+MIIBODCB4KADAgECAgEDMAoGCCqGSM49BAMCMAAwIBcNMDgwNTAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMAAwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBANzG
+/drtGQPlbjYTxjm/hVrYwDTZZzYyIHgDAXNr5kDaJY6uLCmBenfYIhacoIxH6WdF
+XJVC0YwczIcxfEMJdfieltznXkQpTG0oXJZ1qrCYB6lTn93RpGivugiiI/ENxR/A
+CWJam8bvQ7Blb4wqdeZmYZMqKQSjw534Y9Gojj8fAgMBAAGjAjAAMAoGCCqGSM49
+BAMCA0cAMEQCIDs+G+BJm/YjfabunPhFl4minMst6QlzcFLfxKKp3/mPAiAUshou
+86LzridNQVGR9+nwAdu/Y20xSXrASX291s/zUQ==
+-----END CERTIFICATE-----


### PR DESCRIPTION
@aarongable
@vanbroup

Adds a lint that checks for RSA key pair that are susceptible to Fermat's factorization method.

https://fermatattack.secvuln.info/
https://nvd.nist.gov/vuln/detail/CVE-2022-26320
https://en.wikipedia.org/wiki/Fermat%27s_factorization_method

What I find most tricky about this change is that we still seem a bit off from being able to merge support for configuring individual lints (https://github.com/zmap/zlint/pull/648) lints. This makes the value for the number of rounds a hardcoded shot-in-the-dark. My first stab is `1000`, but I'm checking to see what the perf impact is on the test corpus. On the one hand, we don't want a hardcoded value exploding our scan time. On the other hand, we don't want a hardcoded value that is too low and utterly useless in detecting dangerous primes.

EDIT:
Indeed, this lint alone has exploded the runtime of the test corpus on my local by 16x :frowning: . CICD also appears to be choking on this setting.

Addressed #673