### PR TITLE
Enable accepting a PEM encoded CRL via the command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Example ZLint CLI usage:
 See `zlint -h` for all available command line options.
 
 ### Linting Certificate Revocation Lists
-No special flags are necessary when running lints against a certificate revocation list. However, the CRL in question MUST a PEM encoded ASN.1 with the `X509 CRL` PEM armor.
+No special flags are necessary when running lints against a certificate revocation list. However, the CRL in question MUST be a PEM encoded ASN.1 with the `X509 CRL` PEM armor.
 
 The following is an example of a parseable CRL PEM file.
 ```

--- a/README.md
+++ b/README.md
@@ -101,13 +101,30 @@ Example ZLint CLI usage:
 	zlint -exampleConfig
 
 	echo "Lint mycert.pem using a custom configuration for any configurable lints"
-	zlint -config configFile.toml mycert.pemr
+	zlint -config configFile.toml mycert.pem
 
 	echo "List available lint profiles. A profile is a pre-defined collection of lints."
 	zlint -list-profiles
 
 See `zlint -h` for all available command line options.
 
+### Linting Certificate Revocation Lists
+No special flags are necessary when running lints against a certificate revocation list. However, the CRL in question MUST a PEM encoded ASN.1 with the `X509 CRL` PEM armor.
+
+The following is an example of a parseable CRL PEM file.
+```
+-----BEGIN X509 CRL-----
+MIIBnjCBhwIBATANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDEw1BbWlyIHdhcyBI
+ZXJlFw0yMzAzMTMwNTUyNTVaFw0yMzAzMTQwNTUyNTVaoDswOTArBgNVHSMEJDAi
+gCAywvCJz28KsE/6Wf9E1nuiihBFWlUyq7X/RDgn5SllIDAKBgNVHRQEAwIBATAN
+BgkqhkiG9w0BAQsFAAOCAQEAakioBhLs31svWHGmolDhUg6O1daN6zXSAz/avgzl
+38aTKfRSNQ+vM7qgrvCoRojnamziJgXe1hz+/dc8H0/+WEBwVgp1rBzr8f25dSZC
+lXBHT1cNI5RL+wU0pFMouUiwWqwUg8o9iGYkqvhuko4AQIcpAoBuf0OggjCuj48r
+FX7UN7Kz4pc/4ufengKGkf7EeEQffY3zlS0DAtWv+exoQ6Dt+otDr0PbINJZg+46
+TJ/+0w6RsLGoe4Sh/PYPfaCngMyezENUgJgR1+vF6hbVUweeOB+4nFRNxvHMup0G
+GEA4yfzQtHWL8rizWUCyuqXEMPZLzyJT0rv5cLgoOvs+8Q==
+-----END X509 CRL-----
+```
 
 Library Usage
 -------------

--- a/v3/cmd/zlint/main.go
+++ b/v3/cmd/zlint/main.go
@@ -169,11 +169,19 @@ func doLint(inputFile *os.File, inform string, registry lint.Registry) {
 	}
 
 	var asn1Data []byte
+	var isCRL bool
 	switch inform {
 	case "pem":
 		p, _ := pem.Decode(fileBytes)
-		if p == nil || p.Type != "CERTIFICATE" {
+		if p == nil {
 			log.Fatal("unable to parse PEM")
+		}
+		switch p.Type {
+		case "CERTIFICATE":
+		case "X509 CRL":
+			isCRL = true
+		default:
+			log.Fatalf("unknown PEM type (%s)", p.Type)
 		}
 		asn1Data = p.Bytes
 	case "der":
@@ -186,13 +194,20 @@ func doLint(inputFile *os.File, inform string, registry lint.Registry) {
 	default:
 		log.Fatalf("unknown input format %s", format)
 	}
-
-	c, err := x509.ParseCertificate(asn1Data)
-	if err != nil {
-		log.Fatalf("unable to parse certificate: %s", err)
+	var zlintResult *zlint.ResultSet
+	if isCRL {
+		crl, err := x509.ParseRevocationList(asn1Data)
+		if err != nil {
+			log.Fatalf("unable to parse certificate revocation list: %s", err)
+		}
+		zlintResult = zlint.LintRevocationList(crl)
+	} else {
+		c, err := x509.ParseCertificate(asn1Data)
+		if err != nil {
+			log.Fatalf("unable to parse certificate: %s", err)
+		}
+		zlintResult = zlint.LintCertificateEx(c, registry)
 	}
-
-	zlintResult := zlint.LintCertificateEx(c, registry)
 	jsonBytes, err := json.Marshal(zlintResult.Results)
 	if err != nil {
 		log.Fatalf("unable to encode lints JSON: %s", err)


### PR DESCRIPTION
When implementing infrastructure for linting CRLs we had an oversight that we never actually parsed and switched on incoming CRLs from the command line.