### PR TITLE
Inclusion of approximately 190000 email protection certificates into the test corpus

### DIFF
--- a/v3/integration/config.json
+++ b/v3/integration/config.json
@@ -240,19 +240,100 @@
     {
       "Name": "xch.csv",
       "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xch.bz2"
+    },
+    {
+      "Name": "xch.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xch.bz2"
+    },
+    {
+      "Name": "xde.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xde.bz2"
+    },
+    {
+      "Name": "xdf.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdf.bz2"
+    },
+    {
+      "Name": "xdg.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdg.bz2"
+    },
+    {
+      "Name": "xdh.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdh.bz2"
+    },
+    {
+      "Name": "xdi.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdi.bz2"
+    },
+    {
+      "Name": "xdj.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdj.bz2"
+    },
+    {
+      "Name": "xdk.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdk.bz2"
+    },
+    {
+      "Name": "xdl.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdl.bz2"
+    },
+    {
+      "Name": "xdm.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdm.bz2"
+    },
+    {
+      "Name": "xdn.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdn.bz2"
+    },
+    {
+      "Name": "xdo.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdo.bz2"
+    },
+    {
+      "Name": "xdp.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdp.bz2"
+    },
+    {
+      "Name": "xdq.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdq.bz2"
+    },
+    {
+      "Name": "xdr.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdr.bz2"
+    },
+    {
+      "Name": "xds.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xds.bz2"
+    },
+    {
+      "Name": "xdt.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdt.bz2"
+    },
+    {
+      "Name": "xdu.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdu.bz2"
+    },
+    {
+      "Name": "xdv.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdv.bz2"
+    },
+    {
+      "Name": "xdw.csv",
+      "URL": "https://github.com/zmap/zlint-test-corpus/raw/master/certificates/xdw.bz2"
     }
   ],
   "Expected": {
+    "e_algorithm_identifier_improper_encoding": {},
     "e_basic_constraints_not_critical": {
-      "ErrCount": 11
+      "ErrCount": 23
     },
     "e_br_prohibit_dsa_usage": {},
     "e_ca_common_name_missing": {},
     "e_ca_country_name_invalid": {
-      "ErrCount": 5
+      "ErrCount": 8
     },
     "e_ca_country_name_missing": {
-      "ErrCount": 31
+      "ErrCount": 72
     },
     "e_ca_crl_sign_not_set": {
       "ErrCount": 1
@@ -262,24 +343,24 @@
       "ErrCount": 1
     },
     "e_ca_key_usage_missing": {
-      "ErrCount": 9
+      "ErrCount": 13
     },
     "e_ca_key_usage_not_critical": {
-      "ErrCount": 21
+      "ErrCount": 40
     },
     "e_ca_organization_name_missing": {
-      "ErrCount": 64
+      "ErrCount": 128
     },
     "e_ca_subject_field_empty": {},
     "e_cab_dv_conflicts_with_locality": {
-      "ErrCount": 12
+      "ErrCount": 13
     },
     "e_cab_dv_conflicts_with_org": {
-      "ErrCount": 12
+      "ErrCount": 13
     },
     "e_cab_dv_conflicts_with_postal": {},
     "e_cab_dv_conflicts_with_province": {
-      "ErrCount": 12
+      "ErrCount": 13
     },
     "e_cab_dv_conflicts_with_street": {},
     "e_cab_iv_requires_personal_name": {},
@@ -292,69 +373,78 @@
     "e_cert_policy_iv_requires_province_or_locality": {},
     "e_cert_policy_ov_requires_country": {},
     "e_cert_policy_ov_requires_province_or_locality": {
-      "ErrCount": 322
+      "ErrCount": 326
     },
     "e_cert_sig_alg_not_match_tbs_sig_alg": {
-      "ErrCount": 10
+      "ErrCount": 11
     },
     "e_cert_unique_identifier_version_not_2_or_3": {},
     "e_distribution_point_incomplete": {},
     "e_dnsname_bad_character_in_label": {
-      "ErrCount": 167
+      "ErrCount": 55927
     },
-    "e_dnsname_contains_bare_iana_suffix": {},
+    "e_dnsname_contains_bare_iana_suffix": {
+      "ErrCount": 8
+    },
+    "e_dnsname_contains_prohibited_reserved_label": {},
     "e_dnsname_empty_label": {
-      "ErrCount": 11
-    },
-    "e_rfc_dnsname_empty_label": {
-      "ErrCount": 10
+      "ErrCount": 197
     },
     "e_dnsname_hyphen_in_sld": {},
-    "e_dnsname_label_too_long": {},
+    "e_dnsname_label_too_long": {
+      "ErrCount": 22
+    },
     "e_dnsname_left_label_wildcard_correct": {
-      "ErrCount": 5
+      "ErrCount": 17
     },
     "e_dnsname_not_valid_tld": {
-      "ErrCount": 138
+      "ErrCount": 86371
     },
     "e_dnsname_underscore_in_sld": {
-      "ErrCount": 1
+      "ErrCount": 5
     },
-    "e_rfc_dnsname_underscore_in_sld": {
-      "ErrCount": 1
+    "e_dnsname_wildcard_only_in_left_label": {
+      "ErrCount": 2
     },
-    "e_dnsname_wildcard_only_in_left_label": {},
     "e_dsa_correct_order_in_subgroup": {},
-    "e_dsa_improper_modulus_or_divisor_size": {},
+    "e_dsa_improper_modulus_or_divisor_size": {
+      "ErrCount": 11
+    },
     "e_dsa_params_missing": {},
-    "e_dsa_shorter_than_2048_bits": {},
+    "e_dsa_shorter_than_2048_bits": {
+      "ErrCount": 11
+    },
     "e_dsa_unique_correct_representation": {},
     "e_ec_improper_curves": {},
+    "e_ecdsa_allowed_ku": {},
     "e_ev_business_category_missing": {
       "ErrCount": 2
     },
     "e_ev_country_name_missing": {},
-    "e_ev_organization_id_missing": {},
-    "e_ev_organization_name_missing": {},
-    "e_ev_serial_number_missing": {
+    "e_ev_not_wildcard": {
       "ErrCount": 1
     },
+    "e_ev_organization_id_missing": {},
+    "e_ev_organization_name_missing": {},
+    "e_ev_san_ip_address_present": {
+      "ErrCount": 3
+    },
+    "e_ev_serial_number_missing": {
+      "ErrCount": 2
+    },
     "e_ev_valid_time_too_long": {
-      "ErrCount": 151
+      "ErrCount": 221
     },
     "e_ext_aia_marked_critical": {},
     "e_ext_authority_key_identifier_critical": {},
-    "e_ext_authority_key_identifier_missing": {
-      "ErrCount": 37
-    },
     "e_ext_authority_key_identifier_no_key_identifier": {
-      "ErrCount": 66
+      "ErrCount": 9987
     },
     "e_ext_cert_policy_disallowed_any_policy_qualifier": {},
     "e_ext_cert_policy_duplicate": {},
     "e_ext_cert_policy_explicit_text_ia5_string": {},
     "e_ext_cert_policy_explicit_text_too_long": {
-      "ErrCount": 431
+      "ErrCount": 567
     },
     "e_ext_duplicate_extension": {},
     "e_ext_freshest_crl_marked_critical": {},
@@ -370,20 +460,24 @@
     "e_ext_key_usage_cert_sign_without_ca": {},
     "e_ext_key_usage_without_bits": {},
     "e_ext_name_constraints_not_critical": {
-      "ErrCount": 130
+      "ErrCount": 216
     },
     "e_ext_name_constraints_not_in_ca": {},
     "e_ext_nc_intersects_reserved_ip": {},
     "e_ext_policy_constraints_empty": {},
-    "e_ext_policy_constraints_not_critical": {},
+    "e_ext_policy_constraints_not_critical": {
+      "ErrCount": 88
+    },
     "e_ext_policy_map_any_policy": {},
     "e_ext_san_contains_reserved_ip": {
-      "ErrCount": 1
+      "ErrCount": 42
     },
     "e_ext_san_directory_name_present": {
-      "ErrCount": 738
+      "ErrCount": 15676
     },
-    "e_ext_san_dns_name_too_long": {},
+    "e_ext_san_dns_name_too_long": {
+      "ErrCount": 1
+    },
     "e_ext_san_dns_not_ia5_string": {
       "ErrCount": 1
     },
@@ -392,32 +486,40 @@
       "ErrCount": 2
     },
     "e_ext_san_missing": {
-      "ErrCount": 93
+      "ErrCount": 52385
     },
     "e_ext_san_no_entries": {
       "ErrCount": 3
     },
     "e_ext_san_not_critical_without_subject": {},
     "e_ext_san_other_name_present": {
-      "ErrCount": 19
+      "ErrCount": 476
     },
     "e_ext_san_registered_id_present": {},
-    "e_ext_san_rfc822_format_invalid": {},
+    "e_ext_san_rfc822_format_invalid": {
+      "ErrCount": 6
+    },
     "e_ext_san_rfc822_name_present": {
-      "ErrCount": 119
+      "ErrCount": 36356
     },
     "e_ext_san_space_dns_name": {},
     "e_ext_san_uniform_resource_identifier_present": {
-      "ErrCount": 1
+      "ErrCount": 231
     },
-    "e_ext_san_uri_format_invalid": {},
-    "e_ext_san_uri_host_not_fqdn_or_ip": {},
+    "e_ext_san_uri_format_invalid": {
+      "ErrCount": 186
+    },
+    "e_ext_san_uri_host_not_fqdn_or_ip": {
+      "ErrCount": 186
+    },
     "e_ext_san_uri_not_ia5": {},
-    "e_ext_san_uri_relative": {},
+    "e_ext_san_uri_relative": {
+      "ErrCount": 186
+    },
     "e_ext_subject_directory_attr_critical": {},
     "e_ext_subject_key_identifier_critical": {},
     "e_ext_subject_key_identifier_missing_ca": {
-      "ErrCount": 5
+      "ErrCount": 14
     },
     "e_ext_tor_service_descriptor_hash_invalid": {},
     "e_generalized_time_does_not_include_seconds": {},
@@ -427,20 +529,28 @@
     "e_ian_dns_name_includes_null_char": {},
     "e_ian_dns_name_starts_with_period": {},
     "e_ian_wildcard_not_first": {},
-    "e_inhibit_any_policy_not_critical": {},
+    "e_incorrect_ku_encoding": {
+      "ErrCount": 6725
+    },
+    "e_inhibit_any_policy_not_critical": {
+      "ErrCount": 70
+    },
     "e_international_dns_name_not_nfc": {},
-    "e_international_dns_name_not_unicode": {},
+    "e_international_dns_name_not_unicode": {
+      "ErrCount": 1
+    },
     "e_invalid_certificate_version": {},
     "e_issuer_dn_country_not_printable_string": {},
     "e_issuer_field_empty": {},
+    "e_key_usage_incorrect_length": {},
     "e_mp_authority_key_identifier_correct": {
-      "ErrCount": 3463
+      "ErrCount": 3704
     },
     "e_mp_ecdsa_pub_key_encoding_correct": {},
     "e_mp_ecdsa_signature_encoding_correct": {},
     "e_mp_exponent_cannot_be_one": {},
     "e_mp_modulus_must_be_2048_bits_or_more": {
-      "ErrCount": 1
+      "ErrCount": 8
     },
     "e_mp_modulus_must_be_divisible_by_8": {
       "ErrCount": 21
@@ -451,25 +561,33 @@
     "e_name_constraint_maximum_not_absent": {},
     "e_name_constraint_minimum_non_zero": {},
     "e_name_constraint_not_fqdn": {},
-    "e_ocsp_id_pkix_ocsp_nocheck_ext_not_included_server_auth": {
-      "ErrCount": 78
+    "e_no_underscores_before_1_6_2": {
+      "ErrCount": 370
     },
-    "e_old_root_ca_rsa_mod_less_than_2048_bits": {},
+    "e_ocsp_id_pkix_ocsp_nocheck_ext_not_included_server_auth": {
+      "ErrCount": 93
+    },
+    "e_old_root_ca_rsa_mod_less_than_2048_bits": {
+      "ErrCount": 1
+    },
     "e_old_sub_ca_rsa_mod_less_than_1024_bits": {},
-    "e_old_sub_cert_rsa_mod_less_than_1024_bits": {},
+    "e_old_sub_cert_rsa_mod_less_than_1024_bits": {
+      "ErrCount": 439
+    },
     "e_onion_subject_validity_time_too_large": {},
+    "e_organizational_unit_name_prohibited": {},
     "e_path_len_constraint_improperly_included": {
-      "ErrCount": 4
+      "ErrCount": 17
     },
     "e_path_len_constraint_zero_or_less": {},
     "e_prohibit_dsa_usage": {},
     "e_public_key_type_not_allowed": {},
     "e_qcstatem_etsi_present_qcs_critical": {},
     "e_qcstatem_etsi_type_as_statem": {
-      "ErrCount": 234
+      "ErrCount": 240
     },
     "e_qcstatem_mandatory_etsi_statems": {
-      "ErrCount": 1677
+      "ErrCount": 1707
     },
     "e_qcstatem_qccompliance_valid": {},
     "e_qcstatem_qclimitvalue_valid": {},
@@ -477,131 +595,160 @@
     "e_qcstatem_qcretentionperiod_valid": {},
     "e_qcstatem_qcsscd_valid": {},
     "e_qcstatem_qctype_valid": {},
+    "e_rfc_dnsname_empty_label": {
+      "ErrCount": 16
+    },
+    "e_rfc_dnsname_hyphen_in_sld": {},
+    "e_rfc_dnsname_label_too_long": {},
+    "e_rfc_dnsname_underscore_in_sld": {
+      "ErrCount": 1
+    },
     "e_root_ca_extended_key_usage_present": {},
     "e_root_ca_key_usage_must_be_critical": {
-      "ErrCount": 14
+      "ErrCount": 19
     },
     "e_root_ca_key_usage_present": {
       "ErrCount": 5
     },
+    "e_rsa_allowed_ku_ca": {
+      "ErrCount": 2
+    },
+    "e_rsa_allowed_ku_ee": {
+      "ErrCount": 1774
+    },
+    "e_rsa_allowed_ku_no_encipherment_ca": {
+      "ErrCount": 18
+    },
     "e_rsa_exp_negative": {},
+    "e_rsa_fermat_factorization": {},
     "e_rsa_mod_less_than_2048_bits": {
-      "ErrCount": 51
+      "ErrCount": 34006
     },
     "e_rsa_no_public_key": {},
     "e_rsa_public_exponent_not_odd": {},
     "e_rsa_public_exponent_too_small": {},
-    "e_san_bare_wildcard": {},
+    "e_san_bare_wildcard": {
+      "ErrCount": 1
+    },
     "e_san_dns_name_includes_null_char": {},
     "e_san_dns_name_onion_invalid": {},
     "e_san_dns_name_onion_not_ev_cert": {},
     "e_san_dns_name_starts_with_period": {},
     "e_san_wildcard_not_first": {
-      "ErrCount": 2
+      "ErrCount": 12
     },
     "e_serial_number_longer_than_20_octets": {
-      "ErrCount": 190
+      "ErrCount": 252
     },
     "e_serial_number_not_positive": {
-      "ErrCount": 6
+      "ErrCount": 10
     },
-    "e_signature_algorithm_not_supported": {},
+    "e_signature_algorithm_not_supported": {
+      "ErrCount": 23
+    },
     "e_spki_rsa_encryption_parameter_not_null": {
       "ErrCount": 7
     },
     "e_sub_ca_aia_marked_critical": {},
     "e_sub_ca_aia_missing": {
-      "ErrCount": 110
+      "ErrCount": 292
     },
     "e_sub_ca_certificate_policies_missing": {
-      "ErrCount": 34
+      "ErrCount": 59
     },
     "e_sub_ca_crl_distribution_points_does_not_contain_url": {
-      "ErrCount": 1
+      "ErrCount": 2
     },
     "e_sub_ca_crl_distribution_points_marked_critical": {},
     "e_sub_ca_crl_distribution_points_missing": {
-      "ErrCount": 3
+      "ErrCount": 4
     },
     "e_sub_cert_aia_does_not_contain_ocsp_url": {
-      "ErrCount": 93
+      "ErrCount": 13944
     },
     "e_sub_cert_aia_marked_critical": {},
     "e_sub_cert_aia_missing": {
-      "ErrCount": 66
+      "ErrCount": 11935
     },
     "e_sub_cert_cert_policy_empty": {
-      "ErrCount": 8
+      "ErrCount": 738
     },
     "e_sub_cert_certificate_policies_missing": {
-      "ErrCount": 8
+      "ErrCount": 738
     },
     "e_sub_cert_country_name_must_appear": {
-      "ErrCount": 1
+      "ErrCount": 171
     },
     "e_sub_cert_crl_distribution_points_does_not_contain_url": {
-      "ErrCount": 29
+      "ErrCount": 13669
     },
     "e_sub_cert_crl_distribution_points_marked_critical": {},
     "e_sub_cert_eku_missing": {
-      "ErrCount": 84
+      "ErrCount": 81098
     },
-    "e_sub_cert_eku_server_auth_client_auth_missing": {},
+    "e_sub_cert_eku_server_auth_client_auth_missing": {
+      "ErrCount": 4934
+    },
     "e_sub_cert_given_name_surname_contains_correct_policy": {
-      "ErrCount": 10
+      "ErrCount": 1793
     },
     "e_sub_cert_key_usage_cert_sign_bit_set": {},
     "e_sub_cert_key_usage_crl_sign_bit_set": {},
     "e_sub_cert_locality_name_must_appear": {
-      "ErrCount": 607
+      "ErrCount": 2709
     },
     "e_sub_cert_locality_name_must_not_appear": {
-      "ErrCount": 13
+      "ErrCount": 15
     },
     "e_sub_cert_not_is_ca": {
       "ErrCount": 1
     },
     "e_sub_cert_or_sub_ca_using_sha1": {
-      "ErrCount": 12
+      "ErrCount": 1295
     },
     "e_sub_cert_postal_code_must_not_appear": {},
     "e_sub_cert_province_must_appear": {
-      "ErrCount": 607
+      "ErrCount": 2709
     },
     "e_sub_cert_province_must_not_appear": {
       "ErrCount": 8
     },
     "e_sub_cert_street_address_should_not_exist": {},
     "e_sub_cert_valid_time_longer_than_39_months": {
-      "ErrCount": 365
+      "ErrCount": 2756
     },
     "e_sub_cert_valid_time_longer_than_825_days": {
-      "ErrCount": 21
-    },
-    "e_subject_common_name_max_length": {
       "ErrCount": 31
     },
-    "e_subject_common_name_not_exactly_from_san": {},
+    "e_subject_common_name_max_length": {
+      "ErrCount": 60
+    },
+    "e_subject_common_name_not_exactly_from_san": {
+      "ErrCount": 2
+    },
     "e_subject_common_name_not_from_san": {
-      "ErrCount": 229
+      "ErrCount": 94976
     },
     "e_subject_contains_noninformational_value": {
-      "ErrCount": 325
+      "ErrCount": 338
     },
+    "e_subject_contains_organizational_unit_name_and_no_organization_name": {},
     "e_subject_contains_reserved_arpa_ip": {},
     "e_subject_contains_reserved_ip": {
       "ErrCount": 1
     },
     "e_subject_country_not_iso": {
-      "ErrCount": 6
+      "ErrCount": 167
     },
-    "e_subject_dn_country_not_printable_string": {},
+    "e_subject_dn_country_not_printable_string": {
+      "ErrCount": 4
+    },
     "e_subject_dn_not_printable_characters": {
-      "ErrCount": 70
+      "ErrCount": 541
     },
     "e_subject_dn_serial_number_max_length": {},
     "e_subject_dn_serial_number_not_printable_string": {
-      "ErrCount": 50
+      "ErrCount": 51
     },
     "e_subject_email_max_length": {},
     "e_subject_empty_without_san": {},
@@ -610,121 +757,113 @@
     "e_subject_locality_name_max_length": {},
     "e_subject_not_dn": {},
     "e_subject_organization_name_max_length": {
-      "ErrCount": 38
+      "ErrCount": 92
     },
     "e_subject_organizational_unit_name_max_length": {
-      "ErrCount": 80
+      "ErrCount": 151
     },
     "e_subject_postal_code_max_length": {
-      "ErrCount": 2
+      "ErrCount": 3
     },
     "e_subject_printable_string_badalpha": {
-      "ErrCount": 7
+      "ErrCount": 225
     },
     "e_subject_state_name_max_length": {},
     "e_subject_street_address_max_length": {},
     "e_subject_surname_max_length": {},
-    "e_tbs_signature_rsa_encryption_parameter_not_null": {
-      "ErrCount": 96
+    "e_superfluous_ku_encoding": {
+      "ErrCount": 3
     },
-    "e_tls_server_cert_valid_time_longer_than_398_days": {},
+    "e_tbs_signature_rsa_encryption_parameter_not_null": {
+      "ErrCount": 103
+    },
+    "e_tls_server_cert_valid_time_longer_than_398_days": {
+      "ErrCount": 3
+    },
+    "e_underscore_not_permissible_in_dnsname": {},
     "e_utc_time_does_not_include_seconds": {
       "ErrCount": 1
     },
     "e_utc_time_not_in_zulu": {},
     "e_validity_time_not_positive": {},
     "e_wrong_time_format_pre2050": {
-      "ErrCount": 19
-    },
-    "e_ev_not_wildcard": {
-      "ErrCount": 1
-    },
-    "e_ecdsa_allowed_ku": {},
-    "e_rsa_allowed_ku_ca": {
-      "ErrCount": 1
-    },
-    "e_rsa_allowed_ku_no_encipherment_ca": {
-      "ErrCount": 12
-    },
-    "e_rsa_allowed_ku_ee": {
-      "ErrCount": 181
+      "ErrCount": 23
     },
     "n_ca_digital_signature_not_set": {
-      "NoticeCount": 724
+      "NoticeCount": 1409
     },
     "n_contains_redacted_dnsname": {
-      "NoticeCount": 459
+      "NoticeCount": 464
     },
     "n_dnsname_wildcard_left_of_public_suffix": {
-      "NoticeCount": 1
+      "NoticeCount": 3
     },
     "n_ecdsa_ee_invalid_ku": {
-      "NoticeCount": 29
+      "NoticeCount": 31
     },
     "n_mp_allowed_eku": {
-      "NoticeCount": 14
+      "NoticeCount": 48
     },
-    "n_multiple_subject_rdn": {},
+    "n_multiple_subject_rdn": {
+      "NoticeCount": 972
+    },
     "n_san_dns_name_duplicate": {
-      "NoticeCount": 705
+      "NoticeCount": 5342
     },
     "n_san_iana_pub_suffix_empty": {
-      "NoticeCount": 34
+      "NoticeCount": 668
     },
     "n_sub_ca_eku_missing": {
-      "NoticeCount": 678
+      "NoticeCount": 1415
     },
     "n_sub_ca_eku_not_technically_constrained": {
       "NoticeCount": 10
     },
     "n_subject_common_name_included": {
-      "NoticeCount": 593196
+      "NoticeCount": 712639
     },
     "w_ct_sct_policy_count_unsatisfied": {
-      "NoticeCount": 4680
+      "NoticeCount": 5003
     },
     "w_distribution_point_missing_ldap_or_uri": {
-      "WarnCount": 5
+      "WarnCount": 1249
     },
     "w_dnsname_underscore_in_trd": {
-      "WarnCount": 339
-    },
-    "w_rfc_dnsname_underscore_in_trd": {
-      "WarnCount": 339
+      "WarnCount": 382
     },
     "w_eku_critical_improperly": {},
     "w_ext_aia_access_location_missing": {
-      "WarnCount": 284
+      "WarnCount": 863
     },
     "w_ext_cert_policy_contains_noticeref": {
-      "WarnCount": 7191
+      "WarnCount": 7821
     },
     "w_ext_cert_policy_explicit_text_includes_control": {
       "WarnCount": 1
     },
     "w_ext_cert_policy_explicit_text_not_nfc": {},
     "w_ext_cert_policy_explicit_text_not_utf8": {
-      "WarnCount": 9872
+      "WarnCount": 15350
     },
     "w_ext_crl_distribution_marked_critical": {},
     "w_ext_ian_critical": {},
     "w_ext_key_usage_not_critical": {
-      "WarnCount": 16755
+      "WarnCount": 25323
     },
     "w_ext_policy_map_not_critical": {
-      "WarnCount": 3
+      "WarnCount": 163
     },
     "w_ext_policy_map_not_in_cert_policy": {
-      "WarnCount": 3
+      "WarnCount": 5
     },
     "w_ext_san_critical_with_subject_dn": {
-      "WarnCount": 30
+      "WarnCount": 95
     },
     "w_ext_subject_key_identifier_missing_sub_cert": {
-      "WarnCount": 59194
+      "WarnCount": 119268
     },
     "w_extra_subject_common_names": {
-      "WarnCount": 16
+      "WarnCount": 36
     },
     "w_ian_iana_pub_suffix_empty": {},
     "w_issuer_dn_leading_whitespace": {},
@@ -734,58 +873,61 @@
     "w_name_constraint_on_registered_id": {},
     "w_name_constraint_on_x400": {},
     "w_qcstatem_qcpds_lang_case": {
-      "WarnCount": 816
+      "WarnCount": 934
     },
     "w_qcstatem_qctype_web": {
-      "WarnCount": 25
+      "WarnCount": 55
     },
-    "w_root_ca_basic_constraints_path_len_constraint_field_present": {},
-    "w_root_ca_contains_cert_policy": {
+    "w_rfc_dnsname_underscore_in_trd": {
+      "WarnCount": 364
+    },
+    "w_root_ca_basic_constraints_path_len_constraint_field_present": {
       "WarnCount": 3
+    },
+    "w_root_ca_contains_cert_policy": {
+      "WarnCount": 8
     },
     "w_rsa_mod_factors_smaller_than_752": {},
     "w_rsa_mod_not_odd": {},
     "w_rsa_public_exponent_not_in_range": {
-      "WarnCount": 45
+      "WarnCount": 110
     },
     "w_sub_ca_aia_does_not_contain_issuing_ca_url": {
-      "WarnCount": 574
+      "WarnCount": 990
     },
-    "w_sub_ca_aia_missing": {},
+    "w_sub_ca_aia_missing": {
+      "WarnCount": 4
+    },
     "w_sub_ca_certificate_policies_marked_critical": {},
     "w_sub_ca_eku_critical": {
       "WarnCount": 9
     },
     "w_sub_ca_name_constraints_not_critical": {
-      "WarnCount": 93
+      "WarnCount": 115
     },
     "w_sub_cert_aia_does_not_contain_issuing_ca_url": {
-      "WarnCount": 33636
+      "WarnCount": 48465
     },
     "w_sub_cert_certificate_policies_marked_critical": {},
     "w_sub_cert_eku_extra_values": {
-      "WarnCount": 2025
+      "WarnCount": 25405
     },
     "w_sub_cert_sha1_expiration_too_long": {
-      "WarnCount": 10
+      "WarnCount": 11058
     },
     "w_subject_contains_malformed_arpa_ip": {
       "WarnCount": 2
     },
     "w_subject_dn_leading_whitespace": {
-      "WarnCount": 17
+      "WarnCount": 36
     },
     "w_subject_dn_trailing_whitespace": {
-      "WarnCount": 64
+      "WarnCount": 213
     },
     "w_subject_given_name_recommended_max_length": {},
     "w_subject_surname_recommended_max_length": {},
-    "w_tls_server_cert_valid_time_longer_than_397_days": {},
-    "e_no_underscores_before_1_6_2": {
-      "ErrCount": 340
-    },
-    "e_incorrect_ku_encoding": {
-      "ErrCount": 6586
+    "w_tls_server_cert_valid_time_longer_than_397_days": {
+      "WarnCount": 223
     }
   }
 }


### PR DESCRIPTION
The ZLint project has begun writing lints for email protection certificates (https://github.com/zmap/zlint/pull/713) so it would appropriate to have a wide corpus for testing.

These certs were pulled from Censys using the following query.

```sql
SELECT fingerprint_sha256, raw FROM `censys-io.certificates_v2.certificates` 
WHERE (parsed.extensions.extended_key_usage.any = true 
or parsed.extensions.extended_key_usage.email_protection = true
or parsed.extensions.extended_key_usage is null)
and validation.nss.ever_valid = true
```

Aside from reformatting and sanitization, I have also gone through the task of deduplicating these certificates against the corpus because (as it turns out) there are about 1500 certs that are both email protection certs _and_ server auth certs.