### PR TITLE
Add lint to check for incorrect 'unused' bit encoding in KeyUsages

### DIFF
--- a/v3/integration/config.json
+++ b/v3/integration/config.json
@@ -783,6 +783,9 @@
     "w_tls_server_cert_valid_time_longer_than_397_days": {},
     "e_no_underscores_before_1_6_2": {
       "ErrCount": 340
+    },
+    "e_incorrect_ku_encoding": {
+      "ErrCount": 6586
     }
   }
 }

--- a/v3/lints/rfc/lint_incorrect_ku_encoding.go
+++ b/v3/lints/rfc/lint_incorrect_ku_encoding.go
@@ -1,0 +1,80 @@
+/*
+ * ZLint Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package rfc
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+func init() {
+	lint.RegisterLint(&lint.Lint{
+		Name:          "e_incorrect_ku_encoding",
+		Description:   "RFC 5280 Section 4.2.1.3 describes the value of a KeyUsage to be a DER encoded BitString, which itself defines that all trailing 0 bits be counted as being \"unused\".",
+		Citation:      "Where ITU-T Rec. X.680 | ISO/IEC 8824-1, 21.7, applies, the bitstring shall have all trailing 0 bits removed before it is encoded.",
+		Source:        lint.RFC5280,
+		EffectiveDate: util.ZeroDate,
+		Lint:          func() lint.LintInterface { return &incorrectKuEncoding{} },
+	})
+}
+
+type incorrectKuEncoding struct{}
+
+func NewIncorrectKuEncoding() lint.LintInterface {
+	return &incorrectKuEncoding{}
+}
+
+func (l *incorrectKuEncoding) CheckApplies(c *x509.Certificate) bool {
+	ku := util.GetExtFromCert(c, util.KeyUsageOID)
+	return ku != nil && len(ku.Value) > 0
+}
+
+func (l *incorrectKuEncoding) Execute(c *x509.Certificate) *lint.LintResult {
+	ku := util.GetExtFromCert(c, util.KeyUsageOID).Value
+	if len(ku) < 4 {
+		return &lint.LintResult{
+			Status:  lint.Fatal,
+			Details: fmt.Sprintf("KeyUsage encodings must be at least four bytes long. Got %d bytes", len(ku)),
+		}
+	}
+	// Byte 0: Tag
+	// Byte 1: Length
+	// Byte 2: Unused bits
+	// Bytes 3..n: KeyUsage
+	declaredUnused := uint(ku[2])
+	actualUnused := big.NewInt(0).SetBytes(ku[3:]).TrailingZeroBits()
+	if declaredUnused == actualUnused {
+		return &lint.LintResult{Status: lint.Pass}
+	}
+	// Just a bit of formatting to a visualized binary form so
+	// it's easier for users to see what the exact binary that
+	// we're referring to so that they can debug their own certs.
+	binary := make([]string, len(ku))
+	for i, b := range ku {
+		binary[i] = fmt.Sprintf("%08b", b)
+	}
+	return &lint.LintResult{
+		Status: lint.Error,
+		Details: fmt.Sprintf(
+			"KeyUsage contains an inefficient encoding wherein the number of 'unused bits' is declared to be "+
+				"%d, but it should be %d. Raw Bytes: %v, Raw Binary: [%s]",
+			declaredUnused, actualUnused, ku, strings.Join(binary, " "),
+		)}
+}

--- a/v3/lints/rfc/lint_incorrect_ku_encoding_test.go
+++ b/v3/lints/rfc/lint_incorrect_ku_encoding_test.go
@@ -15,31 +15,41 @@
 package rfc
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/zmap/zlint/v3/lint"
 	"github.com/zmap/zlint/v3/test"
 )
 
-func TestKuIncorrectEndoding(t *testing.T) {
+func TestKuIncorrectEncoding(t *testing.T) {
 	data := []struct {
-		file string
-		want lint.LintStatus
+		file    string
+		want    lint.LintStatus
+		details string
 	}{
 		{
-			"incorrect_unused_bits_in_ku_encoding.pem", lint.Error,
+			"incorrect_unused_bits_in_ku_encoding.pem",
+			lint.Error,
+			"declared to be 5, but it should be 7",
 		},
 		{
-			"keyUsageCertSignEndEntity.pem", lint.Pass,
+			"keyUsageCertSignEndEntity.pem",
+			lint.Pass,
+			"",
 		},
 	}
 	for _, d := range data {
 		file := d.file
 		want := d.want
+		details := d.details
 		t.Run(file, func(t *testing.T) {
 			got := test.TestLint("e_incorrect_ku_encoding", file)
 			if got.Status != want {
 				t.Errorf("expected %v got %v", want, got)
+			}
+			if !strings.Contains(got.Details, details) {
+				t.Errorf("expected the returned details to contain '%s' but got %s", details, got.Details)
 			}
 		})
 	}

--- a/v3/lints/rfc/lint_incorrect_ku_encoding_test.go
+++ b/v3/lints/rfc/lint_incorrect_ku_encoding_test.go
@@ -1,0 +1,46 @@
+/*
+ * ZLint Copyright 2022 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package rfc
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestKuIncorrectEndoding(t *testing.T) {
+	data := []struct {
+		file string
+		want lint.LintStatus
+	}{
+		{
+			"incorrect_unused_bits_in_ku_encoding.pem", lint.Error,
+		},
+		{
+			"keyUsageCertSignEndEntity.pem", lint.Pass,
+		},
+	}
+	for _, d := range data {
+		file := d.file
+		want := d.want
+		t.Run(file, func(t *testing.T) {
+			got := test.TestLint("e_incorrect_ku_encoding", file)
+			if got.Status != want {
+				t.Errorf("expected %v got %v", want, got)
+			}
+		})
+	}
+}

--- a/v3/testdata/incorrect_unused_bits_in_ku_encoding.pem
+++ b/v3/testdata/incorrect_unused_bits_in_ku_encoding.pem
@@ -1,49 +1,122 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 3 (0x3)
-        Signature Algorithm: ecdsa-with-SHA256
-        Issuer: 
+        Serial Number:
+            9a:14:f8:1a:24:9b:14:eb:e4:39:fe:f5:4a:56:5f:92
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = FR, ST = Paris, L = Paris, O = Gandi, CN = Gandi Standard SSL CA 2
         Validity
-            Not Before: Mar  2 15:17:12 2018 GMT
-            Not After : Mar  2 15:17:12 2020 GMT
-        Subject: CN = of3wk4tupf2ws33q.onion
+            Not Before: Jun  7 00:00:00 2019 GMT
+            Not After : Jun  7 23:59:59 2020 GMT
+        Subject: OU = Domain Control Validated, OU = Gandi Standard SSL, CN = 8b31df000871489f84bad670bfecc50b.yatu.ws
         Subject Public Key Info:
-            Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (1024 bit)
-                Modulus:
-                    00:dc:c6:fd:da:ed:19:03:e5:6e:36:13:c6:39:bf:
-                    85:5a:d8:c0:34:d9:67:36:32:20:78:03:01:73:6b:
-                    e6:40:da:25:8e:ae:2c:29:81:7a:77:d8:22:16:9c:
-                    a0:8c:47:e9:67:45:5c:95:42:d1:8c:1c:cc:87:31:
-                    7c:43:09:75:f8:9e:96:dc:e7:5e:44:29:4c:6d:28:
-                    5c:96:75:aa:b0:98:07:a9:53:9f:dd:d1:a4:68:af:
-                    ba:08:a2:23:f1:0d:c5:1f:c0:09:62:5a:9b:c6:ef:
-                    43:b0:65:6f:8c:2a:75:e6:66:61:93:2a:29:04:a3:
-                    c3:9d:f8:63:d1:a8:8e:3f:1f
-                Exponent: 65537 (0x10001)
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:b9:59:ee:ae:d4:5e:5b:e1:4c:87:ff:99:09:b6:
+                    50:79:c6:e0:dc:d4:73:1f:f3:02:a5:7d:1f:65:90:
+                    95:09:8d:91:a5:8d:bb:7d:52:e6:6f:dd:eb:21:19:
+                    37:8a:c5:97:e0:c5:a6:f2:e4:81:8d:ce:7c:c4:9e:
+                    b4:6c:6d:ee:e8
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
         X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                keyid:B3:90:A7:D8:C9:AF:4E:CD:61:3C:9F:7C:AD:5D:7F:41:FD:69:30:EA
+
+            X509v3 Subject Key Identifier: 
+                37:8B:A1:D9:96:2C:A7:21:24:0C:FC:67:75:FB:69:EE:E0:AA:9B:47
             X509v3 Key Usage: critical
-                Digital Signature, CRL Sign
-            X509v3 Subject Alternative Name: 
-                DNS:zmap.io, DNS:OF3WK4TUPF2WS33Q.onion
+                Digital Signature
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
             X509v3 Certificate Policies: 
-                Policy: 1.3.6.1.4.1.36305.2
+                Policy: 1.3.6.1.4.1.6449.1.2.2.26
+                  CPS: https://cps.usertrust.com
+                Policy: 2.23.140.1.2.1
 
-    Signature Algorithm: ecdsa-with-SHA256
-         30:44:02:20:20:6a:70:74:10:df:33:20:2b:b4:45:d7:92:d1:
-         24:e2:24:82:8f:48:2c:da:29:32:3d:fc:69:10:55:c5:62:01:
-         02:20:27:2a:91:8f:05:ab:bd:b9:32:b7:fd:df:de:cf:a2:35:
-         28:2a:80:b9:6c:35:74:a6:77:8b:69:56:60:8f:82:ab
+            X509v3 CRL Distribution Points: 
+
+                Full Name:
+                  URI:http://crl.usertrust.com/GandiStandardSSLCA2.crl
+
+            Authority Information Access: 
+                CA Issuers - URI:http://crt.usertrust.com/GandiStandardSSLCA2.crt
+                OCSP - URI:http://ocsp.usertrust.com
+
+            X509v3 Subject Alternative Name: 
+                DNS:8b31df000871489f84bad670bfecc50b.yatu.ws
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : BB:D9:DF:BC:1F:8A:71:B5:93:94:23:97:AA:92:7B:47:
+                                38:57:95:0A:AB:52:E8:1A:90:96:64:36:8E:1E:D1:85
+                    Timestamp : Jun  7 20:56:56.189 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:46:02:21:00:DB:6B:7E:76:4C:68:37:DC:3F:B8:BE:
+                                01:81:99:D7:27:B9:01:01:E1:F4:E3:72:56:59:28:74:
+                                F6:21:F4:13:75:02:21:00:85:15:C8:55:AB:6B:39:B5:
+                                34:0E:9B:8B:A1:D7:67:F0:F4:07:C4:A1:4C:6D:8D:CF:
+                                1B:90:BD:4D:BD:6C:A6:76
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 5E:A7:73:F9:DF:56:C0:E7:B5:36:48:7D:D0:49:E0:32:
+                                7A:91:9A:0C:84:A1:12:12:84:18:75:96:81:71:45:58
+                    Timestamp : Jun  7 20:56:56.221 2019 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:45:02:20:47:6A:14:45:EB:31:A9:15:FA:03:58:EE:
+                                C7:C4:23:A2:56:23:EE:5F:F4:7F:14:83:AE:48:C5:B8:
+                                18:94:00:33:02:21:00:B7:7B:2B:10:E6:52:5F:DA:2F:
+                                2B:DE:D7:B0:5C:A4:48:91:A6:1C:D8:6B:4B:50:84:2D:
+                                9C:26:5B:63:74:A2:83
+    Signature Algorithm: sha256WithRSAEncryption
+         2e:c5:52:10:21:20:55:88:7b:c3:67:28:32:81:bc:c2:64:24:
+         56:b8:3e:1c:da:ef:2b:79:8a:57:c0:55:e4:a2:ee:71:51:d4:
+         2d:60:e2:9e:7e:fc:7f:71:23:ef:dc:90:e3:aa:5e:ce:13:52:
+         40:43:58:b7:73:3a:49:7e:6e:40:39:1a:c0:ed:88:87:fb:12:
+         65:43:14:c5:18:98:ab:0a:e1:40:5c:7f:64:76:6b:6a:82:e9:
+         85:c4:db:c5:70:f1:fd:18:22:c9:49:4c:04:db:6e:68:66:d1:
+         de:48:eb:31:c6:56:b6:93:95:09:02:8d:2b:ce:9f:de:cc:e2:
+         bc:40:ce:80:52:81:b4:51:3d:9f:91:c7:ce:bf:99:53:66:3f:
+         a7:a6:62:87:20:21:31:7b:3b:77:10:b5:72:62:f5:27:98:a3:
+         37:4d:4b:84:10:3f:5c:dd:44:3f:f2:44:f2:c1:bc:09:7e:d6:
+         2c:85:79:46:05:22:5b:63:5f:39:74:fe:be:71:f1:94:b1:18:
+         7a:40:fa:c8:ad:9e:bf:0e:16:99:77:53:9c:37:4e:4f:bf:1f:
+         88:a4:79:f6:e0:d4:11:92:ba:e0:54:17:21:31:ec:88:99:95:
+         d2:3b:13:dd:c9:3f:ac:02:f6:5c:93:14:0e:0e:8e:61:90:ff:
+         63:25:5c:04
 -----BEGIN CERTIFICATE-----
-MIIBrDCCAVOgAwIBAgIBAzAKBggqhkjOPQQDAjAAMB4XDTE4MDMwMjE1MTcxMloX
-DTIwMDMwMjE1MTcxMlowITEfMB0GA1UEAxMWb2Yzd2s0dHVwZjJ3czMzcS5vbmlv
-bjCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA3Mb92u0ZA+VuNhPGOb+FWtjA
-NNlnNjIgeAMBc2vmQNoljq4sKYF6d9giFpygjEfpZ0VclULRjBzMhzF8Qwl1+J6W
-3OdeRClMbShclnWqsJgHqVOf3dGkaK+6CKIj8Q3FH8AJYlqbxu9DsGVvjCp15mZh
-kyopBKPDnfhj0aiOPx8CAwEAAaNWMFQwDgYDVR0PAQH/BAQDAgCCMCoGA1UdEQQj
-MCGCB3ptYXAuaW+CFk9GM1dLNFRVUEYyV1MzM1Eub25pb24wFgYDVR0gBA8wDTAL
-BgkrBgEEAYKbUQIwCgYIKoZIzj0EAwIDRwAwRAIgIGpwdBDfMyArtEXXktEk4iSC
-j0gs2ikyPfxpEFXFYgECICcqkY8Fq725Mrf9397PojUoKoC5bDV0pneLaVZgj4Kr
+MIIFWDCCBECgAwIBAgIRAJoU+BokmxTr5Dn+9UpWX5IwDQYJKoZIhvcNAQELBQAw
+XzELMAkGA1UEBhMCRlIxDjAMBgNVBAgTBVBhcmlzMQ4wDAYDVQQHEwVQYXJpczEO
+MAwGA1UEChMFR2FuZGkxIDAeBgNVBAMTF0dhbmRpIFN0YW5kYXJkIFNTTCBDQSAy
+MB4XDTE5MDYwNzAwMDAwMFoXDTIwMDYwNzIzNTk1OVowczEhMB8GA1UECxMYRG9t
+YWluIENvbnRyb2wgVmFsaWRhdGVkMRswGQYDVQQLExJHYW5kaSBTdGFuZGFyZCBT
+U0wxMTAvBgNVBAMTKDhiMzFkZjAwMDg3MTQ4OWY4NGJhZDY3MGJmZWNjNTBiLnlh
+dHUud3MwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS5We6u1F5b4UyH/5kJtlB5
+xuDc1HMf8wKlfR9lkJUJjZGljbt9UuZv3eshGTeKxZfgxaby5IGNznzEnrRsbe7o
+o4ICxDCCAsAwHwYDVR0jBBgwFoAUs5Cn2MmvTs1hPJ98rV1/Qf1pMOowHQYDVR0O
+BBYEFDeLodmWLKchJAz8Z3X7ae7gqptHMA4GA1UdDwEB/wQEAwIFgDAMBgNVHRMB
+Af8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjBLBgNVHSAERDBC
+MDYGCysGAQQBsjEBAgIaMCcwJQYIKwYBBQUHAgEWGWh0dHBzOi8vY3BzLnVzZXJ0
+cnVzdC5jb20wCAYGZ4EMAQIBMEEGA1UdHwQ6MDgwNqA0oDKGMGh0dHA6Ly9jcmwu
+dXNlcnRydXN0LmNvbS9HYW5kaVN0YW5kYXJkU1NMQ0EyLmNybDBzBggrBgEFBQcB
+AQRnMGUwPAYIKwYBBQUHMAKGMGh0dHA6Ly9jcnQudXNlcnRydXN0LmNvbS9HYW5k
+aVN0YW5kYXJkU1NMQ0EyLmNydDAlBggrBgEFBQcwAYYZaHR0cDovL29jc3AudXNl
+cnRydXN0LmNvbTAzBgNVHREELDAqgig4YjMxZGYwMDA4NzE0ODlmODRiYWQ2NzBi
+ZmVjYzUwYi55YXR1LndzMIIBBQYKKwYBBAHWeQIEAgSB9gSB8wDxAHcAu9nfvB+K
+cbWTlCOXqpJ7RzhXlQqrUugakJZkNo4e0YUAAAFrM7rqfQAABAMASDBGAiEA22t+
+dkxoN9w/uL4BgZnXJ7kBAeH043JWWSh09iH0E3UCIQCFFchVq2s5tTQOm4uh12fw
+9AfEoUxtjc8bkL1NvWymdgB2AF6nc/nfVsDntTZIfdBJ4DJ6kZoMhKESEoQYdZaB
+cUVYAAABazO66p0AAAQDAEcwRQIgR2oUResxqRX6A1jux8QjolYj7l/0fxSDrkjF
+uBiUADMCIQC3eysQ5lJf2i8r3tewXKRIkaYc2GtLUIQtnCZbY3SigzANBgkqhkiG
+9w0BAQsFAAOCAQEALsVSECEgVYh7w2coMoG8wmQkVrg+HNrvK3mKV8BV5KLucVHU
+LWDinn78f3Ej79yQ46pezhNSQENYt3M6SX5uQDkawO2Ih/sSZUMUxRiYqwrhQFx/
+ZHZraoLphcTbxXDx/RgiyUlMBNtuaGbR3kjrMcZWtpOVCQKNK86f3szivEDOgFKB
+tFE9n5HHzr+ZU2Y/p6ZihyAhMXs7dxC1cmL1J5ijN01LhBA/XN1EP/JE8sG8CX7W
+LIV5RgUiW2NfOXT+vnHxlLEYekD6yK2evw4WmXdTnDdOT78fiKR59uDUEZK64FQX
+ITHsiJmV0jsT3ck/rAL2XJMUDg6OYZD/YyVcBA==
 -----END CERTIFICATE-----
-

--- a/v3/testdata/incorrect_unused_bits_in_ku_encoding.pem
+++ b/v3/testdata/incorrect_unused_bits_in_ku_encoding.pem
@@ -1,0 +1,49 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Mar  2 15:17:12 2018 GMT
+            Not After : Mar  2 15:17:12 2020 GMT
+        Subject: CN = of3wk4tupf2ws33q.onion
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (1024 bit)
+                Modulus:
+                    00:dc:c6:fd:da:ed:19:03:e5:6e:36:13:c6:39:bf:
+                    85:5a:d8:c0:34:d9:67:36:32:20:78:03:01:73:6b:
+                    e6:40:da:25:8e:ae:2c:29:81:7a:77:d8:22:16:9c:
+                    a0:8c:47:e9:67:45:5c:95:42:d1:8c:1c:cc:87:31:
+                    7c:43:09:75:f8:9e:96:dc:e7:5e:44:29:4c:6d:28:
+                    5c:96:75:aa:b0:98:07:a9:53:9f:dd:d1:a4:68:af:
+                    ba:08:a2:23:f1:0d:c5:1f:c0:09:62:5a:9b:c6:ef:
+                    43:b0:65:6f:8c:2a:75:e6:66:61:93:2a:29:04:a3:
+                    c3:9d:f8:63:d1:a8:8e:3f:1f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, CRL Sign
+            X509v3 Subject Alternative Name: 
+                DNS:zmap.io, DNS:OF3WK4TUPF2WS33Q.onion
+            X509v3 Certificate Policies: 
+                Policy: 1.3.6.1.4.1.36305.2
+
+    Signature Algorithm: ecdsa-with-SHA256
+         30:44:02:20:20:6a:70:74:10:df:33:20:2b:b4:45:d7:92:d1:
+         24:e2:24:82:8f:48:2c:da:29:32:3d:fc:69:10:55:c5:62:01:
+         02:20:27:2a:91:8f:05:ab:bd:b9:32:b7:fd:df:de:cf:a2:35:
+         28:2a:80:b9:6c:35:74:a6:77:8b:69:56:60:8f:82:ab
+-----BEGIN CERTIFICATE-----
+MIIBrDCCAVOgAwIBAgIBAzAKBggqhkjOPQQDAjAAMB4XDTE4MDMwMjE1MTcxMloX
+DTIwMDMwMjE1MTcxMlowITEfMB0GA1UEAxMWb2Yzd2s0dHVwZjJ3czMzcS5vbmlv
+bjCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA3Mb92u0ZA+VuNhPGOb+FWtjA
+NNlnNjIgeAMBc2vmQNoljq4sKYF6d9giFpygjEfpZ0VclULRjBzMhzF8Qwl1+J6W
+3OdeRClMbShclnWqsJgHqVOf3dGkaK+6CKIj8Q3FH8AJYlqbxu9DsGVvjCp15mZh
+kyopBKPDnfhj0aiOPx8CAwEAAaNWMFQwDgYDVR0PAQH/BAQDAgCCMCoGA1UdEQQj
+MCGCB3ptYXAuaW+CFk9GM1dLNFRVUEYyV1MzM1Eub25pb24wFgYDVR0gBA8wDTAL
+BgkrBgEEAYKbUQIwCgYIKoZIzj0EAwIDRwAwRAIgIGpwdBDfMyArtEXXktEk4iSC
+j0gs2ikyPfxpEFXFYgECICcqkY8Fq725Mrf9397PojUoKoC5bDV0pneLaVZgj4Kr
+-----END CERTIFICATE-----
+


### PR DESCRIPTION
At-mentions for @aarongable and @CBonnell since you both helped with #682 so I would appreciate a perfunctory glance at this follow-on lint if you happen have the time and energy.

---

This lint is a continuation of #682 wherein KeyUsages were found to be incorrectly padded (that is, there are more trailing `0` bits than is declared in the BitString).

As per [ITU X.690-0207](https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf)...

> 11.2.2 Where ITU-T Rec. X.680 | ISO/IEC 8824-1, 21.7, applies, the bitstring shall have all trailing 0 bits removed
before it is encoded.

In this context, what it means for a bit to be "removed" is to declare it as being "unused". For example, the bit field `01011000` has three trailing `0` bits that should be "removed" (that is, declared to be unused).

### Test Corpus

There is a large number of failures in the test corpus (over 6500) so it took some digging to confirm that this lint is reasonable.

Let us take the chose text cert as an example (whose ASN1 can be found on [crt.sh](https://crt.sh/?asn1=1552750250))

The KU for this certificate is the following...
`0x03 0x02 0x05 0x80`

Or, in binary...
`00000011 00000010 00000101 10000000`

What this is saying is:
`0x03`: This is a bitstring
`0x02`: That is two bytes long
`0x05`: And has five unused bits
`0x80`: Whose contents are `0x80`

However, we can see clearly that  `0x80` does not have five unused bits...
`100 00000`
...rather, it has seven.

Indeed, after a bit of digging through the zcrypto/x509 extension construction logic I did indeed find [an old bug](https://github.com/zmap/zcrypto/blob/25a10ac913f05ba363d7bdc0aeb5ce7d5569967f/x509/x509.go#L2274) wherein the unused bits would always be 0. This was fixed in [CL 168990043](https://codereview.appspot.com/168990043) and, indeed, the fixed Go stdlib agrees with our notions on what the encoding should be.

As such, it seems as though that there was likely and ASN1 implementation that is widely used that at some point had this KU encoding bug.