### PR TITLE
Lint to enforce no trailing zero byte on KeyUsage bitstrings

### DIFF
--- a/v3/lints/rfc/lint_superfluous_ku_encoding.go
+++ b/v3/lints/rfc/lint_superfluous_ku_encoding.go
@@ -1,0 +1,61 @@
+/*
+ * ZLint Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package rfc
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+func init() {
+	lint.RegisterLint(&lint.Lint{
+		Name:          "e_superfluous_ku_encoding",
+		Description:   "RFC 5280 Section 4.2.1.3 describes the value of a KeyUsage to be a DER encoded BitString, which itself must not have unnecessary trailing 00 bytes.",
+		Citation:      "1.2.2 Where Rec. ITU-T X.680 | ISO/IEC 8824-1, 22.7, applies, the bitstring shall have all trailing 0 bits removed before it is encoded.",
+		Source:        lint.RFC5280,
+		EffectiveDate: util.ZeroDate,
+		Lint:          func() lint.LintInterface { return &superfluousKuEncoding{} },
+	})
+}
+
+type superfluousKuEncoding struct{}
+
+func NewSuperfluousKuEncoding() lint.LintInterface {
+	return &superfluousKuEncoding{}
+}
+
+func (l *superfluousKuEncoding) CheckApplies(c *x509.Certificate) bool {
+	ku := util.GetExtFromCert(c, util.KeyUsageOID)
+	return ku != nil && len(ku.Value) > 0
+}
+
+func (l *superfluousKuEncoding) Execute(c *x509.Certificate) *lint.LintResult {
+	ku := util.GetExtFromCert(c, util.KeyUsageOID).Value
+	if ku[len(ku)-1] != 0 {
+		return &lint.LintResult{Status: lint.Pass}
+	}
+	binary := make([]string, len(ku))
+	for i, b := range ku {
+		binary[i] = fmt.Sprintf("%08b", b)
+	}
+	// E.G. KeyUsage contains superfluous trailing 00 byte. Bytes: [3 3 7 6 0], Binary: [00000011 00000011 00000111 00000110 00000000]
+	return &lint.LintResult{Status: lint.Error, Details: fmt.Sprintf(
+		"KeyUsage contains superfluous trailing 00 byte. Bytes: %v, Binary: [%s]", ku, strings.Join(binary, " "),
+	)}
+}

--- a/v3/lints/rfc/lint_superfluous_ku_encoding_test.go
+++ b/v3/lints/rfc/lint_superfluous_ku_encoding_test.go
@@ -1,0 +1,54 @@
+/*
+ * ZLint Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package rfc
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestSuperfluousKuEncoding(t *testing.T) {
+	testCases := []struct {
+		name           string
+		filepath       string
+		expectedStatus lint.LintStatus
+	}{
+		{
+			name:           "Known Trustwave P256 with trailing zero byte in KU",
+			filepath:       "trustwaveP256CASuperfluousBytesOnKU.pem",
+			expectedStatus: lint.Error,
+		},
+		{
+			name:           "Known Trustwave P256 with trailing zero byte in KU",
+			filepath:       "trustwaveP384CASuperfluousBytesOnKU.pem",
+			expectedStatus: lint.Error,
+		},
+		{
+			name:           "A cert with CertSign | CRLSign and no trailing zery byte",
+			filepath:       "keyUsageWithoutTrailingZeroes.pem",
+			expectedStatus: lint.Pass,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := test.TestLint("e_superfluous_ku_encoding", tc.filepath)
+			if result.Status != tc.expectedStatus {
+				t.Errorf("expected result %v was %v", tc.expectedStatus, result.Status)
+			}
+		})
+	}
+}

--- a/v3/testdata/keyUsageWithoutTrailingZeroes.pem
+++ b/v3/testdata/keyUsageWithoutTrailingZeroes.pem
@@ -1,0 +1,49 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Mar  2 15:17:12 2018 GMT
+            Not After : Mar  2 15:17:12 2020 GMT
+        Subject: CN = of3wk4tupf2ws33q.onion
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (1024 bit)
+                Modulus:
+                    00:dc:c6:fd:da:ed:19:03:e5:6e:36:13:c6:39:bf:
+                    85:5a:d8:c0:34:d9:67:36:32:20:78:03:01:73:6b:
+                    e6:40:da:25:8e:ae:2c:29:81:7a:77:d8:22:16:9c:
+                    a0:8c:47:e9:67:45:5c:95:42:d1:8c:1c:cc:87:31:
+                    7c:43:09:75:f8:9e:96:dc:e7:5e:44:29:4c:6d:28:
+                    5c:96:75:aa:b0:98:07:a9:53:9f:dd:d1:a4:68:af:
+                    ba:08:a2:23:f1:0d:c5:1f:c0:09:62:5a:9b:c6:ef:
+                    43:b0:65:6f:8c:2a:75:e6:66:61:93:2a:29:04:a3:
+                    c3:9d:f8:63:d1:a8:8e:3f:1f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:OF3WK4TUPF2WS33Q.onion
+            X509v3 Certificate Policies: 
+                Policy: 1.3.6.1.4.1.36305.2
+
+    Signature Algorithm: ecdsa-with-SHA256
+         30:45:02:20:22:a8:45:3b:49:6d:18:9e:e3:c3:79:82:8f:f2:
+         89:1b:5b:64:fd:a6:a2:ad:a3:14:ec:67:de:e8:96:ab:34:1d:
+         02:21:00:d9:7e:e0:3e:d2:ea:43:36:c7:46:5f:55:c1:80:27:
+         6b:7d:30:eb:0a:5a:9c:7b:d1:8e:d3:ab:a3:bb:c4:60:fd
+-----BEGIN CERTIFICATE-----
+MIIBrTCCAVOgAwIBAgIBAzAKBggqhkjOPQQDAjAAMB4XDTE4MDMwMjE1MTcxMloX
+DTIwMDMwMjE1MTcxMlowITEfMB0GA1UEAxMWb2Yzd2s0dHVwZjJ3czMzcS5vbmlv
+bjCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA3Mb92u0ZA+VuNhPGOb+FWtjA
+NNlnNjIgeAMBc2vmQNoljq4sKYF6d9giFpygjEfpZ0VclULRjBzMhzF8Qwl1+J6W
+3OdeRClMbShclnWqsJgHqVOf3dGkaK+6CKIj8Q3FH8AJYlqbxu9DsGVvjCp15mZh
+kyopBKPDnfhj0aiOPx8CAwEAAaNWMFQwDgYDVR0PAQH/BAQDAgAGMCoGA1UdEQQj
+MCGCB3ptYXAuaW+CFk9GM1dLNFRVUEYyV1MzM1Eub25pb24wFgYDVR0gBA8wDTAL
+BgkrBgEEAYKbUQIwCgYIKoZIzj0EAwIDSAAwRQIgIqhFO0ltGJ7jw3mCj/KJG1tk
+/aairaMU7Gfe6JarNB0CIQDZfuA+0upDNsdGX1XBgCdrfTDrClqce9GO06uju8Rg
+/Q==
+-----END CERTIFICATE-----

--- a/v3/testdata/trustwaveP256CASuperfluousBytesOnKU.pem
+++ b/v3/testdata/trustwaveP256CASuperfluousBytesOnKU.pem
@@ -1,0 +1,49 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:6a:5f:08:3f:28:5c:3e:51:95:df:5d
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: C = US, ST = Illinois, L = Chicago, O = "Trustwave Holdings, Inc.", CN = Trustwave Global ECC P256 Certification Authority
+        Validity
+            Not Before: Aug 23 19:35:10 2017 GMT
+            Not After : Aug 23 19:35:10 2042 GMT
+        Subject: C = US, ST = Illinois, L = Chicago, O = "Trustwave Holdings, Inc.", CN = Trustwave Global ECC P256 Certification Authority
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:7e:fb:6c:e6:23:e3:73:32:08:ca:60:e6:53:9c:
+                    ba:74:8d:18:b0:78:90:52:80:dd:38:c0:4a:1d:d1:
+                    a8:cc:93:a4:97:06:38:ca:0d:15:62:c6:8e:01:2a:
+                    65:9d:aa:df:34:91:2e:81:c1:e4:33:92:31:c4:fd:
+                    09:3a:a6:3f:ad
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Subject Key Identifier: 
+                A3:41:06:AC:90:6D:D1:4A:EB:75:A5:4A:10:99:B3:B1:A1:8B:4A:F7
+    Signature Algorithm: ecdsa-with-SHA256
+         30:44:02:20:07:e6:54:da:0e:a0:5a:b2:ae:11:9f:87:c5:b6:
+         ff:69:de:25:be:f8:a0:b7:08:f3:44:ce:2a:df:08:21:0c:37:
+         02:20:2d:26:03:a0:05:bd:6b:d1:f6:5c:f8:65:cc:86:6d:b3:
+         9c:34:48:63:84:09:c5:8d:77:1a:e2:cc:9c:e1:74:7b
+-----BEGIN CERTIFICATE-----
+MIICYDCCAgegAwIBAgIMDWpfCD8oXD5Rld9dMAoGCCqGSM49BAMCMIGRMQswCQYD
+VQQGEwJVUzERMA8GA1UECBMISWxsaW5vaXMxEDAOBgNVBAcTB0NoaWNhZ28xITAf
+BgNVBAoTGFRydXN0d2F2ZSBIb2xkaW5ncywgSW5jLjE6MDgGA1UEAxMxVHJ1c3R3
+YXZlIEdsb2JhbCBFQ0MgUDI1NiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0x
+NzA4MjMxOTM1MTBaFw00MjA4MjMxOTM1MTBaMIGRMQswCQYDVQQGEwJVUzERMA8G
+A1UECBMISWxsaW5vaXMxEDAOBgNVBAcTB0NoaWNhZ28xITAfBgNVBAoTGFRydXN0
+d2F2ZSBIb2xkaW5ncywgSW5jLjE6MDgGA1UEAxMxVHJ1c3R3YXZlIEdsb2JhbCBF
+Q0MgUDI1NiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTBZMBMGByqGSM49AgEGCCqG
+SM49AwEHA0IABH77bOYj43MyCMpg5lOcunSNGLB4kFKA3TjASh3RqMyTpJcGOMoN
+FWLGjgEqZZ2q3zSRLoHB5DOSMcT9CTqmP62jQzBBMA8GA1UdEwEB/wQFMAMBAf8w
+DwYDVR0PAQH/BAUDAwcGADAdBgNVHQ4EFgQUo0EGrJBt0UrrdaVKEJmzsaGLSvcw
+CgYIKoZIzj0EAwIDRwAwRAIgB+ZU2g6gWrKuEZ+Hxbb/ad4lvvigtwjzRM4q3wgh
+DDcCIC0mA6AFvWvR9lz4ZcyGbbOcNEhjhAnFjXca4syc4XR7
+-----END CERTIFICATE-----

--- a/v3/testdata/trustwaveP384CASuperfluousBytesOnKU.pem
+++ b/v3/testdata/trustwaveP384CASuperfluousBytesOnKU.pem
@@ -1,0 +1,55 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            08:bd:85:97:6c:99:27:a4:80:68:47:3b
+        Signature Algorithm: ecdsa-with-SHA384
+        Issuer: C = US, ST = Illinois, L = Chicago, O = "Trustwave Holdings, Inc.", CN = Trustwave Global ECC P384 Certification Authority
+        Validity
+            Not Before: Aug 23 19:36:43 2017 GMT
+            Not After : Aug 23 19:36:43 2042 GMT
+        Subject: C = US, ST = Illinois, L = Chicago, O = "Trustwave Holdings, Inc.", CN = Trustwave Global ECC P384 Certification Authority
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (384 bit)
+                pub:
+                    04:6b:da:0d:75:35:08:31:47:05:ae:45:99:55:f1:
+                    11:13:2e:4a:f8:10:31:23:a3:7e:83:d3:7f:28:08:
+                    3a:26:1a:3a:cf:97:82:1f:80:b7:27:09:8f:d1:8e:
+                    30:c4:0a:9b:0e:ac:58:04:ab:f7:36:7d:94:23:a4:
+                    9b:0a:8a:8b:ab:eb:fd:39:25:66:f1:5e:fe:8c:ae:
+                    8d:41:79:9d:09:60:ce:28:a9:d3:8a:6d:f3:d6:45:
+                    d4:f2:98:84:38:65:a0
+                ASN1 OID: secp384r1
+                NIST CURVE: P-384
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Subject Key Identifier: 
+                55:A9:84:89:D2:C1:32:BD:18:CB:6C:A6:07:4E:C8:E7:9D:BE:82:90
+    Signature Algorithm: ecdsa-with-SHA384
+         30:64:02:30:37:01:92:97:45:12:7e:a0:f3:3e:ad:19:3a:72:
+         dd:f4:50:93:03:12:be:44:d2:4f:41:a4:8c:9c:9d:1f:a3:f6:
+         c2:92:e7:48:14:fe:4e:9b:a5:91:57:ae:c6:37:72:bb:02:30:
+         67:25:0a:b1:0c:5e:ee:a9:63:92:6f:e5:90:0b:fe:66:22:ca:
+         47:fd:8a:31:f7:83:fe:7a:bf:10:be:18:2b:1e:8f:f6:29:1e:
+         94:59:ef:8e:21:37:cb:51:98:a5:6e:4b
+-----BEGIN CERTIFICATE-----
+MIICnTCCAiSgAwIBAgIMCL2Fl2yZJ6SAaEc7MAoGCCqGSM49BAMDMIGRMQswCQYD
+VQQGEwJVUzERMA8GA1UECBMISWxsaW5vaXMxEDAOBgNVBAcTB0NoaWNhZ28xITAf
+BgNVBAoTGFRydXN0d2F2ZSBIb2xkaW5ncywgSW5jLjE6MDgGA1UEAxMxVHJ1c3R3
+YXZlIEdsb2JhbCBFQ0MgUDM4NCBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0x
+NzA4MjMxOTM2NDNaFw00MjA4MjMxOTM2NDNaMIGRMQswCQYDVQQGEwJVUzERMA8G
+A1UECBMISWxsaW5vaXMxEDAOBgNVBAcTB0NoaWNhZ28xITAfBgNVBAoTGFRydXN0
+d2F2ZSBIb2xkaW5ncywgSW5jLjE6MDgGA1UEAxMxVHJ1c3R3YXZlIEdsb2JhbCBF
+Q0MgUDM4NCBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTB2MBAGByqGSM49AgEGBSuB
+BAAiA2IABGvaDXU1CDFHBa5FmVXxERMuSvgQMSOjfoPTfygIOiYaOs+Xgh+AtycJ
+j9GOMMQKmw6sWASr9zZ9lCOkmwqKi6vr/TklZvFe/oyujUF5nQlgziip04pt89ZF
+1PKYhDhloKNDMEEwDwYDVR0TAQH/BAUwAwEB/zAPBgNVHQ8BAf8EBQMDBwYAMB0G
+A1UdDgQWBBRVqYSJ0sEyvRjLbKYHTsjnnb6CkDAKBggqhkjOPQQDAwNnADBkAjA3
+AZKXRRJ+oPM+rRk6ct30UJMDEr5E0k9BpIycnR+j9sKS50gU/k6bpZFXrsY3crsC
+MGclCrEMXu6pY5Jv5ZAL/mYiykf9ijH3g/56vxC+GCsej/YpHpRZ744hN8tRmKVu
+Sw==
+-----END CERTIFICATE-----


### PR DESCRIPTION
This lint addresses #681 where certificates were discovered whose KeyUsage encodings violated DER's requirement on minimal bitstring representations.

The following are interested parties in this issue:

@robplee
@aarongable 
@CBonnell 