### PR TITLE
Fix SPKI Encoding Lint's RSA BR Section

### DIFF
--- a/v3/lints/cabf_br/lint_subject_public_key_info_improper_algorithm_object_identifier_encoding.go
+++ b/v3/lints/cabf_br/lint_subject_public_key_info_improper_algorithm_object_identifier_encoding.go
@@ -30,7 +30,7 @@ type algorithmObjectIdentifierEncoding struct{}
 This lint refers to CAB Baseline Requirements (Version 1.7.4) chapter 7.1.3.1, which defines the
 required encodings of AlgorithmObjectIdentifiers inside a SubjectPublicKeyInfo field.
 
-Section 7.1.3.1.2: When encoded, the AlgorithmIdentifier for RSA keys MUST be byte‐for‐byte
+Section 7.1.3.1.1: When encoded, the AlgorithmIdentifier for RSA keys MUST be byte‐for‐byte
 identical with the following hex‐encoded bytes: 300d06092a864886f70d0101010500
 
 Section 7.1.3.1.2: When encoded, the AlgorithmIdentifier for ECDSA keys MUST be


### PR DESCRIPTION
Fixes an error in the documentation of this lint.

The RSA AlgorithmIdentifier is specified in 7.1.3.1.1. ECDSA is referenced in 7.1.3.1.2
https://github.com/cabforum/servercert/blob/main/docs/BR.md#71311-rsa