### PR TITLE
Add new lint to block organisational unit names as of 1st September 2022

### DIFF
--- a/v3/lints/cabf_br/lint_organizational_unit_name_prohibited.go
+++ b/v3/lints/cabf_br/lint_organizational_unit_name_prohibited.go
@@ -1,7 +1,7 @@
 package cabf_br
 
 /*
- * ZLint Copyright 2021 Regents of the University of Michigan
+ * ZLint Copyright 2022 Regents of the University of Michigan
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/v3/lints/cabf_br/lint_organizational_unit_name_prohibited.go
+++ b/v3/lints/cabf_br/lint_organizational_unit_name_prohibited.go
@@ -26,7 +26,7 @@ func init() {
 		Description:   "OrganizationalUnitName is prohibited if...the certificate was issued on or after September 1, 2022",
 		Citation:      "BRs: 7.1.4.2.2-i",
 		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABFBRs_1_8_1_Date,
+		EffectiveDate: util.CABFBRs_OU_Prohibited_Date,
 		Lint:          NewOrganizationalUnitNameProhibited,
 	})
 }

--- a/v3/lints/cabf_br/lint_organizational_unit_name_prohibited.go
+++ b/v3/lints/cabf_br/lint_organizational_unit_name_prohibited.go
@@ -1,0 +1,50 @@
+package cabf_br
+
+/*
+ * ZLint Copyright 2021 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+func init() {
+	lint.RegisterLint(&lint.Lint{
+		Name:          "e_organizational_unit_name_prohibited",
+		Description:   "OrganizationalUnitName is prohibited if...the certificate was issued on or after September 1, 2022",
+		Citation:      "BRs: 7.1.4.2.2-i",
+		Source:        lint.CABFBaselineRequirements,
+		EffectiveDate: util.CABFBRs_1_8_1_Date,
+		Lint:          NewOrganizationalUnitNameProhibited,
+	})
+}
+
+type OrganizationalUnitNameProhibited struct{}
+
+func NewOrganizationalUnitNameProhibited() lint.LintInterface {
+	return &OrganizationalUnitNameProhibited{}
+}
+
+func (l *OrganizationalUnitNameProhibited) CheckApplies(c *x509.Certificate) bool {
+	return true
+}
+
+func (l *OrganizationalUnitNameProhibited) Execute(c *x509.Certificate) *lint.LintResult {
+	if c.Subject.OrganizationalUnit != nil {
+		return &lint.LintResult{Status: lint.Error}
+	}
+
+	return &lint.LintResult{Status: lint.Pass}
+}

--- a/v3/lints/cabf_br/lint_organizational_unit_name_prohibited_test.go
+++ b/v3/lints/cabf_br/lint_organizational_unit_name_prohibited_test.go
@@ -1,7 +1,7 @@
 package cabf_br
 
 /*
- * ZLint Copyright 2021 Regents of the University of Michigan
+ * ZLint Copyright 2022 Regents of the University of Michigan
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/v3/lints/cabf_br/lint_organizational_unit_name_prohibited_test.go
+++ b/v3/lints/cabf_br/lint_organizational_unit_name_prohibited_test.go
@@ -1,0 +1,55 @@
+package cabf_br
+
+/*
+ * ZLint Copyright 2021 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestOrganizationalUnitNameProhibited(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		InputFilename  string
+		ExpectedResult lint.LintStatus
+	}{
+		{
+			Name:           "Certificate issued after rule that doesn't have an OU",
+			InputFilename:  "ouAbsentAfterSep22.pem",
+			ExpectedResult: lint.Pass,
+		},
+		{
+			Name:           "Certificate issued before rule comes into effect",
+			InputFilename:  "ouPresentBeforeSep22.pem",
+			ExpectedResult: lint.NE,
+		},
+		{
+			Name:           "Certificate issued after rule applies that contains an OU",
+			InputFilename:  "ouPresentAfterSep22.pem",
+			ExpectedResult: lint.Error,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := test.TestLint("e_organizational_unit_name_prohibited", tc.InputFilename)
+			if result.Status != tc.ExpectedResult {
+				t.Errorf("expected result %v was %v", tc.ExpectedResult, result.Status)
+			}
+		})
+	}
+}

--- a/v3/testdata/ouAbsentAfterSep22.pem
+++ b/v3/testdata/ouAbsentAfterSep22.pem
@@ -1,0 +1,38 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Sep  1 00:00:00 2022 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.com
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:5c:cf:65:b6:bd:f2:a2:91:9c:ad:9d:3b:c0:51:
+                    8d:7d:6c:8c:3b:d8:9c:91:ff:9f:2e:22:33:cf:82:
+                    c8:3c:f5:47:79:52:0f:da:ca:84:93:17:8e:4e:1f:
+                    39:a1:a9:68:ed:45:61:0d:19:a6:51:e8:43:fe:33:
+                    2d:3c:be:cf:0c
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Subject Alternative Name: 
+                DNS:example.com, DNS:other.example.com, DNS:third.example.com
+    Signature Algorithm: ecdsa-with-SHA256
+         30:46:02:21:00:be:db:5f:81:3e:6b:8c:db:59:03:af:23:55:
+         dc:2c:63:b1:15:a6:54:bd:3e:1a:a0:3a:da:80:ee:96:af:e5:
+         a0:02:21:00:9b:57:70:11:bb:f7:9d:e8:f6:1a:90:e0:50:44:
+         27:30:25:a1:50:a2:5d:e8:85:37:42:7c:09:10:d6:3c:fa:10
+-----BEGIN CERTIFICATE-----
+MIIBRzCB7aADAgECAgEDMAoGCCqGSM49BAMCMAAwIBcNMjIwOTAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMBYxFDASBgNVBAMTC2V4YW1wbGUuY29tMFkwEwYHKoZI
+zj0CAQYIKoZIzj0DAQcDQgAEXM9ltr3yopGcrZ07wFGNfWyMO9ickf+fLiIzz4LI
+PPVHeVIP2sqEkxeOTh85oalo7UVhDRmmUehD/jMtPL7PDKNAMD4wPAYDVR0RBDUw
+M4ILZXhhbXBsZS5jb22CEW90aGVyLmV4YW1wbGUuY29tghF0aGlyZC5leGFtcGxl
+LmNvbTAKBggqhkjOPQQDAgNJADBGAiEAvttfgT5rjNtZA68jVdwsY7EVplS9Phqg
+OtqA7pav5aACIQCbV3ARu/ed6PYakOBQRCcwJaFQol3ohTdCfAkQ1jz6EA==
+-----END CERTIFICATE-----

--- a/v3/testdata/ouPresentAfterSep22.pem
+++ b/v3/testdata/ouPresentAfterSep22.pem
@@ -1,0 +1,39 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Sep  1 00:00:00 2022 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.com, OU = Example Unit
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:9b:73:61:fc:f7:cc:07:a4:33:50:9f:53:d0:96:
+                    9e:e7:9f:0d:e1:b8:6a:78:b6:90:b8:9c:02:7d:41:
+                    3a:98:54:49:06:8e:da:03:b7:9f:db:7e:eb:6b:0e:
+                    89:1e:b0:e6:4c:18:71:c2:68:17:9c:cb:9d:37:d4:
+                    70:90:f9:15:be
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Subject Alternative Name: 
+                DNS:example.com, DNS:other.example.com, DNS:third.example.com
+    Signature Algorithm: ecdsa-with-SHA256
+         30:45:02:21:00:8b:09:c7:c2:2e:fa:1d:2e:8a:ba:bf:1c:14:
+         3c:44:9a:3c:d1:67:16:8f:60:fb:7e:be:4b:b3:a9:93:1e:04:
+         73:02:20:3b:16:71:3d:34:80:f9:78:83:20:e2:07:bb:8b:71:
+         03:f9:12:b7:38:68:56:d5:a9:fc:6b:1f:9e:06:eb:e6:35
+-----BEGIN CERTIFICATE-----
+MIIBXjCCAQSgAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTIyMDkwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAtMRQwEgYDVQQDEwtleGFtcGxlLmNvbTEVMBMGA1UE
+CxMMRXhhbXBsZSBVbml0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEm3Nh/PfM
+B6QzUJ9T0Jae558N4bhqeLaQuJwCfUE6mFRJBo7aA7ef237raw6JHrDmTBhxwmgX
+nMudN9RwkPkVvqNAMD4wPAYDVR0RBDUwM4ILZXhhbXBsZS5jb22CEW90aGVyLmV4
+YW1wbGUuY29tghF0aGlyZC5leGFtcGxlLmNvbTAKBggqhkjOPQQDAgNIADBFAiEA
+iwnHwi76HS6Kur8cFDxEmjzRZxaPYPt+vkuzqZMeBHMCIDsWcT00gPl4gyDiB7uL
+cQP5Erc4aFbVqfxrH54G6+Y1
+-----END CERTIFICATE-----

--- a/v3/testdata/ouPresentBeforeSep22.pem
+++ b/v3/testdata/ouPresentBeforeSep22.pem
@@ -1,0 +1,39 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Aug  1 00:00:00 2022 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.com, OU = Example Unit
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:cd:73:2d:da:e1:5a:e4:6a:0d:fe:b7:b7:35:5d:
+                    e2:97:35:20:3f:60:36:09:09:74:f2:9f:af:94:e3:
+                    ef:1f:de:8c:2b:da:4c:47:5b:de:1e:63:da:cc:bf:
+                    b1:80:27:e1:a2:1a:b6:5d:b2:5c:7a:56:37:89:7a:
+                    cb:a0:54:ef:c6
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Subject Alternative Name: 
+                DNS:example.com, DNS:other.example.com, DNS:third.example.com
+    Signature Algorithm: ecdsa-with-SHA256
+         30:44:02:20:0c:7e:03:28:74:1c:57:63:f9:99:0a:e4:22:97:
+         cd:77:77:1a:6b:48:70:d0:c5:6d:41:a1:11:76:32:2b:02:d7:
+         02:20:6c:de:d7:d4:93:0d:67:54:f5:f6:e4:f3:9b:ba:4a:07:
+         9e:6f:4e:74:13:6f:a2:c3:de:cc:68:6c:0a:9f:7e:e4
+-----BEGIN CERTIFICATE-----
+MIIBXTCCAQSgAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTIyMDgwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAtMRQwEgYDVQQDEwtleGFtcGxlLmNvbTEVMBMGA1UE
+CxMMRXhhbXBsZSBVbml0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzXMt2uFa
+5GoN/re3NV3ilzUgP2A2CQl08p+vlOPvH96MK9pMR1veHmPazL+xgCfhohq2XbJc
+elY3iXrLoFTvxqNAMD4wPAYDVR0RBDUwM4ILZXhhbXBsZS5jb22CEW90aGVyLmV4
+YW1wbGUuY29tghF0aGlyZC5leGFtcGxlLmNvbTAKBggqhkjOPQQDAgNHADBEAiAM
+fgModBxXY/mZCuQil813dxprSHDQxW1BoRF2MisC1wIgbN7X1JMNZ1T19uTzm7pK
+B55vTnQTb6LD3sxobAqffuQ=
+-----END CERTIFICATE-----

--- a/v3/util/time.go
+++ b/v3/util/time.go
@@ -68,6 +68,7 @@ var (
 	AppleReducedLifetimeDate                         = time.Date(2020, time.September, 1, 0, 0, 0, 0, time.UTC)
 	CABFBRs_1_8_0_Date                               = time.Date(2021, time.August, 21, 0, 0, 0, 0, time.UTC)
 	NoReservedDomainLabelsDate                       = time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC)
+	CABFBRs_1_8_1_Date                               = time.Date(2022, time.September, 1, 0, 0, 0, 0, time.UTC)
 )
 
 var (

--- a/v3/util/time.go
+++ b/v3/util/time.go
@@ -1,5 +1,5 @@
 /*
- * ZLint Copyright 2021 Regents of the University of Michigan
+ * ZLint Copyright 2022 Regents of the University of Michigan
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -68,7 +68,7 @@ var (
 	AppleReducedLifetimeDate                         = time.Date(2020, time.September, 1, 0, 0, 0, 0, time.UTC)
 	CABFBRs_1_8_0_Date                               = time.Date(2021, time.August, 21, 0, 0, 0, 0, time.UTC)
 	NoReservedDomainLabelsDate                       = time.Date(2021, time.October, 1, 0, 0, 0, 0, time.UTC)
-	CABFBRs_1_8_1_Date                               = time.Date(2022, time.September, 1, 0, 0, 0, 0, time.UTC)
+	CABFBRs_OU_Prohibited_Date                       = time.Date(2022, time.September, 1, 0, 0, 0, 0, time.UTC)
 )
 
 var (


### PR DESCRIPTION
I've attempted to address #628.  ~I took a guess at what the appropriate version number for the BRs will be but please let me know if I've guessed wrong.~  (Nevermind, I realised that the version of the document is not as important as the rule change has a particular date mentioned and I can just describe that instead of a version number for the BRs)   I ran make integration -overwriteExpected to try and get an entry in the config.json record for the new lint but it didn't seem to change the file so I think I might have made a mistake somewhere but I can't work out where as it looks right to me...

So far, I've just tackled the easy bit of SC47 and banned them utterly from 1st September.  I'll try to suss out the combination rules and add a rule effective sooner but I am less certain if that's needed if it's outright banned in September but I'll see what I can work out from the PR Corey linked in the issue he opened.

Also, I'm English so can reviewers be extra careful to check that I've correctly, incorrectly spelled "organizational" across all the files I've added/changed 😄 