### PR TITLE
Ensure AIA URLs point to public paths

### DIFF
--- a/v3/integration/config.json
+++ b/v3/integration/config.json
@@ -931,6 +931,9 @@
     "w_subject_surname_recommended_max_length": {},
     "w_tls_server_cert_valid_time_longer_than_397_days": {
       "WarnCount": 223
+    },
+    "w_sub_cert_aia_contains_internal_names": {
+      "WarnCount": 210
     }
   }
 }

--- a/v3/lints/cabf_br/lint_sub_cert_aia_contains_internal_names.go
+++ b/v3/lints/cabf_br/lint_sub_cert_aia_contains_internal_names.go
@@ -58,7 +58,7 @@ func (l *subCertAIAInternalName) Execute(c *x509.Certificate) *lint.LintResult {
 	for _, u := range c.OCSPServer {
 		purl, err := url.Parse(u)
 		if err != nil {
-			return &lint.LintResult{Status: lint.Fatal}
+			return &lint.LintResult{Status: lint.Error}
 		}
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
@@ -67,7 +67,7 @@ func (l *subCertAIAInternalName) Execute(c *x509.Certificate) *lint.LintResult {
 	for _, u := range c.IssuingCertificateURL {
 		purl, err := url.Parse(u)
 		if err != nil {
-			return &lint.LintResult{Status: lint.Fatal}
+			return &lint.LintResult{Status: lint.Error}
 		}
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}

--- a/v3/lints/cabf_br/lint_sub_cert_aia_contains_internal_names.go
+++ b/v3/lints/cabf_br/lint_sub_cert_aia_contains_internal_names.go
@@ -1,0 +1,77 @@
+package cabf_br
+
+/*
+ * ZLint Copyright 2023 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+type subCertAIAInternalName struct{}
+
+/************************************************************************
+BRs: 7.1.2.10.3
+CA Certificate Authority Information Access
+This extension MAY be present. If present, it MUST NOT be marked critical, and it MUST contain the
+HTTP URL of the CA’s CRL service.
+
+id-ad-ocsp        A HTTP URL of the Issuing CA's OCSP responder.
+id-ad-caIssuers   A HTTP URL of the Issuing CA's Certificate.
+*************************************************************************/
+
+func init() {
+	lint.RegisterLint(&lint.Lint{
+		Name:          "w_sub_cert_aia_contains_internal_names",
+		Description:   "Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the issuing CA’s certificate, for public certificates this should not be an internal name",
+		Citation:      "BRs: 7.1.2.10.3",
+		Source:        lint.CABFBaselineRequirements,
+		EffectiveDate: util.CABEffectiveDate,
+		Lint:          NewSubCertAIAInternalName,
+	})
+}
+
+func NewSubCertAIAInternalName() lint.LintInterface {
+	return &subCertAIAInternalName{}
+}
+
+func (l *subCertAIAInternalName) CheckApplies(c *x509.Certificate) bool {
+	return util.IsSubscriberCert(c)
+}
+
+func (l *subCertAIAInternalName) Execute(c *x509.Certificate) *lint.LintResult {
+	for _, u := range c.OCSPServer {
+		purl, err := url.Parse(u)
+		if err != nil {
+			return &lint.LintResult{Status: lint.Fatal}
+		}
+		if !util.HasValidTLD(purl.Host, time.Now()) {
+			return &lint.LintResult{Status: lint.Warn}
+		}
+	}
+	for _, u := range c.IssuingCertificateURL {
+		purl, err := url.Parse(u)
+		if err != nil {
+			return &lint.LintResult{Status: lint.Fatal}
+		}
+		if !util.HasValidTLD(purl.Host, time.Now()) {
+			return &lint.LintResult{Status: lint.Warn}
+		}
+	}
+	return &lint.LintResult{Status: lint.Pass}
+}

--- a/v3/lints/cabf_br/lint_sub_cert_aia_contains_internal_names.go
+++ b/v3/lints/cabf_br/lint_sub_cert_aia_contains_internal_names.go
@@ -60,7 +60,7 @@ func (l *subCertAIAInternalName) Execute(c *x509.Certificate) *lint.LintResult {
 		if err != nil {
 			return &lint.LintResult{Status: lint.Fatal}
 		}
-		if !util.HasValidTLD(purl.Host, time.Now()) {
+		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
 	}
@@ -69,7 +69,7 @@ func (l *subCertAIAInternalName) Execute(c *x509.Certificate) *lint.LintResult {
 		if err != nil {
 			return &lint.LintResult{Status: lint.Fatal}
 		}
-		if !util.HasValidTLD(purl.Host, time.Now()) {
+		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
 	}

--- a/v3/lints/cabf_br/lint_sub_cert_aia_contains_internal_names_test.go
+++ b/v3/lints/cabf_br/lint_sub_cert_aia_contains_internal_names_test.go
@@ -1,4 +1,4 @@
-package cabf_smime_br
+package cabf_br
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	"github.com/zmap/zlint/v3/test"
 )
 
-func TestSMIMEStrictAIAInternalName(t *testing.T) {
+func TestAIAInternalName(t *testing.T) {
 	testCases := []struct {
 		Name           string
 		InputFilename  string
@@ -15,18 +15,18 @@ func TestSMIMEStrictAIAInternalName(t *testing.T) {
 	}{
 		{
 			Name:           "pass - aia with valid names",
-			InputFilename:  "smime/aiaWithValidNamesStrict.pem",
+			InputFilename:  "aiaWithValidNames.pem",
 			ExpectedResult: lint.Pass,
 		},
 		{
 			Name:           "warn - aia with internal names",
-			InputFilename:  "smime/aiaWithInternalNamesStrict.pem",
+			InputFilename:  "aiaWithInternalNames.pem",
 			ExpectedResult: lint.Warn,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			result := test.TestLint("w_smime_strict_aia_contains_internal_names", tc.InputFilename)
+			result := test.TestLint("w_sub_cert_aia_contains_internal_names", tc.InputFilename)
 			if result.Status != tc.ExpectedResult {
 				t.Errorf("expected result %v was %v - details: %v", tc.ExpectedResult, result.Status, result.Details)
 			}

--- a/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
@@ -57,6 +57,7 @@ func (l *smimeLegacyAIAContainsInternalNames) CheckApplies(c *x509.Certificate) 
 }
 
 func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint.LintResult {
+	atLeastOneHttp := false
 	for _, u := range c.OCSPServer {
 		purl, err := url.Parse(u)
 		if err != nil {
@@ -65,7 +66,15 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
+		if purl.Scheme == "http" {
+			atLeastOneHttp = true
+		}
 	}
+	if !atLeastOneHttp {
+		return &lint.LintResult{Status: lint.Error, Details: "at least one accessMethod MUST have the URI scheme HTTP"}
+	}
+
+	atLeastOneHttp = false
 	for _, u := range c.IssuingCertificateURL {
 		purl, err := url.Parse(u)
 		if err != nil {
@@ -74,6 +83,13 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
+		if purl.Scheme == "http" {
+			atLeastOneHttp = true
+		}
 	}
+	if !atLeastOneHttp {
+		return &lint.LintResult{Status: lint.Error, Details: "at least one accessMethod MUST have the URI scheme HTTP"}
+	}
+
 	return &lint.LintResult{Status: lint.Pass}
 }

--- a/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
@@ -66,7 +66,7 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
-		if purl.Scheme == "http" {
+		if purl.Scheme == "http" || purl.Scheme == "https" {
 			atLeastOneHttp = true
 		}
 	}
@@ -83,7 +83,7 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
-		if purl.Scheme == "http" {
+		if purl.Scheme == "http" || purl.Scheme == "https" {
 			atLeastOneHttp = true
 		}
 	}

--- a/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
@@ -1,0 +1,79 @@
+package cabf_smime_br
+
+/*
+ * ZLint Copyright 2023 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+type smimeLegacyAIAContainsInternalNames struct{}
+
+/************************************************************************
+BRs: 7.1.2.3c
+CA Certificate Authority Information Access
+The authorityInformationAccess extension MAY contain one or more accessMethod
+values for each of the following types:
+
+id-ad-ocsp        specifies the URI of the Issuing CA's OCSP responder.
+id-ad-caIssuers   specifies the URI of the Issuing CA's Certificate.
+
+For Legacy: When provided, at least one accessMethod SHALL have the URI scheme HTTP. Other schemes (LDAP, FTP, ...) MAY be present.
+*************************************************************************/
+
+func init() {
+	lint.RegisterLint(&lint.Lint{
+		Name:          "w_smime_legacy_aia_contains_internal_names",
+		Description:   "SMIME Legacy certificates authorityInformationAccess When provided, at least one accessMethod SHALL have the URI scheme HTTP. Other schemes (LDAP, FTP, ...) MAY be present.",
+		Citation:      "BRs: 7.1.2.3c",
+		Source:        lint.CABFSMIMEBaselineRequirements,
+		EffectiveDate: util.CABEffectiveDate,
+		Lint:          NewSMIMELegacyAIAInternalName,
+	})
+}
+
+func NewSMIMELegacyAIAInternalName() lint.LintInterface {
+	return &smimeLegacyAIAContainsInternalNames{}
+}
+
+func (l *smimeLegacyAIAContainsInternalNames) CheckApplies(c *x509.Certificate) bool {
+	return util.IsLegacySMIMECertificate(c)
+}
+
+func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint.LintResult {
+	for _, u := range c.OCSPServer {
+		purl, err := url.Parse(u)
+		if err != nil {
+			return &lint.LintResult{Status: lint.Fatal}
+		}
+		if !util.HasValidTLD(purl.Host, time.Now()) {
+			return &lint.LintResult{Status: lint.Warn}
+		}
+	}
+	for _, u := range c.IssuingCertificateURL {
+		purl, err := url.Parse(u)
+		if err != nil {
+			return &lint.LintResult{Status: lint.Fatal}
+		}
+		if !util.HasValidTLD(purl.Host, time.Now()) {
+			return &lint.LintResult{Status: lint.Warn}
+		}
+	}
+	return &lint.LintResult{Status: lint.Pass}
+}

--- a/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
@@ -66,7 +66,7 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
-		if purl.Scheme == "http" || purl.Scheme == "https" {
+		if purl.Scheme == "http" {
 			atLeastOneHttp = true
 		}
 	}
@@ -83,7 +83,7 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
-		if purl.Scheme == "http" || purl.Scheme == "https" {
+		if purl.Scheme == "http" {
 			atLeastOneHttp = true
 		}
 	}

--- a/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
@@ -62,7 +62,7 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if err != nil {
 			return &lint.LintResult{Status: lint.Fatal}
 		}
-		if !util.HasValidTLD(purl.Host, time.Now()) {
+		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
 	}
@@ -71,7 +71,7 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if err != nil {
 			return &lint.LintResult{Status: lint.Fatal}
 		}
-		if !util.HasValidTLD(purl.Host, time.Now()) {
+		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
 	}

--- a/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
@@ -61,7 +61,7 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 	for _, u := range c.OCSPServer {
 		purl, err := url.Parse(u)
 		if err != nil {
-			return &lint.LintResult{Status: lint.Fatal}
+			return &lint.LintResult{Status: lint.Error}
 		}
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
@@ -78,7 +78,7 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 	for _, u := range c.IssuingCertificateURL {
 		purl, err := url.Parse(u)
 		if err != nil {
-			return &lint.LintResult{Status: lint.Fatal}
+			return &lint.LintResult{Status: lint.Error}
 		}
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
@@ -87,7 +87,7 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 			atLeastOneHttp = true
 		}
 	}
-	if !atLeastOneHttp {
+	if !atLeastOneHttp && len(c.IssuingCertificateURL) != 0 {
 		return &lint.LintResult{Status: lint.Error, Details: "at least one accessMethod MUST have the URI scheme HTTP"}
 	}
 

--- a/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
@@ -70,7 +70,7 @@ func (l *smimeLegacyAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 			atLeastOneHttp = true
 		}
 	}
-	if !atLeastOneHttp {
+	if !atLeastOneHttp && len(c.OCSPServer) != 0 {
 		return &lint.LintResult{Status: lint.Error, Details: "at least one accessMethod MUST have the URI scheme HTTP"}
 	}
 

--- a/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names_test.go
+++ b/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names_test.go
@@ -13,11 +13,11 @@ func TestSMIMELegacyAIAInternalName(t *testing.T) {
 		InputFilename  string
 		ExpectedResult lint.LintStatus
 	}{
-		// {
-		// 	Name:           "pass - cert with SAN",
-		// 	InputFilename:  "smime/with_subject_alternative_name.pem",
-		// 	ExpectedResult: lint.Pass,
-		// },
+		{
+			Name:           "pass - cert with SAN",
+			InputFilename:  "smime/aiaWithValidNamesLegacy.pem",
+			ExpectedResult: lint.Pass,
+		},
 		{
 			Name:           "error - cert without SAN",
 			InputFilename:  "smime/aiaWithInternalNamesLegacy.pem",

--- a/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names_test.go
+++ b/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names_test.go
@@ -1,0 +1,35 @@
+package cabf_smime_br
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestSMIMELegacyAIAInternalName(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		InputFilename  string
+		ExpectedResult lint.LintStatus
+	}{
+		// {
+		// 	Name:           "pass - cert with SAN",
+		// 	InputFilename:  "smime/with_subject_alternative_name.pem",
+		// 	ExpectedResult: lint.Pass,
+		// },
+		{
+			Name:           "error - cert without SAN",
+			InputFilename:  "smime/aiaWithInternalNamesLegacy.pem",
+			ExpectedResult: lint.Warn,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := test.TestLint("w_smime_legacy_aia_contains_internal_names", tc.InputFilename)
+			if result.Status != tc.ExpectedResult {
+				t.Errorf("expected result %v was %v - details: %v", tc.ExpectedResult, result.Status, result.Details)
+			}
+		})
+	}
+}

--- a/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
@@ -62,7 +62,7 @@ func (l *smimeStrictAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if err != nil {
 			return &lint.LintResult{Status: lint.Fatal}
 		}
-		if !util.HasValidTLD(purl.Host, time.Now()) {
+		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
 	}
@@ -71,7 +71,7 @@ func (l *smimeStrictAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if err != nil {
 			return &lint.LintResult{Status: lint.Fatal}
 		}
-		if !util.HasValidTLD(purl.Host, time.Now()) {
+		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
 		}
 	}

--- a/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
@@ -60,7 +60,10 @@ func (l *smimeStrictAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 	for _, u := range c.OCSPServer {
 		purl, err := url.Parse(u)
 		if err != nil {
-			return &lint.LintResult{Status: lint.Fatal}
+			return &lint.LintResult{Status: lint.Error}
+		}
+		if purl.Scheme != "http" {
+			return &lint.LintResult{Status: lint.Error}
 		}
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}
@@ -69,7 +72,10 @@ func (l *smimeStrictAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 	for _, u := range c.IssuingCertificateURL {
 		purl, err := url.Parse(u)
 		if err != nil {
-			return &lint.LintResult{Status: lint.Fatal}
+			return &lint.LintResult{Status: lint.Error}
+		}
+		if purl.Scheme != "http" {
+			return &lint.LintResult{Status: lint.Error}
 		}
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
 			return &lint.LintResult{Status: lint.Warn}

--- a/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
@@ -62,7 +62,7 @@ func (l *smimeStrictAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if err != nil {
 			return &lint.LintResult{Status: lint.Error}
 		}
-		if purl.Scheme != "http" {
+		if purl.Scheme != "http" && purl.Scheme != "https" {
 			return &lint.LintResult{Status: lint.Error}
 		}
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
@@ -74,7 +74,7 @@ func (l *smimeStrictAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if err != nil {
 			return &lint.LintResult{Status: lint.Error}
 		}
-		if purl.Scheme != "http" {
+		if purl.Scheme != "http" && purl.Scheme != "https" {
 			return &lint.LintResult{Status: lint.Error}
 		}
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {

--- a/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
@@ -1,0 +1,79 @@
+package cabf_smime_br
+
+/*
+ * ZLint Copyright 2023 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+type smimeStrictAIAContainsInternalNames struct{}
+
+/************************************************************************
+BRs: 7.1.2.3c
+CA Certificate Authority Information Access
+The authorityInformationAccess extension MAY contain one or more accessMethod
+values for each of the following types:
+
+id-ad-ocsp        specifies the URI of the Issuing CA's OCSP responder.
+id-ad-caIssuers   specifies the URI of the Issuing CA's Certificate.
+
+For Strict and Multipurpose: When provided, every accessMethod SHALL have the URI scheme HTTP. Other schemes SHALL NOT be present.
+*************************************************************************/
+
+func init() {
+	lint.RegisterLint(&lint.Lint{
+		Name:          "w_smime_strict_aia_contains_internal_names",
+		Description:   "SMIME Strict certificates authorityInformationAccess When provided, every accessMethod SHALL have the URI scheme HTTP. Other schemes SHALL NOT be present.",
+		Citation:      "BRs: 7.1.2.3c",
+		Source:        lint.CABFSMIMEBaselineRequirements,
+		EffectiveDate: util.CABEffectiveDate,
+		Lint:          NewSMIMEStrictAIAInternalName,
+	})
+}
+
+func NewSMIMEStrictAIAInternalName() lint.LintInterface {
+	return &smimeStrictAIAContainsInternalNames{}
+}
+
+func (l *smimeStrictAIAContainsInternalNames) CheckApplies(c *x509.Certificate) bool {
+	return util.IsStrictSMIMECertificate(c) || util.IsMultipurposeSMIMECertificate(c)
+}
+
+func (l *smimeStrictAIAContainsInternalNames) Execute(c *x509.Certificate) *lint.LintResult {
+	for _, u := range c.OCSPServer {
+		purl, err := url.Parse(u)
+		if err != nil {
+			return &lint.LintResult{Status: lint.Fatal}
+		}
+		if !util.HasValidTLD(purl.Host, time.Now()) {
+			return &lint.LintResult{Status: lint.Warn}
+		}
+	}
+	for _, u := range c.IssuingCertificateURL {
+		purl, err := url.Parse(u)
+		if err != nil {
+			return &lint.LintResult{Status: lint.Fatal}
+		}
+		if !util.HasValidTLD(purl.Host, time.Now()) {
+			return &lint.LintResult{Status: lint.Warn}
+		}
+	}
+	return &lint.LintResult{Status: lint.Pass}
+}

--- a/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
@@ -62,7 +62,7 @@ func (l *smimeStrictAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if err != nil {
 			return &lint.LintResult{Status: lint.Error}
 		}
-		if purl.Scheme != "http" && purl.Scheme != "https" {
+		if purl.Scheme != "http" {
 			return &lint.LintResult{Status: lint.Error}
 		}
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {
@@ -74,7 +74,7 @@ func (l *smimeStrictAIAContainsInternalNames) Execute(c *x509.Certificate) *lint
 		if err != nil {
 			return &lint.LintResult{Status: lint.Error}
 		}
-		if purl.Scheme != "http" && purl.Scheme != "https" {
+		if purl.Scheme != "http" {
 			return &lint.LintResult{Status: lint.Error}
 		}
 		if !util.HasValidTLD(purl.Hostname(), time.Now()) {

--- a/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names_test.go
+++ b/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names_test.go
@@ -1,0 +1,35 @@
+package cabf_smime_br
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestSMIMEStrictAIAInternalName(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		InputFilename  string
+		ExpectedResult lint.LintStatus
+	}{
+		// {
+		// 	Name:           "pass - cert with SAN",
+		// 	InputFilename:  "smime/with_subject_alternative_name.pem",
+		// 	ExpectedResult: lint.Pass,
+		// },
+		{
+			Name:           "warn - cert with internal names in AIA",
+			InputFilename:  "smime/aiaWithInternalNamesLegacy.pem",
+			ExpectedResult: lint.Warn,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := test.TestLint("w_smime_strict_aia_contains_internal_names", tc.InputFilename)
+			if result.Status != tc.ExpectedResult {
+				t.Errorf("expected result %v was %v - details: %v", tc.ExpectedResult, result.Status, result.Details)
+			}
+		})
+	}
+}

--- a/v3/testdata/aiaWithInternalNames.pem
+++ b/v3/testdata/aiaWithInternalNames.pem
@@ -1,0 +1,44 @@
+-------------Leaf-------------
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Jul  1 00:00:00 2013 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:13:46:12:76:34:c9:58:c6:08:99:ea:8f:81:38:
+                    89:f3:2f:da:43:b7:95:10:ac:94:35:50:17:f4:ae:
+                    1f:5b:e9:1e:fb:cb:75:a8:97:24:82:d4:42:36:db:
+                    cb:d3:40:41:54:6a:86:dc:65:c1:cb:52:e4:5f:a6:
+                    71:2b:f5:3c:1e
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication
+            Authority Information Access: 
+                OCSP - URI:http://internalname
+                CA Issuers - URI:http://internalname
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:20:62:9f:37:38:36:16:78:d7:40:00:7c:6e:44:b8:
+        8a:ae:02:90:77:0c:70:56:5f:4f:05:99:e3:06:ab:69:27:41:
+        02:21:00:9b:f4:df:e6:dc:92:03:54:59:94:0a:0d:ec:51:28:
+        a9:fc:ff:07:9e:2a:b9:a8:22:0b:23:8a:71:18:b1:00:ec
+-----BEGIN CERTIFICATE-----
+MIIBWjCCAQCgAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEE0YS
+djTJWMYImeqPgTiJ8y/aQ7eVEKyUNVAX9K4fW+ke+8t1qJckgtRCNtvL00BBVGqG
+3GXBy1LkX6ZxK/U8HqNpMGcwEwYDVR0lBAwwCgYIKwYBBQUHAwEwUAYIKwYBBQUH
+AQEERDBCMB8GCCsGAQUFBzABhhNodHRwOi8vaW50ZXJuYWxuYW1lMB8GCCsGAQUF
+BzAChhNodHRwOi8vaW50ZXJuYWxuYW1lMAoGCCqGSM49BAMCA0gAMEUCIGKfNzg2
+FnjXQAB8bkS4iq4CkHcMcFZfTwWZ4waraSdBAiEAm/Tf5tySA1RZlAoN7FEoqfz/
+B54quagiCyOKcRixAOw=
+-----END CERTIFICATE-----

--- a/v3/testdata/aiaWithValidNames.pem
+++ b/v3/testdata/aiaWithValidNames.pem
@@ -1,0 +1,44 @@
+-------------Leaf-------------
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Jul  1 00:00:00 2013 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:4b:47:1f:0e:2e:8c:19:19:ba:a2:ed:0c:5c:f3:
+                    9d:ac:fc:24:bc:9b:35:d1:47:41:f8:44:3a:5b:1c:
+                    d5:4d:44:3d:d1:f9:bb:c7:5e:06:97:51:05:d2:75:
+                    28:ef:04:9e:a9:df:80:7c:da:43:b6:87:91:f2:f9:
+                    cb:62:94:fe:1a
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication
+            Authority Information Access: 
+                OCSP - URI:http://example.com
+                CA Issuers - URI:http://example.com
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:20:2b:fd:a5:b6:1b:30:2e:50:1a:a5:ae:26:72:e9:
+        34:86:95:59:a4:41:33:ed:f2:2e:4b:ff:da:b9:26:81:96:dc:
+        02:21:00:aa:13:10:65:23:01:f5:2f:f1:1e:8e:e6:7f:2d:56:
+        0a:be:7e:d9:c8:7d:6f:58:4e:49:85:c7:ed:53:8b:ef:dc
+-----BEGIN CERTIFICATE-----
+MIIBVzCB/qADAgECAgEDMAoGCCqGSM49BAMCMAAwIBcNMTMwNzAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMAAwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARLRx8O
+LowZGbqi7Qxc852s/CS8mzXRR0H4RDpbHNVNRD3R+bvHXgaXUQXSdSjvBJ6p34B8
+2kO2h5Hy+ctilP4ao2cwZTATBgNVHSUEDDAKBggrBgEFBQcDATBOBggrBgEFBQcB
+AQRCMEAwHgYIKwYBBQUHMAGGEmh0dHA6Ly9leGFtcGxlLmNvbTAeBggrBgEFBQcw
+AoYSaHR0cDovL2V4YW1wbGUuY29tMAoGCCqGSM49BAMCA0gAMEUCICv9pbYbMC5Q
+GqWuJnLpNIaVWaRBM+3yLkv/2rkmgZbcAiEAqhMQZSMB9S/xHo7mfy1WCr5+2ch9
+b1hOSYXH7VOL79w=
+-----END CERTIFICATE-----

--- a/v3/testdata/smime/aiaWithInternalNamesLegacy.pem
+++ b/v3/testdata/smime/aiaWithInternalNamesLegacy.pem
@@ -1,0 +1,46 @@
+-------------Leaf-------------
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Jul  1 00:00:00 2013 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:96:46:49:35:0c:1a:0e:34:80:cb:ce:20:91:70:
+                    5d:75:83:e0:71:70:a5:d6:90:4e:4f:81:13:42:b7:
+                    61:5b:56:69:5c:f6:13:24:2e:04:4c:b4:a4:c4:5d:
+                    23:46:2d:f2:44:57:3b:19:ea:84:43:42:ae:2a:15:
+                    69:df:18:d9:b5
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                E-mail Protection
+            Authority Information Access: 
+                OCSP - URI:http://internalname
+                CA Issuers - URI:http://internalname
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.5.1.1
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:21:00:c0:94:36:cc:97:78:32:72:60:db:a2:66:a0:
+        4d:4f:5c:6e:39:5f:eb:dc:eb:64:2e:05:0e:b7:d1:e8:60:a1:
+        20:02:20:6e:4b:07:46:4e:bf:61:ab:c4:06:8d:b3:62:27:ac:
+        0f:77:5a:bb:c2:92:75:71:e0:b1:07:aa:7a:ef:8c:87:63
+-----BEGIN CERTIFICATE-----
+MIIBcDCCARagAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElkZJ
+NQwaDjSAy84gkXBddYPgcXCl1pBOT4ETQrdhW1ZpXPYTJC4ETLSkxF0jRi3yRFc7
+GeqEQ0KuKhVp3xjZtaN/MH0wEwYDVR0lBAwwCgYIKwYBBQUHAwQwUAYIKwYBBQUH
+AQEERDBCMB8GCCsGAQUFBzABhhNodHRwOi8vaW50ZXJuYWxuYW1lMB8GCCsGAQUF
+BzAChhNodHRwOi8vaW50ZXJuYWxuYW1lMBQGA1UdIAQNMAswCQYHZ4EMAQUBATAK
+BggqhkjOPQQDAgNIADBFAiEAwJQ2zJd4MnJg26JmoE1PXG45X+vc62QuBQ630ehg
+oSACIG5LB0ZOv2GrxAaNs2InrA93WrvCknVx4LEHqnrvjIdj
+-----END CERTIFICATE-----

--- a/v3/testdata/smime/aiaWithInternalNamesLegacy.pem
+++ b/v3/testdata/smime/aiaWithInternalNamesLegacy.pem
@@ -1,4 +1,3 @@
--------------Leaf-------------
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -13,11 +12,11 @@ Certificate:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
                 pub:
-                    04:96:46:49:35:0c:1a:0e:34:80:cb:ce:20:91:70:
-                    5d:75:83:e0:71:70:a5:d6:90:4e:4f:81:13:42:b7:
-                    61:5b:56:69:5c:f6:13:24:2e:04:4c:b4:a4:c4:5d:
-                    23:46:2d:f2:44:57:3b:19:ea:84:43:42:ae:2a:15:
-                    69:df:18:d9:b5
+                    04:ff:f8:b8:3e:49:fe:38:81:47:72:04:50:f3:28:
+                    60:e6:6a:d2:3e:cf:61:10:2d:3e:1b:a5:68:29:07:
+                    e6:12:6e:56:d2:c5:c9:57:88:14:c5:b8:39:9d:56:
+                    b3:d5:fb:d6:f4:f6:4d:2b:36:c6:c4:f8:7c:d2:86:
+                    57:56:07:04:66
                 ASN1 OID: prime256v1
                 NIST CURVE: P-256
         X509v3 extensions:
@@ -30,17 +29,17 @@ Certificate:
                 Policy: 2.23.140.1.5.1.1
     Signature Algorithm: ecdsa-with-SHA256
     Signature Value:
-        30:45:02:21:00:c0:94:36:cc:97:78:32:72:60:db:a2:66:a0:
-        4d:4f:5c:6e:39:5f:eb:dc:eb:64:2e:05:0e:b7:d1:e8:60:a1:
-        20:02:20:6e:4b:07:46:4e:bf:61:ab:c4:06:8d:b3:62:27:ac:
-        0f:77:5a:bb:c2:92:75:71:e0:b1:07:aa:7a:ef:8c:87:63
+        30:44:02:20:23:1d:e4:1d:dc:ba:69:ab:20:9f:b1:1b:d8:b3:
+        dd:53:ad:78:3e:36:f0:dd:56:ae:de:2b:52:f1:ef:e2:f5:1f:
+        02:20:69:92:53:4f:9f:72:58:d6:76:e2:ac:fe:e3:dd:88:1d:
+        50:68:cc:8a:17:b5:23:f7:3b:9d:6a:58:70:f1:98:7b
 -----BEGIN CERTIFICATE-----
-MIIBcDCCARagAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
-Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElkZJ
-NQwaDjSAy84gkXBddYPgcXCl1pBOT4ETQrdhW1ZpXPYTJC4ETLSkxF0jRi3yRFc7
-GeqEQ0KuKhVp3xjZtaN/MH0wEwYDVR0lBAwwCgYIKwYBBQUHAwQwUAYIKwYBBQUH
+MIIBbzCCARagAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE//i4
+Pkn+OIFHcgRQ8yhg5mrSPs9hEC0+G6VoKQfmEm5W0sXJV4gUxbg5nVaz1fvW9PZN
+KzbGxPh80oZXVgcEZqN/MH0wEwYDVR0lBAwwCgYIKwYBBQUHAwQwUAYIKwYBBQUH
 AQEERDBCMB8GCCsGAQUFBzABhhNodHRwOi8vaW50ZXJuYWxuYW1lMB8GCCsGAQUF
 BzAChhNodHRwOi8vaW50ZXJuYWxuYW1lMBQGA1UdIAQNMAswCQYHZ4EMAQUBATAK
-BggqhkjOPQQDAgNIADBFAiEAwJQ2zJd4MnJg26JmoE1PXG45X+vc62QuBQ630ehg
-oSACIG5LB0ZOv2GrxAaNs2InrA93WrvCknVx4LEHqnrvjIdj
+BggqhkjOPQQDAgNHADBEAiAjHeQd3LppqyCfsRvYs91TrXg+NvDdVq7eK1Lx7+L1
+HwIgaZJTT59yWNZ24qz+492IHVBozIoXtSP3O51qWHDxmHs=
 -----END CERTIFICATE-----

--- a/v3/testdata/smime/aiaWithInternalNamesStrict.pem
+++ b/v3/testdata/smime/aiaWithInternalNamesStrict.pem
@@ -1,4 +1,3 @@
--------------Leaf-------------
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -13,11 +12,11 @@ Certificate:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
                 pub:
-                    04:b4:e1:b9:18:cc:76:73:cf:10:3e:7b:9b:34:18:
-                    fd:bc:3c:06:5c:d9:db:97:2e:fe:e5:c1:09:85:c1:
-                    a8:ee:7d:e0:23:06:55:07:c3:61:79:41:48:d3:1c:
-                    96:d5:f3:b2:64:17:92:c8:86:9c:c8:c1:a6:7b:dc:
-                    65:c4:67:f9:3a
+                    04:e4:d0:84:31:91:f3:f9:2b:2d:c8:d7:a1:8e:fb:
+                    fc:6f:66:89:b1:32:c6:88:33:d5:70:12:d8:33:ab:
+                    8e:e9:cf:ca:27:7b:cf:f4:98:ce:dc:1c:7e:db:60:
+                    e6:84:35:79:ff:f3:1d:91:88:2a:c7:53:b6:23:cc:
+                    f6:8a:be:56:e2
                 ASN1 OID: prime256v1
                 NIST CURVE: P-256
         X509v3 extensions:
@@ -25,22 +24,22 @@ Certificate:
                 E-mail Protection
             Authority Information Access: 
                 OCSP - URI:http://internalname
-                CA Issuers - URI:https://internalname
+                CA Issuers - URI:http://internalname
             X509v3 Certificate Policies: 
                 Policy: 2.23.140.1.5.1.3
     Signature Algorithm: ecdsa-with-SHA256
     Signature Value:
-        30:44:02:20:65:eb:c1:25:80:1b:e3:7d:3d:ed:25:62:7c:c6:
-        c7:75:ba:ea:f6:5d:2f:e0:70:1f:6e:e5:f5:02:a1:ed:59:48:
-        02:20:0c:a8:2d:ef:3d:41:67:7f:c2:07:a9:d4:83:0d:a2:47:
-        6e:7c:a4:5a:29:fd:67:d3:35:df:1f:f7:8d:2b:82:ce
+        30:45:02:21:00:b0:b4:b9:9d:b3:8e:c7:8d:a8:a8:1b:a0:ae:
+        d1:55:79:83:b8:4f:4f:19:2c:7c:43:b0:e0:70:c1:f2:ab:23:
+        66:02:20:4f:1a:37:63:c8:f6:0a:12:53:d9:9e:84:0a:f1:61:
+        8f:2a:b4:6a:b3:06:8d:1f:bc:c6:44:57:9f:f0:0a:0e:61
 -----BEGIN CERTIFICATE-----
-MIIBcTCCARigAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
-Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtOG5
-GMx2c88QPnubNBj9vDwGXNnbly7+5cEJhcGo7n3gIwZVB8NheUFI0xyW1fOyZBeS
-yIacyMGme9xlxGf5OqOBgDB+MBMGA1UdJQQMMAoGCCsGAQUFBwMEMFEGCCsGAQUF
-BwEBBEUwQzAfBggrBgEFBQcwAYYTaHR0cDovL2ludGVybmFsbmFtZTAgBggrBgEF
-BQcwAoYUaHR0cHM6Ly9pbnRlcm5hbG5hbWUwFAYDVR0gBA0wCzAJBgdngQwBBQED
-MAoGCCqGSM49BAMCA0cAMEQCIGXrwSWAG+N9Pe0lYnzGx3W66vZdL+BwH27l9QKh
-7VlIAiAMqC3vPUFnf8IHqdSDDaJHbnykWin9Z9M13x/3jSuCzg==
+MIIBcDCCARagAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5NCE
+MZHz+SstyNehjvv8b2aJsTLGiDPVcBLYM6uO6c/KJ3vP9JjO3Bx+22DmhDV5//Md
+kYgqx1O2I8z2ir5W4qN/MH0wEwYDVR0lBAwwCgYIKwYBBQUHAwQwUAYIKwYBBQUH
+AQEERDBCMB8GCCsGAQUFBzABhhNodHRwOi8vaW50ZXJuYWxuYW1lMB8GCCsGAQUF
+BzAChhNodHRwOi8vaW50ZXJuYWxuYW1lMBQGA1UdIAQNMAswCQYHZ4EMAQUBAzAK
+BggqhkjOPQQDAgNIADBFAiEAsLS5nbOOx42oqBugrtFVeYO4T08ZLHxDsOBwwfKr
+I2YCIE8aN2PI9goSU9mehArxYY8qtGqzBo0fvMZEV5/wCg5h
 -----END CERTIFICATE-----

--- a/v3/testdata/smime/aiaWithInternalNamesStrict.pem
+++ b/v3/testdata/smime/aiaWithInternalNamesStrict.pem
@@ -1,0 +1,46 @@
+-------------Leaf-------------
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Jul  1 00:00:00 2013 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:b4:e1:b9:18:cc:76:73:cf:10:3e:7b:9b:34:18:
+                    fd:bc:3c:06:5c:d9:db:97:2e:fe:e5:c1:09:85:c1:
+                    a8:ee:7d:e0:23:06:55:07:c3:61:79:41:48:d3:1c:
+                    96:d5:f3:b2:64:17:92:c8:86:9c:c8:c1:a6:7b:dc:
+                    65:c4:67:f9:3a
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                E-mail Protection
+            Authority Information Access: 
+                OCSP - URI:http://internalname
+                CA Issuers - URI:https://internalname
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.5.1.3
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:44:02:20:65:eb:c1:25:80:1b:e3:7d:3d:ed:25:62:7c:c6:
+        c7:75:ba:ea:f6:5d:2f:e0:70:1f:6e:e5:f5:02:a1:ed:59:48:
+        02:20:0c:a8:2d:ef:3d:41:67:7f:c2:07:a9:d4:83:0d:a2:47:
+        6e:7c:a4:5a:29:fd:67:d3:35:df:1f:f7:8d:2b:82:ce
+-----BEGIN CERTIFICATE-----
+MIIBcTCCARigAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtOG5
+GMx2c88QPnubNBj9vDwGXNnbly7+5cEJhcGo7n3gIwZVB8NheUFI0xyW1fOyZBeS
+yIacyMGme9xlxGf5OqOBgDB+MBMGA1UdJQQMMAoGCCsGAQUFBwMEMFEGCCsGAQUF
+BwEBBEUwQzAfBggrBgEFBQcwAYYTaHR0cDovL2ludGVybmFsbmFtZTAgBggrBgEF
+BQcwAoYUaHR0cHM6Ly9pbnRlcm5hbG5hbWUwFAYDVR0gBA0wCzAJBgdngQwBBQED
+MAoGCCqGSM49BAMCA0cAMEQCIGXrwSWAG+N9Pe0lYnzGx3W66vZdL+BwH27l9QKh
+7VlIAiAMqC3vPUFnf8IHqdSDDaJHbnykWin9Z9M13x/3jSuCzg==
+-----END CERTIFICATE-----

--- a/v3/testdata/smime/aiaWithValidNamesLegacy.pem
+++ b/v3/testdata/smime/aiaWithValidNamesLegacy.pem
@@ -1,0 +1,46 @@
+-------------Leaf-------------
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Jul  1 00:00:00 2013 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:2a:ba:ab:6a:1b:51:8d:a9:a3:59:d0:b1:39:a8:
+                    b2:bb:a3:40:f3:1f:fe:7e:11:8c:f3:6f:30:39:c0:
+                    4e:49:91:c5:b5:ae:49:67:78:c1:5b:c0:40:c0:ff:
+                    ef:dc:54:d1:34:d3:4b:a0:ef:20:96:00:79:7f:be:
+                    48:ee:81:5b:2c
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                E-mail Protection
+            Authority Information Access: 
+                OCSP - URI:http://example.com
+                CA Issuers - URI:https://example.com
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.5.1.1
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:21:00:8a:1f:29:4f:10:72:1f:25:8b:4d:f5:46:a7:
+        2f:60:2e:86:ce:15:6c:26:61:ff:fb:79:36:b4:3e:df:65:6e:
+        a7:02:20:2b:e1:88:3d:91:d2:b7:a7:35:20:3d:b8:a2:12:f6:
+        2b:98:57:b9:c0:2b:e6:77:ae:9b:36:13:11:16:ff:d4:38
+-----BEGIN CERTIFICATE-----
+MIIBbzCCARWgAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKrqr
+ahtRjamjWdCxOaiyu6NA8x/+fhGM828wOcBOSZHFta5JZ3jBW8BAwP/v3FTRNNNL
+oO8glgB5f75I7oFbLKN+MHwwEwYDVR0lBAwwCgYIKwYBBQUHAwQwTwYIKwYBBQUH
+AQEEQzBBMB4GCCsGAQUFBzABhhJodHRwOi8vZXhhbXBsZS5jb20wHwYIKwYBBQUH
+MAKGE2h0dHBzOi8vZXhhbXBsZS5jb20wFAYDVR0gBA0wCzAJBgdngQwBBQEBMAoG
+CCqGSM49BAMCA0gAMEUCIQCKHylPEHIfJYtN9UanL2Auhs4VbCZh//t5NrQ+32Vu
+pwIgK+GIPZHSt6c1ID24ohL2K5hXucAr5neumzYTERb/1Dg=
+-----END CERTIFICATE-----

--- a/v3/testdata/smime/aiaWithValidNamesLegacy.pem
+++ b/v3/testdata/smime/aiaWithValidNamesLegacy.pem
@@ -1,4 +1,3 @@
--------------Leaf-------------
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -13,11 +12,11 @@ Certificate:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
                 pub:
-                    04:2a:ba:ab:6a:1b:51:8d:a9:a3:59:d0:b1:39:a8:
-                    b2:bb:a3:40:f3:1f:fe:7e:11:8c:f3:6f:30:39:c0:
-                    4e:49:91:c5:b5:ae:49:67:78:c1:5b:c0:40:c0:ff:
-                    ef:dc:54:d1:34:d3:4b:a0:ef:20:96:00:79:7f:be:
-                    48:ee:81:5b:2c
+                    04:d7:ad:e9:f2:3e:78:01:94:ee:51:9e:77:d1:13:
+                    9f:ce:90:7c:61:f1:d7:17:6a:02:f1:54:a9:bd:ba:
+                    a7:57:c8:b0:99:82:36:9b:ad:f3:f9:60:5b:f0:3e:
+                    f9:b5:94:9c:cb:e1:ef:e4:db:ca:11:8b:a2:be:ce:
+                    69:44:7a:86:0f
                 ASN1 OID: prime256v1
                 NIST CURVE: P-256
         X509v3 extensions:
@@ -25,22 +24,22 @@ Certificate:
                 E-mail Protection
             Authority Information Access: 
                 OCSP - URI:http://example.com
-                CA Issuers - URI:https://example.com
+                CA Issuers - URI:http://example.com
             X509v3 Certificate Policies: 
                 Policy: 2.23.140.1.5.1.1
     Signature Algorithm: ecdsa-with-SHA256
     Signature Value:
-        30:45:02:21:00:8a:1f:29:4f:10:72:1f:25:8b:4d:f5:46:a7:
-        2f:60:2e:86:ce:15:6c:26:61:ff:fb:79:36:b4:3e:df:65:6e:
-        a7:02:20:2b:e1:88:3d:91:d2:b7:a7:35:20:3d:b8:a2:12:f6:
-        2b:98:57:b9:c0:2b:e6:77:ae:9b:36:13:11:16:ff:d4:38
+        30:46:02:21:00:a8:50:59:84:77:d9:2a:89:79:e3:f6:6f:60:
+        2a:d9:81:f5:b9:36:0f:bc:4e:4a:d5:9e:b0:f5:13:8f:15:2d:
+        86:02:21:00:fa:32:fc:3d:fc:c3:94:6b:b7:6d:84:a5:32:b5:
+        80:4d:cb:3d:40:5f:91:05:46:8d:21:cd:75:fc:26:0e:8a:c5
 -----BEGIN CERTIFICATE-----
-MIIBbzCCARWgAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
-Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKrqr
-ahtRjamjWdCxOaiyu6NA8x/+fhGM828wOcBOSZHFta5JZ3jBW8BAwP/v3FTRNNNL
-oO8glgB5f75I7oFbLKN+MHwwEwYDVR0lBAwwCgYIKwYBBQUHAwQwTwYIKwYBBQUH
-AQEEQzBBMB4GCCsGAQUFBzABhhJodHRwOi8vZXhhbXBsZS5jb20wHwYIKwYBBQUH
-MAKGE2h0dHBzOi8vZXhhbXBsZS5jb20wFAYDVR0gBA0wCzAJBgdngQwBBQEBMAoG
-CCqGSM49BAMCA0gAMEUCIQCKHylPEHIfJYtN9UanL2Auhs4VbCZh//t5NrQ+32Vu
-pwIgK+GIPZHSt6c1ID24ohL2K5hXucAr5neumzYTERb/1Dg=
+MIIBbzCCARSgAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE163p
+8j54AZTuUZ530ROfzpB8YfHXF2oC8VSpvbqnV8iwmYI2m63z+WBb8D75tZScy+Hv
+5NvKEYuivs5pRHqGD6N9MHswEwYDVR0lBAwwCgYIKwYBBQUHAwQwTgYIKwYBBQUH
+AQEEQjBAMB4GCCsGAQUFBzABhhJodHRwOi8vZXhhbXBsZS5jb20wHgYIKwYBBQUH
+MAKGEmh0dHA6Ly9leGFtcGxlLmNvbTAUBgNVHSAEDTALMAkGB2eBDAEFAQEwCgYI
+KoZIzj0EAwIDSQAwRgIhAKhQWYR32SqJeeP2b2Aq2YH1uTYPvE5K1Z6w9ROPFS2G
+AiEA+jL8PfzDlGu3bYSlMrWATcs9QF+RBUaNIc11/CYOisU=
 -----END CERTIFICATE-----

--- a/v3/testdata/smime/aiaWithValidNamesStrict.pem
+++ b/v3/testdata/smime/aiaWithValidNamesStrict.pem
@@ -1,4 +1,3 @@
--------------Leaf-------------
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -13,11 +12,11 @@ Certificate:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
                 pub:
-                    04:a4:9a:65:ae:91:bb:b1:a0:67:05:19:95:4c:c0:
-                    9f:b6:a9:20:6c:c3:4d:10:c6:d5:34:b9:d7:75:36:
-                    dc:a0:f5:2e:41:99:47:62:20:bf:a6:f6:2c:e7:65:
-                    a2:d9:0d:8a:48:3e:68:9c:83:a5:39:bb:a2:41:4e:
-                    23:ad:16:f0:5f
+                    04:5a:a5:56:3a:03:7d:75:47:a2:b8:f2:30:36:59:
+                    c5:e4:89:34:2c:6e:c5:74:fd:2c:6d:1c:21:e7:f1:
+                    d1:cc:04:f2:aa:88:f5:dd:52:20:57:b8:95:79:97:
+                    51:ea:02:ea:22:f3:d9:00:17:e8:f6:05:60:e2:8e:
+                    96:1f:b9:df:4d
                 ASN1 OID: prime256v1
                 NIST CURVE: P-256
         X509v3 extensions:
@@ -25,22 +24,22 @@ Certificate:
                 E-mail Protection
             Authority Information Access: 
                 OCSP - URI:http://example.com
-                CA Issuers - URI:https://example.com
+                CA Issuers - URI:http://example.com
             X509v3 Certificate Policies: 
                 Policy: 2.23.140.1.5.1.3
     Signature Algorithm: ecdsa-with-SHA256
     Signature Value:
-        30:46:02:21:00:e5:93:5c:ca:ef:66:8b:62:b4:60:fe:f3:73:
-        2e:c4:97:a1:e5:89:b9:46:7c:c4:72:1d:b3:d9:1e:e4:13:33:
-        ec:02:21:00:93:d2:88:65:1f:24:ae:7a:7c:4e:a1:15:59:56:
-        f7:e9:7e:85:8a:54:ff:70:59:f4:ae:f4:9c:2d:59:04:4b:e1
+        30:45:02:21:00:93:d3:05:1a:7c:5c:59:fa:f7:16:99:12:3b:
+        a5:16:00:49:56:bd:0a:c4:8c:eb:a6:a6:d2:57:f5:96:2c:dc:
+        a2:02:20:52:0e:73:ef:98:16:9b:5c:04:36:04:5c:e9:cf:3c:
+        f3:b3:e8:b1:77:84:73:f9:d2:63:a2:8d:3a:29:d7:b4:05
 -----BEGIN CERTIFICATE-----
-MIIBcDCCARWgAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
-Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpJpl
-rpG7saBnBRmVTMCftqkgbMNNEMbVNLnXdTbcoPUuQZlHYiC/pvYs52Wi2Q2KSD5o
-nIOlObuiQU4jrRbwX6N+MHwwEwYDVR0lBAwwCgYIKwYBBQUHAwQwTwYIKwYBBQUH
-AQEEQzBBMB4GCCsGAQUFBzABhhJodHRwOi8vZXhhbXBsZS5jb20wHwYIKwYBBQUH
-MAKGE2h0dHBzOi8vZXhhbXBsZS5jb20wFAYDVR0gBA0wCzAJBgdngQwBBQEDMAoG
-CCqGSM49BAMCA0kAMEYCIQDlk1zK72aLYrRg/vNzLsSXoeWJuUZ8xHIds9ke5BMz
-7AIhAJPSiGUfJK56fE6hFVlW9+l+hYpU/3BZ9K70nC1ZBEvh
+MIIBbjCCARSgAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWqVW
+OgN9dUeiuPIwNlnF5Ik0LG7FdP0sbRwh5/HRzATyqoj13VIgV7iVeZdR6gLqIvPZ
+ABfo9gVg4o6WH7nfTaN9MHswEwYDVR0lBAwwCgYIKwYBBQUHAwQwTgYIKwYBBQUH
+AQEEQjBAMB4GCCsGAQUFBzABhhJodHRwOi8vZXhhbXBsZS5jb20wHgYIKwYBBQUH
+MAKGEmh0dHA6Ly9leGFtcGxlLmNvbTAUBgNVHSAEDTALMAkGB2eBDAEFAQMwCgYI
+KoZIzj0EAwIDSAAwRQIhAJPTBRp8XFn69xaZEjulFgBJVr0KxIzrpqbSV/WWLNyi
+AiBSDnPvmBabXAQ2BFzpzzzzs+ixd4Rz+dJjoo06Kde0BQ==
 -----END CERTIFICATE-----

--- a/v3/testdata/smime/aiaWithValidNamesStrict.pem
+++ b/v3/testdata/smime/aiaWithValidNamesStrict.pem
@@ -1,0 +1,46 @@
+-------------Leaf-------------
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Jul  1 00:00:00 2013 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:a4:9a:65:ae:91:bb:b1:a0:67:05:19:95:4c:c0:
+                    9f:b6:a9:20:6c:c3:4d:10:c6:d5:34:b9:d7:75:36:
+                    dc:a0:f5:2e:41:99:47:62:20:bf:a6:f6:2c:e7:65:
+                    a2:d9:0d:8a:48:3e:68:9c:83:a5:39:bb:a2:41:4e:
+                    23:ad:16:f0:5f
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                E-mail Protection
+            Authority Information Access: 
+                OCSP - URI:http://example.com
+                CA Issuers - URI:https://example.com
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.5.1.3
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:46:02:21:00:e5:93:5c:ca:ef:66:8b:62:b4:60:fe:f3:73:
+        2e:c4:97:a1:e5:89:b9:46:7c:c4:72:1d:b3:d9:1e:e4:13:33:
+        ec:02:21:00:93:d2:88:65:1f:24:ae:7a:7c:4e:a1:15:59:56:
+        f7:e9:7e:85:8a:54:ff:70:59:f4:ae:f4:9c:2d:59:04:4b:e1
+-----BEGIN CERTIFICATE-----
+MIIBcDCCARWgAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTEzMDcwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpJpl
+rpG7saBnBRmVTMCftqkgbMNNEMbVNLnXdTbcoPUuQZlHYiC/pvYs52Wi2Q2KSD5o
+nIOlObuiQU4jrRbwX6N+MHwwEwYDVR0lBAwwCgYIKwYBBQUHAwQwTwYIKwYBBQUH
+AQEEQzBBMB4GCCsGAQUFBzABhhJodHRwOi8vZXhhbXBsZS5jb20wHwYIKwYBBQUH
+MAKGE2h0dHBzOi8vZXhhbXBsZS5jb20wFAYDVR0gBA0wCzAJBgdngQwBBQEDMAoG
+CCqGSM49BAMCA0kAMEYCIQDlk1zK72aLYrRg/vNzLsSXoeWJuUZ8xHIds9ke5BMz
+7AIhAJPSiGUfJK56fE6hFVlW9+l+hYpU/3BZ9K70nC1ZBEvh
+-----END CERTIFICATE-----


### PR DESCRIPTION
As part of the SMIME work, I discovered at least one example of a cert that was issued using an outdated OCSP URL that would have been valid prior to the SMIME BRs. The rules around the AIA paths are not super strict but they are similar for both TLS and SMIME requirements, which read:
```
This extension MAY be present. If present, it MUST NOT be marked critical, and it MUST contain the
HTTP URL of the CA’s CRL service.
```
For publicly trusted certificates that are present in CT logs, these URLs are required to point to a resolvable location and shouldn't contain internal names. However, that requirement is not strictly codified in the requirements but is implied by what the resource is intended to point to. This lint intends to check and warn for this condition that may not be an actual problem, but probably is.

Note: I don't believe the Legacy lint is quite right here. The rule for Legacy reads
```
When provided, at least one accessMethod SHALL have the URI scheme HTTP. Other schemes (LDAP, FTP, ...) MAY be present.
```
The current lint tries to parse the url and make sure the DNS name has a valid TLD. Should I instead try to validate the scheme of the field before parsing in that lint only?

I also combined the Strict and Multipurpose lints into one as they have the same requirements. 

Feedback welcome and desired!