### PR TITLE
Remove references in comments to Initialize() method of lints

### DIFF
--- a/v3/lint/registration.go
+++ b/v3/lint/registration.go
@@ -458,9 +458,9 @@ var globalRegistry = NewRegistry()
 // RegisterLint is called from the Go init() function of a lint implementation.
 //
 // IMPORTANT: RegisterLint will panic if given a nil lint, or a lint with a nil
-// Lint pointer, or if the lint's Initialize function errors, or if the lint
-// name matches a previously registered lint's name. These conditions all
-// indicate a bug that should be addressed by a developer.
+// Lint pointer, or if the lint name matches a previously registered lint's
+// name. These conditions all indicate a bug that should be addressed by a
+// developer.
 //
 // @deprecated - use RegisterCertificateLint instead.
 func RegisterLint(l *Lint) {
@@ -470,10 +470,10 @@ func RegisterLint(l *Lint) {
 // RegisterCertificateLint must be called once for each CertificateLint to be executed.
 // Normally, RegisterCertificateLint is called from the Go init() function of a lint implementation.
 //
-// IMPORTANT: RegisterCertificateLint will panic if given a nil lint, or a lint with a nil
-// Lint pointer, or if the lint's Initialize function errors, or if the lint
-// name matches a previously registered lint's name. These conditions all
-// indicate a bug that should be addressed by a developer.
+// IMPORTANT: RegisterCertificateLint will panic if given a nil lint, or a lint
+// with a nil Lint pointer, or if the lint name matches a previously registered
+// lint's name. These conditions all indicate a bug that should be addressed by
+// a developer.
 func RegisterCertificateLint(l *CertificateLint) {
 	if err := globalRegistry.registerCertificateLint(l); err != nil {
 		panic(fmt.Sprintf("RegisterLint error: %v\n", err.Error()))
@@ -483,10 +483,10 @@ func RegisterCertificateLint(l *CertificateLint) {
 // RegisterRevocationListLint must be called once for each RevocationListLint to be executed.
 // Normally, RegisterRevocationListLint is called from the Go init() function of a lint implementation.
 //
-// IMPORTANT: RegisterRevocationListLint will panic if given a nil lint, or a lint with a nil
-// Lint pointer, or if the lint's Initialize function errors, or if the lint
-// name matches a previously registered lint's name. These conditions all
-// indicate a bug that should be addressed by a developer.
+// IMPORTANT: RegisterRevocationListLint will panic if given a nil lint, or a
+// lint with a nil Lint pointer, or if the lint name matches a previously
+// registered lint's name. These conditions all indicate a bug that should be
+// addressed by a developer.
 func RegisterRevocationListLint(l *RevocationListLint) {
 	// RegisterLint always sets initialize to true. It's assumed this is called by
 	// the package init() functions and therefore must be doing the first


### PR DESCRIPTION
Hello Zlint team!

Just a small PR to update some comments that still refer to lints having an Initialize method. This appears to no longer be the case but a warning in the comments for RegisterLint, RegisterCertificateLint, and RegisterRevocationListLint was still referencing lints having such a method.

Regards,
Todd Gaunt