### PR TITLE
CABF SMIME lints failed to be registered in the CLI due to a missing blank import

### DIFF
--- a/v3/lint/source.go
+++ b/v3/lint/source.go
@@ -51,7 +51,7 @@ func (s *LintSource) UnmarshalJSON(data []byte) error {
 	}
 
 	switch LintSource(throwAway) {
-	case RFC5280, RFC5480, RFC5891, CABFBaselineRequirements, CABFEVGuidelines, MozillaRootStorePolicy, AppleRootStorePolicy, Community, EtsiEsi:
+	case RFC5280, RFC5480, RFC5891, CABFBaselineRequirements, CABFEVGuidelines, CABFSMIMEBaselineRequirements, MozillaRootStorePolicy, AppleRootStorePolicy, Community, EtsiEsi:
 		*s = LintSource(throwAway)
 		return nil
 	default:
@@ -79,6 +79,8 @@ func (s *LintSource) FromString(src string) {
 		*s = CABFBaselineRequirements
 	case CABFEVGuidelines:
 		*s = CABFEVGuidelines
+	case CABFSMIMEBaselineRequirements:
+		*s = CABFSMIMEBaselineRequirements
 	case MozillaRootStorePolicy:
 		*s = MozillaRootStorePolicy
 	case AppleRootStorePolicy:

--- a/v3/zlint.go
+++ b/v3/zlint.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/zmap/zlint/v3/lints/apple"
 	_ "github.com/zmap/zlint/v3/lints/cabf_br"
 	_ "github.com/zmap/zlint/v3/lints/cabf_ev"
+	_ "github.com/zmap/zlint/v3/lints/cabf_smime_br"
 	_ "github.com/zmap/zlint/v3/lints/community"
 	_ "github.com/zmap/zlint/v3/lints/etsi"
 	_ "github.com/zmap/zlint/v3/lints/mozilla"


### PR DESCRIPTION
Thank you for your patience @cardonator 

The infrastructure for a lint to register itself leans on Go's magical `init` function which is automatically executed at program startup.

However, the `init` function is not executed if the package is not referred to by the main program, which is why `zlint.go` features a short list of imports performed solely for the side effect of triggering these `init` functions.

Unfortunately, we missed this import when building the CABF SMIME framework. The cause is that almost all of the testing, tooling, and integration tests are focused on either the library usage of Zlint or on testing lints against the corpus of certs scraped from the wild. Such a CLI integration test would be a valuable thing to consider spending time on, however I believe it is out of scope of this particularly pernicious issue.

Resolves #759 