### PR TITLE
[LSC] Convert all Lints to CertificateLints

### DIFF
--- a/v3/lints/apple/lint_ct_sct_policy_count_unsatisfied.go
+++ b/v3/lints/apple/lint_ct_sct_policy_count_unsatisfied.go
@@ -27,13 +27,15 @@ import (
 type sctPolicyCount struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ct_sct_policy_count_unsatisfied",
-		Description:   "Check if certificate has enough embedded SCTs to meet Apple CT Policy",
-		Citation:      "https://support.apple.com/en-us/HT205280",
-		Source:        lint.AppleRootStorePolicy,
-		EffectiveDate: util.AppleCTPolicyDate,
-		Lint:          NewSctPolicyCount,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ct_sct_policy_count_unsatisfied",
+			Description:   "Check if certificate has enough embedded SCTs to meet Apple CT Policy",
+			Citation:      "https://support.apple.com/en-us/HT205280",
+			Source:        lint.AppleRootStorePolicy,
+			EffectiveDate: util.AppleCTPolicyDate,
+		},
+		Lint: NewSctPolicyCount,
 	})
 }
 

--- a/v3/lints/apple/lint_e_server_cert_valid_time_longer_than_398_days.go
+++ b/v3/lints/apple/lint_e_server_cert_valid_time_longer_than_398_days.go
@@ -25,14 +25,16 @@ import (
 type serverCertValidityTooLong struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name: "e_tls_server_cert_valid_time_longer_than_398_days",
-		Description: "TLS server certificates issued on or after September 1, 2020 " +
-			"00:00 GMT/UTC must not have a validity period greater than 398 days",
-		Citation:      "https://support.apple.com/en-us/HT211025",
-		Source:        lint.AppleRootStorePolicy,
-		EffectiveDate: util.AppleReducedLifetimeDate,
-		Lint:          NewServerCertValidityTooLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name: "e_tls_server_cert_valid_time_longer_than_398_days",
+			Description: "TLS server certificates issued on or after September 1, 2020 " +
+				"00:00 GMT/UTC must not have a validity period greater than 398 days",
+			Citation:      "https://support.apple.com/en-us/HT211025",
+			Source:        lint.AppleRootStorePolicy,
+			EffectiveDate: util.AppleReducedLifetimeDate,
+		},
+		Lint: NewServerCertValidityTooLong,
 	})
 }
 

--- a/v3/lints/apple/lint_w_server_cert_valid_time_longer_than_397_days.go
+++ b/v3/lints/apple/lint_w_server_cert_valid_time_longer_than_397_days.go
@@ -25,14 +25,16 @@ import (
 type serverCertValidityAlmostTooLong struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name: "w_tls_server_cert_valid_time_longer_than_397_days",
-		Description: "TLS server certificates issued on or after September 1, 2020 " +
-			"00:00 GMT/UTC should not have a validity period greater than 397 days",
-		Citation:      "https://support.apple.com/en-us/HT211025",
-		Source:        lint.AppleRootStorePolicy,
-		EffectiveDate: util.AppleReducedLifetimeDate,
-		Lint:          NewServerCertValidityAlmostTooLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name: "w_tls_server_cert_valid_time_longer_than_397_days",
+			Description: "TLS server certificates issued on or after September 1, 2020 " +
+				"00:00 GMT/UTC should not have a validity period greater than 397 days",
+			Citation:      "https://support.apple.com/en-us/HT211025",
+			Source:        lint.AppleRootStorePolicy,
+			EffectiveDate: util.AppleReducedLifetimeDate,
+		},
+		Lint: NewServerCertValidityAlmostTooLong,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ca_common_name_missing.go
+++ b/v3/lints/cabf_br/lint_ca_common_name_missing.go
@@ -23,13 +23,15 @@ import (
 type caCommonNameMissing struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ca_common_name_missing",
-		Description:   "CA Certificates common name MUST be included.",
-		Citation:      "BRs: 7.1.4.3.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV148Date,
-		Lint:          NewCaCommonNameMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ca_common_name_missing",
+			Description:   "CA Certificates common name MUST be included.",
+			Citation:      "BRs: 7.1.4.3.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV148Date,
+		},
+		Lint: NewCaCommonNameMissing,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ca_country_name_invalid.go
+++ b/v3/lints/cabf_br/lint_ca_country_name_invalid.go
@@ -31,13 +31,15 @@ in which the CA’s place	of business	is located.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ca_country_name_invalid",
-		Description:   "Root and Subordinate CA certificates MUST have a two-letter country code specified in ISO 3166-1",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCaCountryNameInvalid,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ca_country_name_invalid",
+			Description:   "Root and Subordinate CA certificates MUST have a two-letter country code specified in ISO 3166-1",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCaCountryNameInvalid,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ca_country_name_missing.go
+++ b/v3/lints/cabf_br/lint_ca_country_name_missing.go
@@ -31,13 +31,15 @@ in which the CA’s place	of business	is located.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ca_country_name_missing",
-		Description:   "Root and Subordinate CA certificates MUST have a countryName present in subject information",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCaCountryNameMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ca_country_name_missing",
+			Description:   "Root and Subordinate CA certificates MUST have a countryName present in subject information",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCaCountryNameMissing,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ca_crl_sign_not_set.go
+++ b/v3/lints/cabf_br/lint_ca_crl_sign_not_set.go
@@ -30,13 +30,15 @@ signing OCSP responses, then the digitalSignature bit MUST be set.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ca_crl_sign_not_set",
-		Description:   "Root and Subordinate CA certificate keyUsage extension's crlSign bit MUST be set",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCaCRLSignNotSet,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ca_crl_sign_not_set",
+			Description:   "Root and Subordinate CA certificate keyUsage extension's crlSign bit MUST be set",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCaCRLSignNotSet,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ca_digital_signature_not_set.go
+++ b/v3/lints/cabf_br/lint_ca_digital_signature_not_set.go
@@ -33,13 +33,15 @@ If the Root CA Private Key is used for signing OCSP responses, then the digitalS
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "n_ca_digital_signature_not_set",
-		Description:   "Root and Subordinate CA Certificates that wish to use their private key for signing OCSP responses will not be able to without their digital signature set",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCaDigSignNotSet,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "n_ca_digital_signature_not_set",
+			Description:   "Root and Subordinate CA Certificates that wish to use their private key for signing OCSP responses will not be able to without their digital signature set",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCaDigSignNotSet,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ca_is_ca.go
+++ b/v3/lints/cabf_br/lint_ca_is_ca.go
@@ -24,13 +24,15 @@ import (
 type caIsCA struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ca_is_ca",
-		Description:   "Root and Sub CA Certificate: The CA field MUST be set to true.",
-		Citation:      "BRs: 7.1.2.1, BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCaIsCA,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ca_is_ca",
+			Description:   "Root and Sub CA Certificate: The CA field MUST be set to true.",
+			Citation:      "BRs: 7.1.2.1, BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCaIsCA,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ca_key_cert_sign_not_set.go
+++ b/v3/lints/cabf_br/lint_ca_key_cert_sign_not_set.go
@@ -29,13 +29,15 @@ If the Root CA Private Key is used for signing OCSP responses, then the digitalS
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ca_key_cert_sign_not_set",
-		Description:   "Root CA Certificate: Bit positions for keyCertSign and cRLSign MUST be set.",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCaKeyCertSignNotSet,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ca_key_cert_sign_not_set",
+			Description:   "Root CA Certificate: Bit positions for keyCertSign and cRLSign MUST be set.",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCaKeyCertSignNotSet,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ca_key_usage_missing.go
+++ b/v3/lints/cabf_br/lint_ca_key_usage_missing.go
@@ -31,13 +31,15 @@ Conforming CAs MUST include this extension in certificates that
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ca_key_usage_missing",
-		Description:   "Root and Subordinate CA certificate keyUsage extension MUST be present",
-		Citation:      "BRs: 7.1.2.1, RFC 5280: 4.2.1.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewCaKeyUsageMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ca_key_usage_missing",
+			Description:   "Root and Subordinate CA certificate keyUsage extension MUST be present",
+			Citation:      "BRs: 7.1.2.1, RFC 5280: 4.2.1.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewCaKeyUsageMissing,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ca_key_usage_not_critical.go
+++ b/v3/lints/cabf_br/lint_ca_key_usage_not_critical.go
@@ -29,13 +29,15 @@ If the Root CA Private Key is used for signing OCSP responses, then the digitalS
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ca_key_usage_not_critical",
-		Description:   "Root and Subordinate CA certificate keyUsage extension MUST be marked as critical",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCaKeyUsageNotCrit,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ca_key_usage_not_critical",
+			Description:   "Root and Subordinate CA certificate keyUsage extension MUST be marked as critical",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCaKeyUsageNotCrit,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ca_organization_name_missing.go
+++ b/v3/lints/cabf_br/lint_ca_organization_name_missing.go
@@ -28,13 +28,15 @@ The Certificate Subject MUST contain the following: organizationName (OID 2.5.4.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ca_organization_name_missing",
-		Description:   "Root and Subordinate CA certificates MUST have a organizationName present in subject information",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCaOrganizationNameMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ca_organization_name_missing",
+			Description:   "Root and Subordinate CA certificates MUST have a organizationName present in subject information",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCaOrganizationNameMissing,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_locality.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_locality.go
@@ -24,13 +24,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cab_dv_conflicts_with_locality",
-		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, locality name MUST NOT be included in subject",
-		Citation:      "BRs: 7.1.6.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCertPolicyConflictsWithLocality,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cab_dv_conflicts_with_locality",
+			Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, locality name MUST NOT be included in subject",
+			Citation:      "BRs: 7.1.6.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCertPolicyConflictsWithLocality,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_org.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_org.go
@@ -33,13 +33,15 @@ field.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cab_dv_conflicts_with_org",
-		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, organization name MUST NOT be included in subject",
-		Citation:      "BRs: 7.1.6.4",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCertPolicyConflictsWithOrg,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cab_dv_conflicts_with_org",
+			Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, organization name MUST NOT be included in subject",
+			Citation:      "BRs: 7.1.6.4",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCertPolicyConflictsWithOrg,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_postal.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_postal.go
@@ -33,13 +33,15 @@ field.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cab_dv_conflicts_with_postal",
-		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, postalCode MUST NOT be included in subject",
-		Citation:      "BRs: 7.1.6.4",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCertPolicyConflictsWithPostal,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cab_dv_conflicts_with_postal",
+			Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, postalCode MUST NOT be included in subject",
+			Citation:      "BRs: 7.1.6.4",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCertPolicyConflictsWithPostal,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_province.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_province.go
@@ -33,13 +33,15 @@ field.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cab_dv_conflicts_with_province",
-		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, stateOrProvinceName MUST NOT be included in subject",
-		Citation:      "BRs: 7.1.6.4",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCertPolicyConflictsWithProvince,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cab_dv_conflicts_with_province",
+			Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, stateOrProvinceName MUST NOT be included in subject",
+			Citation:      "BRs: 7.1.6.4",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCertPolicyConflictsWithProvince,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_street.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_street.go
@@ -33,13 +33,15 @@ field.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cab_dv_conflicts_with_street",
-		Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, streetAddress MUST NOT be included in subject",
-		Citation:      "BRs: 7.1.6.4",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCertPolicyConflictsWithStreet,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cab_dv_conflicts_with_street",
+			Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, streetAddress MUST NOT be included in subject",
+			Citation:      "BRs: 7.1.6.4",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCertPolicyConflictsWithStreet,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_cab_iv_requires_personal_name.go
+++ b/v3/lints/cabf_br/lint_cab_iv_requires_personal_name.go
@@ -34,13 +34,15 @@ the Subject field.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cab_iv_requires_personal_name",
-		Description:   "If certificate policy 2.23.140.1.2.3 is included, either organizationName or givenName and surname MUST be included in subject",
-		Citation:      "BRs: 7.1.6.4",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV131Date,
-		Lint:          NewCertPolicyRequiresPersonalName,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cab_iv_requires_personal_name",
+			Description:   "If certificate policy 2.23.140.1.2.3 is included, either organizationName or givenName and surname MUST be included in subject",
+			Citation:      "BRs: 7.1.6.4",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV131Date,
+		},
+		Lint: NewCertPolicyRequiresPersonalName,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_cab_ov_requires_org.go
+++ b/v3/lints/cabf_br/lint_cab_ov_requires_org.go
@@ -33,13 +33,15 @@ required under Section 7.1.4.2.2), and countryName in the Subject field.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cab_ov_requires_org",
-		Description:   "If certificate policy 2.23.140.1.2.2 is included, organizationName MUST be included in subject",
-		Citation:      "BRs: 7.1.6.4",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCertPolicyRequiresOrg,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cab_ov_requires_org",
+			Description:   "If certificate policy 2.23.140.1.2.2 is included, organizationName MUST be included in subject",
+			Citation:      "BRs: 7.1.6.4",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCertPolicyRequiresOrg,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_cert_policy_iv_requires_country.go
+++ b/v3/lints/cabf_br/lint_cert_policy_iv_requires_country.go
@@ -34,13 +34,15 @@ the Subject field.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cert_policy_iv_requires_country",
-		Description:   "If certificate policy 2.23.140.1.2.3 is included, countryName MUST be included in subject",
-		Citation:      "BRs: 7.1.6.4",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV131Date,
-		Lint:          NewCertPolicyIVRequiresCountry,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cert_policy_iv_requires_country",
+			Description:   "If certificate policy 2.23.140.1.2.3 is included, countryName MUST be included in subject",
+			Citation:      "BRs: 7.1.6.4",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV131Date,
+		},
+		Lint: NewCertPolicyIVRequiresCountry,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_cert_policy_iv_requires_province_or_locality.go
+++ b/v3/lints/cabf_br/lint_cert_policy_iv_requires_province_or_locality.go
@@ -35,13 +35,15 @@ the Subject field.
 // 7.1.4.2.2 applies only to subscriber certificates.
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cert_policy_iv_requires_province_or_locality",
-		Description:   "If certificate policy 2.23.140.1.2.3 is included, localityName or stateOrProvinceName MUST be included in subject",
-		Citation:      "BRs: 7.1.6.4",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV131Date,
-		Lint:          NewCertPolicyIVRequiresProvinceOrLocal,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cert_policy_iv_requires_province_or_locality",
+			Description:   "If certificate policy 2.23.140.1.2.3 is included, localityName or stateOrProvinceName MUST be included in subject",
+			Citation:      "BRs: 7.1.6.4",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV131Date,
+		},
+		Lint: NewCertPolicyIVRequiresProvinceOrLocal,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_cert_policy_ov_requires_country.go
+++ b/v3/lints/cabf_br/lint_cert_policy_ov_requires_country.go
@@ -33,13 +33,15 @@ required under Section 7.1.4.2.2), and countryName in the Subject field.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cert_policy_ov_requires_country",
-		Description:   "If certificate policy 2.23.140.1.2.2 is included, countryName MUST be included in subject",
-		Citation:      "BRs: 7.1.6.4",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCertPolicyOVRequiresCountry,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cert_policy_ov_requires_country",
+			Description:   "If certificate policy 2.23.140.1.2.2 is included, countryName MUST be included in subject",
+			Citation:      "BRs: 7.1.6.4",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCertPolicyOVRequiresCountry,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_cert_policy_ov_requires_province_or_locality.go
+++ b/v3/lints/cabf_br/lint_cert_policy_ov_requires_province_or_locality.go
@@ -35,13 +35,15 @@ Note: 7.1.4.2.2 applies only to subscriber certificates.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cert_policy_ov_requires_province_or_locality",
-		Description:   "If certificate policy 2.23.140.1.2.2 is included, localityName or stateOrProvinceName MUST be included in subject",
-		Citation:      "BRs: 7.1.6.4",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCertPolicyOVRequiresProvinceOrLocal,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cert_policy_ov_requires_province_or_locality",
+			Description:   "If certificate policy 2.23.140.1.2.2 is included, localityName or stateOrProvinceName MUST be included in subject",
+			Citation:      "BRs: 7.1.6.4",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCertPolicyOVRequiresProvinceOrLocal,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dh_params_missing.go
+++ b/v3/lints/cabf_br/lint_dh_params_missing.go
@@ -25,14 +25,16 @@ import (
 type dsaParamsMissing struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:            "e_dsa_params_missing",
-		Description:     "DSA: Certificates MUST include all domain parameters",
-		Citation:        "BRs v1.7.0: 6.1.6",
-		Source:          lint.CABFBaselineRequirements,
-		EffectiveDate:   util.CABEffectiveDate,
-		IneffectiveDate: util.CABFBRs_1_7_1_Date,
-		Lint:            NewDsaParamsMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:            "e_dsa_params_missing",
+			Description:     "DSA: Certificates MUST include all domain parameters",
+			Citation:        "BRs v1.7.0: 6.1.6",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.CABFBRs_1_7_1_Date,
+		},
+		Lint: NewDsaParamsMissing,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_bad_character_in_label.go
+++ b/v3/lints/cabf_br/lint_dnsname_bad_character_in_label.go
@@ -27,13 +27,15 @@ type DNSNameProperCharacters struct {
 }
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dnsname_bad_character_in_label",
-		Description:   "Characters in labels of DNSNames MUST be alphanumeric, - , _ or *",
-		Citation:      "BRs: 7.1.4.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewDNSNameProperCharacters,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dnsname_bad_character_in_label",
+			Description:   "Characters in labels of DNSNames MUST be alphanumeric, - , _ or *",
+			Citation:      "BRs: 7.1.4.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewDNSNameProperCharacters,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_check_left_label_wildcard.go
+++ b/v3/lints/cabf_br/lint_dnsname_check_left_label_wildcard.go
@@ -25,13 +25,15 @@ import (
 type DNSNameLeftLabelWildcardCheck struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dnsname_left_label_wildcard_correct",
-		Description:   "Wildcards in the left label of DNSName should only be *",
-		Citation:      "BRs: 1.6.1, Wildcard Certificate and Wildcard Domain Name",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewDNSNameLeftLabelWildcardCheck,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dnsname_left_label_wildcard_correct",
+			Description:   "Wildcards in the left label of DNSName should only be *",
+			Citation:      "BRs: 1.6.1, Wildcard Certificate and Wildcard Domain Name",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewDNSNameLeftLabelWildcardCheck,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_contains_bare_iana_suffix.go
+++ b/v3/lints/cabf_br/lint_dnsname_contains_bare_iana_suffix.go
@@ -23,13 +23,15 @@ import (
 type dnsNameContainsBareIANASuffix struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dnsname_contains_bare_iana_suffix",
-		Description:   "DNSNames should not contain a bare IANA suffix.",
-		Citation:      "BRs: 1.6.1, Base Domain Name",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewDnsNameContainsBareIANASuffix,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dnsname_contains_bare_iana_suffix",
+			Description:   "DNSNames should not contain a bare IANA suffix.",
+			Citation:      "BRs: 1.6.1, Base Domain Name",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewDnsNameContainsBareIANASuffix,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_contains_empty_label.go
+++ b/v3/lints/cabf_br/lint_dnsname_contains_empty_label.go
@@ -25,13 +25,15 @@ import (
 type DNSNameEmptyLabel struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dnsname_empty_label",
-		Description:   "DNSNames should not have an empty label.",
-		Citation:      "BRs: 7.1.4.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewDNSNameEmptyLabel,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dnsname_empty_label",
+			Description:   "DNSNames should not have an empty label.",
+			Citation:      "BRs: 7.1.4.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewDNSNameEmptyLabel,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_contains_prohibited_reserved_label.go
+++ b/v3/lints/cabf_br/lint_dnsname_contains_prohibited_reserved_label.go
@@ -23,13 +23,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dnsname_contains_prohibited_reserved_label",
-		Description:   "FQDNs MUST consist solely of Domain Labels that are P‐Labels or Non‐Reserved LDH Labels",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.NoReservedDomainLabelsDate,
-		Lint:          NewDNSNameContainsProhibitedReservedLabel,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dnsname_contains_prohibited_reserved_label",
+			Description:   "FQDNs MUST consist solely of Domain Labels that are P‐Labels or Non‐Reserved LDH Labels",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.NoReservedDomainLabelsDate,
+		},
+		Lint: NewDNSNameContainsProhibitedReservedLabel,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_hyphen_in_sld.go
+++ b/v3/lints/cabf_br/lint_dnsname_hyphen_in_sld.go
@@ -25,13 +25,15 @@ import (
 type DNSNameHyphenInSLD struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dnsname_hyphen_in_sld",
-		Description:   "DNSName should not have a hyphen beginning or ending the SLD",
-		Citation:      "BRs 7.1.4.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewDNSNameHyphenInSLD,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dnsname_hyphen_in_sld",
+			Description:   "DNSName should not have a hyphen beginning or ending the SLD",
+			Citation:      "BRs 7.1.4.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewDNSNameHyphenInSLD,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_label_too_long.go
+++ b/v3/lints/cabf_br/lint_dnsname_label_too_long.go
@@ -25,13 +25,15 @@ import (
 type DNSNameLabelLengthTooLong struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dnsname_label_too_long",
-		Description:   "DNSName labels MUST be less than or equal to 63 characters",
-		Citation:      "RFC 1035",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewDNSNameLabelLengthTooLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dnsname_label_too_long",
+			Description:   "DNSName labels MUST be less than or equal to 63 characters",
+			Citation:      "RFC 1035",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewDNSNameLabelLengthTooLong,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_right_label_valid_tld.go
+++ b/v3/lints/cabf_br/lint_dnsname_right_label_valid_tld.go
@@ -23,13 +23,15 @@ import (
 type DNSNameValidTLD struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dnsname_not_valid_tld",
-		Description:   "DNSNames must have a valid TLD.",
-		Citation:      "BRs: 3.2.2.4",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewDNSNameValidTLD,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dnsname_not_valid_tld",
+			Description:   "DNSNames must have a valid TLD.",
+			Citation:      "BRs: 3.2.2.4",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewDNSNameValidTLD,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_underscore_in_sld.go
+++ b/v3/lints/cabf_br/lint_dnsname_underscore_in_sld.go
@@ -25,13 +25,15 @@ import (
 type DNSNameUnderscoreInSLD struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dnsname_underscore_in_sld",
-		Description:   "DNSName MUST NOT contain underscore characters",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewDNSNameUnderscoreInSLD,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dnsname_underscore_in_sld",
+			Description:   "DNSName MUST NOT contain underscore characters",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewDNSNameUnderscoreInSLD,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_underscore_in_trd.go
+++ b/v3/lints/cabf_br/lint_dnsname_underscore_in_trd.go
@@ -25,13 +25,15 @@ import (
 type DNSNameUnderscoreInTRD struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_dnsname_underscore_in_trd",
-		Description:   "DNSName MUST NOT contain underscore characters",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewDNSNameUnderscoreInTRD,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_dnsname_underscore_in_trd",
+			Description:   "DNSName MUST NOT contain underscore characters",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewDNSNameUnderscoreInTRD,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_wildcard_left_of_public_suffix.go
+++ b/v3/lints/cabf_br/lint_dnsname_wildcard_left_of_public_suffix.go
@@ -23,13 +23,15 @@ import (
 type DNSNameWildcardLeftofPublicSuffix struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "n_dnsname_wildcard_left_of_public_suffix",
-		Description:   "the CA MUST establish and follow a documented procedure[^pubsuffix] that determines if the wildcard character occurs in the first label position to the left of a “registry‐controlled” label or “public suffix”",
-		Citation:      "BRs: 3.2.2.6",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewDNSNameWildcardLeftofPublicSuffix,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "n_dnsname_wildcard_left_of_public_suffix",
+			Description:   "the CA MUST establish and follow a documented procedure[^pubsuffix] that determines if the wildcard character occurs in the first label position to the left of a “registry‐controlled” label or “public suffix”",
+			Citation:      "BRs: 3.2.2.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewDNSNameWildcardLeftofPublicSuffix,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dnsname_wildcard_only_in_left_label.go
+++ b/v3/lints/cabf_br/lint_dnsname_wildcard_only_in_left_label.go
@@ -25,13 +25,15 @@ import (
 type DNSNameWildcardOnlyInLeftlabel struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dnsname_wildcard_only_in_left_label",
-		Description:   "DNSName should not have wildcards except in the left-most label",
-		Citation:      "BRs: 1.6.1, Wildcard Domain Name",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewDNSNameWildcardOnlyInLeftlabel,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dnsname_wildcard_only_in_left_label",
+			Description:   "DNSName should not have wildcards except in the left-most label",
+			Citation:      "BRs: 1.6.1, Wildcard Domain Name",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewDNSNameWildcardOnlyInLeftlabel,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dsa_correct_order_in_subgroup.go
+++ b/v3/lints/cabf_br/lint_dsa_correct_order_in_subgroup.go
@@ -27,13 +27,15 @@ import (
 type dsaSubgroup struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dsa_correct_order_in_subgroup",
-		Description:   "DSA: Public key value has the unique correct representation in the field, and that the key has the correct order in the subgroup",
-		Citation:      "BRs v1.7.0: 6.1.6",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewDsaSubgroup,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dsa_correct_order_in_subgroup",
+			Description:   "DSA: Public key value has the unique correct representation in the field, and that the key has the correct order in the subgroup",
+			Citation:      "BRs v1.7.0: 6.1.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewDsaSubgroup,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dsa_improper_modulus_or_divisor_size.go
+++ b/v3/lints/cabf_br/lint_dsa_improper_modulus_or_divisor_size.go
@@ -25,13 +25,15 @@ import (
 type dsaImproperSize struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dsa_improper_modulus_or_divisor_size",
-		Description:   "Certificates MUST meet the following requirements for DSA algorithm type and key size: L=2048 and N=224,256 or L=3072 and N=256",
-		Citation:      "BRs v1.7.0: 6.1.5",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewDsaImproperSize,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dsa_improper_modulus_or_divisor_size",
+			Description:   "Certificates MUST meet the following requirements for DSA algorithm type and key size: L=2048 and N=224,256 or L=3072 and N=256",
+			Citation:      "BRs v1.7.0: 6.1.5",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewDsaImproperSize,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dsa_shorter_than_2048_bits.go
+++ b/v3/lints/cabf_br/lint_dsa_shorter_than_2048_bits.go
@@ -25,14 +25,16 @@ import (
 type dsaTooShort struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:        "e_dsa_shorter_than_2048_bits",
-		Description: "DSA modulus size must be at least 2048 bits",
-		Citation:    "BRs v1.7.0: 6.1.5",
-		// Refer to BRs: 6.1.5, taking the statement "Before 31 Dec 2010" literally
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewDsaTooShort,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:        "e_dsa_shorter_than_2048_bits",
+			Description: "DSA modulus size must be at least 2048 bits",
+			Citation:    "BRs v1.7.0: 6.1.5",
+			// Refer to BRs: 6.1.5, taking the statement "Before 31 Dec 2010" literally
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewDsaTooShort,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_dsa_unique_correct_representation.go
+++ b/v3/lints/cabf_br/lint_dsa_unique_correct_representation.go
@@ -27,13 +27,15 @@ import (
 type dsaUniqueCorrectRepresentation struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_dsa_unique_correct_representation",
-		Description:   "DSA: Public key value has the unique correct representation in the field, and that the key has the correct order in the subgroup",
-		Citation:      "BRs v1.7.0: 6.1.6",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewDsaUniqueCorrectRepresentation,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_dsa_unique_correct_representation",
+			Description:   "DSA: Public key value has the unique correct representation in the field, and that the key has the correct order in the subgroup",
+			Citation:      "BRs v1.7.0: 6.1.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewDsaUniqueCorrectRepresentation,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_e_sub_ca_aia_missing.go
+++ b/v3/lints/cabf_br/lint_e_sub_ca_aia_missing.go
@@ -31,14 +31,16 @@ marked critical, and it MUST contain the HTTP URL of the Issuing CA’s OCSP res
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:            "e_sub_ca_aia_missing",
-		Description:     "Subordinate CA Certificate: authorityInformationAccess MUST be present, with the exception of stapling.",
-		Citation:        "BRs: 7.1.2.2",
-		Source:          lint.CABFBaselineRequirements,
-		EffectiveDate:   util.CABEffectiveDate,
-		IneffectiveDate: util.CABFBRs_1_7_1_Date,
-		Lint:            NewCaAiaMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:            "e_sub_ca_aia_missing",
+			Description:     "Subordinate CA Certificate: authorityInformationAccess MUST be present, with the exception of stapling.",
+			Citation:        "BRs: 7.1.2.2",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.CABFBRs_1_7_1_Date,
+		},
+		Lint: NewCaAiaMissing,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ec_improper_curves.go
+++ b/v3/lints/cabf_br/lint_ec_improper_curves.go
@@ -31,14 +31,16 @@ ECC Curve: NIST P-256, P-384, or P-521
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:        "e_ec_improper_curves",
-		Description: "Only one of NIST P‐256, P‐384, or P‐521 can be used",
-		Citation:    "BRs: 6.1.5",
-		Source:      lint.CABFBaselineRequirements,
-		// Refer to BRs: 6.1.5, taking the statement "Before 31 Dec 2010" literally
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewEcImproperCurves,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:        "e_ec_improper_curves",
+			Description: "Only one of NIST P‐256, P‐384, or P‐521 can be used",
+			Citation:    "BRs: 6.1.5",
+			Source:      lint.CABFBaselineRequirements,
+			// Refer to BRs: 6.1.5, taking the statement "Before 31 Dec 2010" literally
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewEcImproperCurves,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ext_nc_intersects_reserved_ip.go
+++ b/v3/lints/cabf_br/lint_ext_nc_intersects_reserved_ip.go
@@ -34,13 +34,15 @@ Subject commonName field containing a Reserved IP Address or Internal Name.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_nc_intersects_reserved_ip",
-		Description:   "iPAddress name constraint intersects an IANA reserved network",
-		Citation:      "BRs: 7.1.5 / 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewNCReservedIPNet,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_nc_intersects_reserved_ip",
+			Description:   "iPAddress name constraint intersects an IANA reserved network",
+			Citation:      "BRs: 7.1.5 / 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewNCReservedIPNet,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ext_san_contains_reserved_ip.go
+++ b/v3/lints/cabf_br/lint_ext_san_contains_reserved_ip.go
@@ -23,13 +23,15 @@ import (
 type SANReservedIP struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_contains_reserved_ip",
-		Description:   "CAs SHALL NOT issue certificates with a subjectAltName extension or subject:commonName field containing a Reserved IP Address or Internal Name.",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSANReservedIP,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_contains_reserved_ip",
+			Description:   "CAs SHALL NOT issue certificates with a subjectAltName extension or subject:commonName field containing a Reserved IP Address or Internal Name.",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSANReservedIP,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ext_san_critical_with_subject_dn.go
+++ b/v3/lints/cabf_br/lint_ext_san_critical_with_subject_dn.go
@@ -34,13 +34,15 @@ Further, if the only subject identity included in the certificate is an
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_san_critical_with_subject_dn",
-		Description:   "If the subject contains a distinguished name, subjectAlternateName SHOULD be non-critical",
-		Citation:      "RFC 5280: 4.2.1.6",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewExtSANCriticalWithSubjectDN,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_san_critical_with_subject_dn",
+			Description:   "If the subject contains a distinguished name, subjectAlternateName SHOULD be non-critical",
+			Citation:      "RFC 5280: 4.2.1.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewExtSANCriticalWithSubjectDN,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ext_san_directory_name_present.go
+++ b/v3/lints/cabf_br/lint_ext_san_directory_name_present.go
@@ -34,13 +34,15 @@ Wildcard FQDNs are permitted.
 *************************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_directory_name_present",
-		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSANDirName,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_directory_name_present",
+			Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSANDirName,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ext_san_edi_party_name_present.go
+++ b/v3/lints/cabf_br/lint_ext_san_edi_party_name_present.go
@@ -34,13 +34,15 @@ Wildcard FQDNs are permitted.
 *************************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_edi_party_name_present",
-		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSANEDI,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_edi_party_name_present",
+			Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSANEDI,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ext_san_missing.go
+++ b/v3/lints/cabf_br/lint_ext_san_missing.go
@@ -30,13 +30,15 @@ Required/Optional: Required
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_missing",
-		Description:   "Subscriber certificates MUST contain the Subject Alternate Name extension",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSANMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_missing",
+			Description:   "Subscriber certificates MUST contain the Subject Alternate Name extension",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSANMissing,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ext_san_other_name_present.go
+++ b/v3/lints/cabf_br/lint_ext_san_other_name_present.go
@@ -34,13 +34,15 @@ Wildcard FQDNs are permitted.
 *************************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_other_name_present",
-		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSANOtherName,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_other_name_present",
+			Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSANOtherName,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ext_san_registered_id_present.go
+++ b/v3/lints/cabf_br/lint_ext_san_registered_id_present.go
@@ -34,13 +34,15 @@ Wildcard FQDNs are permitted.
 *************************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_registered_id_present",
-		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSANRegId,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_registered_id_present",
+			Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSANRegId,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ext_san_rfc822_name_present.go
+++ b/v3/lints/cabf_br/lint_ext_san_rfc822_name_present.go
@@ -34,13 +34,15 @@ Wildcard FQDNs are permitted.
 *************************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_rfc822_name_present",
-		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSANRfc822,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_rfc822_name_present",
+			Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types.",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSANRfc822,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ext_san_uniform_resource_identifier_present.go
+++ b/v3/lints/cabf_br/lint_ext_san_uniform_resource_identifier_present.go
@@ -34,13 +34,15 @@ Wildcard FQDNs are permitted.
 *************************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_uniform_resource_identifier_present",
-		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSANURI,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_uniform_resource_identifier_present",
+			Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' and 'ipaddress' name types",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSANURI,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ext_tor_service_descriptor_hash_invalid.go
+++ b/v3/lints/cabf_br/lint_ext_tor_service_descriptor_hash_invalid.go
@@ -27,13 +27,15 @@ import (
 type torServiceDescHashInvalid struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_tor_service_descriptor_hash_invalid",
-		Description:   "certificates with v2 .onion names need valid TorServiceDescriptors in extension",
-		Citation:      "BRs: Ballot 201, Ballot SC27",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV201Date,
-		Lint:          NewTorServiceDescHashInvalid,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_tor_service_descriptor_hash_invalid",
+			Description:   "certificates with v2 .onion names need valid TorServiceDescriptors in extension",
+			Citation:      "BRs: Ballot 201, Ballot SC27",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV201Date,
+		},
+		Lint: NewTorServiceDescHashInvalid,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_extra_subject_common_names.go
+++ b/v3/lints/cabf_br/lint_extra_subject_common_names.go
@@ -23,13 +23,15 @@ import (
 type extraSubjectCommonNames struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_extra_subject_common_names",
-		Description:   "if present the subject commonName field MUST contain a single IP address or Fully-Qualified Domain Name",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewExtraSubjectCommonNames,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_extra_subject_common_names",
+			Description:   "if present the subject commonName field MUST contain a single IP address or Fully-Qualified Domain Name",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewExtraSubjectCommonNames,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_invalid_certificate_version.go
+++ b/v3/lints/cabf_br/lint_invalid_certificate_version.go
@@ -27,13 +27,15 @@ Certificates MUST be of type X.509 v3.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_invalid_certificate_version",
-		Description:   "Certificates MUST be of type X.590 v3",
-		Citation:      "BRs: 7.1.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV130Date,
-		Lint:          NewInvalidCertificateVersion,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_invalid_certificate_version",
+			Description:   "Certificates MUST be of type X.590 v3",
+			Citation:      "BRs: 7.1.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV130Date,
+		},
+		Lint: NewInvalidCertificateVersion,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_no_underscores_before_1_6_2.go
+++ b/v3/lints/cabf_br/lint_no_underscores_before_1_6_2.go
@@ -24,14 +24,16 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:            "e_no_underscores_before_1_6_2",
-		Description:     "Before explicitly stating as such in CABF 1.6.2, the stance of RFC5280 is adopted that DNSNames MUST NOT contain an underscore character.",
-		Citation:        "BR 7.1.4.2.1",
-		Source:          lint.CABFBaselineRequirements,
-		EffectiveDate:   util.ZeroDate,
-		IneffectiveDate: util.CABFBRs_1_6_2_Date,
-		Lint:            func() lint.LintInterface { return &NoUnderscoreBefore1_6_2{} },
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:            "e_no_underscores_before_1_6_2",
+			Description:     "Before explicitly stating as such in CABF 1.6.2, the stance of RFC5280 is adopted that DNSNames MUST NOT contain an underscore character.",
+			Citation:        "BR 7.1.4.2.1",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.ZeroDate,
+			IneffectiveDate: util.CABFBRs_1_6_2_Date,
+		},
+		Lint: func() lint.LintInterface { return &NoUnderscoreBefore1_6_2{} },
 	})
 }
 

--- a/v3/lints/cabf_br/lint_ocsp_id_pkix_ocsp_nocheck_ext_not_included_server_auth.go
+++ b/v3/lints/cabf_br/lint_ocsp_id_pkix_ocsp_nocheck_ext_not_included_server_auth.go
@@ -23,14 +23,16 @@ import (
 type OCSPIDPKIXOCSPNocheckExtNotIncludedServerAuth struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name: "e_ocsp_id_pkix_ocsp_nocheck_ext_not_included_server_auth",
-		Description: "OCSP signing Certificate MUST contain an extension of type id-pkixocsp-nocheck, as" +
-			" defined by RFC6960",
-		Citation:      "BRs: 4.9.9",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewOCSPIDPKIXOCSPNocheckExtNotIncludedServerAuth,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name: "e_ocsp_id_pkix_ocsp_nocheck_ext_not_included_server_auth",
+			Description: "OCSP signing Certificate MUST contain an extension of type id-pkixocsp-nocheck, as" +
+				" defined by RFC6960",
+			Citation:      "BRs: 4.9.9",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewOCSPIDPKIXOCSPNocheckExtNotIncludedServerAuth,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
+++ b/v3/lints/cabf_br/lint_old_root_ca_rsa_mod_less_than_2048_bits.go
@@ -25,13 +25,15 @@ import (
 type rootCaModSize struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_old_root_ca_rsa_mod_less_than_2048_bits",
-		Description:   "In a validity period beginning on or before 31 Dec 2010, root CA certificates using RSA public key algorithm MUST use a 2048 bit modulus",
-		Citation:      "BRs: 6.1.5",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewRootCaModSize,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_old_root_ca_rsa_mod_less_than_2048_bits",
+			Description:   "In a validity period beginning on or before 31 Dec 2010, root CA certificates using RSA public key algorithm MUST use a 2048 bit modulus",
+			Citation:      "BRs: 6.1.5",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewRootCaModSize,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
+++ b/v3/lints/cabf_br/lint_old_sub_ca_rsa_mod_less_than_1024_bits.go
@@ -27,14 +27,16 @@ import (
 type subCaModSize struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:        "e_old_sub_ca_rsa_mod_less_than_1024_bits",
-		Description: "In a validity period beginning on or before 31 Dec 2010 and ending on or before 31 Dec 2013, subordinate CA certificates using RSA public key algorithm MUST use a 1024 bit modulus",
-		Citation:    "BRs: 6.1.5",
-		Source:      lint.CABFBaselineRequirements,
-		// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSubCaModSize,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:        "e_old_sub_ca_rsa_mod_less_than_1024_bits",
+			Description: "In a validity period beginning on or before 31 Dec 2010 and ending on or before 31 Dec 2013, subordinate CA certificates using RSA public key algorithm MUST use a 1024 bit modulus",
+			Citation:    "BRs: 6.1.5",
+			Source:      lint.CABFBaselineRequirements,
+			// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSubCaModSize,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
+++ b/v3/lints/cabf_br/lint_old_sub_cert_rsa_mod_less_than_1024_bits.go
@@ -25,14 +25,16 @@ import (
 type subModSize struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:        "e_old_sub_cert_rsa_mod_less_than_1024_bits",
-		Description: "In a validity period ending on or before 31 Dec 2013, subscriber certificates using RSA public key algorithm MUST use a 1024 bit modulus",
-		Citation:    "BRs: 6.1.5",
-		Source:      lint.CABFBaselineRequirements,
-		// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSubModSize,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:        "e_old_sub_cert_rsa_mod_less_than_1024_bits",
+			Description: "In a validity period ending on or before 31 Dec 2013, subscriber certificates using RSA public key algorithm MUST use a 1024 bit modulus",
+			Citation:    "BRs: 6.1.5",
+			Source:      lint.CABFBaselineRequirements,
+			// since effective date should be checked against end date in this specific case, putting time check into checkApplies instead, ZeroDate here to automatically pass NE test
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSubModSize,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_organizational_unit_name_prohibited.go
+++ b/v3/lints/cabf_br/lint_organizational_unit_name_prohibited.go
@@ -21,13 +21,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_organizational_unit_name_prohibited",
-		Description:   "OrganizationalUnitName is prohibited if...the certificate was issued on or after September 1, 2022",
-		Citation:      "BRs: 7.1.4.2.2-i",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABFBRs_OU_Prohibited_Date,
-		Lint:          NewOrganizationalUnitNameProhibited,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_organizational_unit_name_prohibited",
+			Description:   "OrganizationalUnitName is prohibited if...the certificate was issued on or after September 1, 2022",
+			Citation:      "BRs: 7.1.4.2.2-i",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABFBRs_OU_Prohibited_Date,
+		},
+		Lint: NewOrganizationalUnitNameProhibited,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_prohibit_dsa_usage.go
+++ b/v3/lints/cabf_br/lint_prohibit_dsa_usage.go
@@ -23,13 +23,15 @@ import (
 type prohibitDSAUsage struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_br_prohibit_dsa_usage",
-		Description:   "DSA was removed from the Baseline Requirements as a valid signature algorithm in 1.7.1.",
-		Citation:      "BRs: v1.7.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABFBRs_1_7_1_Date,
-		Lint:          NewProhibitDSAUsage,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_br_prohibit_dsa_usage",
+			Description:   "DSA was removed from the Baseline Requirements as a valid signature algorithm in 1.7.1.",
+			Citation:      "BRs: v1.7.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABFBRs_1_7_1_Date,
+		},
+		Lint: NewProhibitDSAUsage,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_public_key_type_not_allowed.go
+++ b/v3/lints/cabf_br/lint_public_key_type_not_allowed.go
@@ -23,13 +23,15 @@ import (
 type publicKeyAllowed struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_public_key_type_not_allowed",
-		Description:   "Certificates MUST have RSA, DSA, or ECDSA public key type",
-		Citation:      "BRs: 6.1.5",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewPublicKeyAllowed,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_public_key_type_not_allowed",
+			Description:   "Certificates MUST have RSA, DSA, or ECDSA public key type",
+			Citation:      "BRs: 6.1.5",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewPublicKeyAllowed,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
+++ b/v3/lints/cabf_br/lint_root_ca_basic_constraints_path_len_constraint_field_present.go
@@ -30,13 +30,15 @@ This extension MUST appear as a critical extension. The cA field MUST be set tru
 ***********************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_root_ca_basic_constraints_path_len_constraint_field_present",
-		Description:   "Root CA certificate basicConstraint extension pathLenConstraint field SHOULD NOT be present",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewRootCaPathLenPresent,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_root_ca_basic_constraints_path_len_constraint_field_present",
+			Description:   "Root CA certificate basicConstraint extension pathLenConstraint field SHOULD NOT be present",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewRootCaPathLenPresent,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_root_ca_contains_cert_policy.go
+++ b/v3/lints/cabf_br/lint_root_ca_contains_cert_policy.go
@@ -28,13 +28,15 @@ This extension SHOULD NOT be present.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_root_ca_contains_cert_policy",
-		Description:   "Root CA Certificate: certificatePolicies SHOULD NOT be present.",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewRootCAContainsCertPolicy,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_root_ca_contains_cert_policy",
+			Description:   "Root CA Certificate: certificatePolicies SHOULD NOT be present.",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewRootCAContainsCertPolicy,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_root_ca_extended_key_usage_present.go
+++ b/v3/lints/cabf_br/lint_root_ca_extended_key_usage_present.go
@@ -28,13 +28,15 @@ This extension MUST NOT be present.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_root_ca_extended_key_usage_present",
-		Description:   "Root CA Certificate: extendedKeyUsage MUST NOT be present.t",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewRootCAContainsEKU,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_root_ca_extended_key_usage_present",
+			Description:   "Root CA Certificate: extendedKeyUsage MUST NOT be present.t",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewRootCAContainsEKU,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_root_ca_key_usage_must_be_critical.go
+++ b/v3/lints/cabf_br/lint_root_ca_key_usage_must_be_critical.go
@@ -23,13 +23,15 @@ import (
 type rootCAKeyUsageMustBeCritical struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_root_ca_key_usage_must_be_critical",
-		Description:   "Root CA certificates MUST have Key Usage Extension marked critical",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewRootCAKeyUsageMustBeCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_root_ca_key_usage_must_be_critical",
+			Description:   "Root CA certificates MUST have Key Usage Extension marked critical",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewRootCAKeyUsageMustBeCritical,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_root_ca_key_usage_present.go
+++ b/v3/lints/cabf_br/lint_root_ca_key_usage_present.go
@@ -23,13 +23,15 @@ import (
 type rootCAKeyUsagePresent struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_root_ca_key_usage_present",
-		Description:   "Root CA certificates MUST have Key Usage Extension Present",
-		Citation:      "BRs: 7.1.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewRootCAKeyUsagePresent,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_root_ca_key_usage_present",
+			Description:   "Root CA certificates MUST have Key Usage Extension Present",
+			Citation:      "BRs: 7.1.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewRootCAKeyUsagePresent,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_rsa_mod_factors_smaller_than_752_bits.go
+++ b/v3/lints/cabf_br/lint_rsa_mod_factors_smaller_than_752_bits.go
@@ -30,13 +30,15 @@ RSA: The CA SHALL confirm that the value of the public exponent is an odd number
 **************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_rsa_mod_factors_smaller_than_752",
-		Description:   "RSA: Modulus SHOULD also have the following characteristics: no factors smaller than 752",
-		Citation:      "BRs: 6.1.6",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV113Date,
-		Lint:          NewRsaModSmallFactor,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_rsa_mod_factors_smaller_than_752",
+			Description:   "RSA: Modulus SHOULD also have the following characteristics: no factors smaller than 752",
+			Citation:      "BRs: 6.1.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV113Date,
+		},
+		Lint: NewRsaModSmallFactor,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_rsa_mod_less_than_2048_bits.go
+++ b/v3/lints/cabf_br/lint_rsa_mod_less_than_2048_bits.go
@@ -25,13 +25,15 @@ import (
 type rsaParsedTestsKeySize struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rsa_mod_less_than_2048_bits",
-		Description:   "For certificates valid after 31 Dec 2013, all certificates using RSA public key algorithm MUST have 2048 bits of modulus",
-		Citation:      "BRs: 6.1.5",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewRsaParsedTestsKeySize,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rsa_mod_less_than_2048_bits",
+			Description:   "For certificates valid after 31 Dec 2013, all certificates using RSA public key algorithm MUST have 2048 bits of modulus",
+			Citation:      "BRs: 6.1.5",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewRsaParsedTestsKeySize,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_rsa_mod_not_odd.go
+++ b/v3/lints/cabf_br/lint_rsa_mod_not_odd.go
@@ -31,13 +31,15 @@ RSA: The CA SHALL confirm that the value of the public exponent is an odd number
 *******************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_rsa_mod_not_odd",
-		Description:   "RSA: Modulus SHOULD also have the following characteristics: an odd number",
-		Citation:      "BRs: 6.1.6",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV113Date,
-		Lint:          NewRsaParsedTestsKeyModOdd,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_rsa_mod_not_odd",
+			Description:   "RSA: Modulus SHOULD also have the following characteristics: an odd number",
+			Citation:      "BRs: 6.1.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV113Date,
+		},
+		Lint: NewRsaParsedTestsKeyModOdd,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_rsa_public_exponent_not_in_range.go
+++ b/v3/lints/cabf_br/lint_rsa_public_exponent_not_in_range.go
@@ -33,13 +33,15 @@ RSA: The CA SHALL confirm that the value of the public exponent is an odd number
 *******************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_rsa_public_exponent_not_in_range",
-		Description:   "RSA: Public exponent SHOULD be in the range between 2^16 + 1 and 2^256 - 1",
-		Citation:      "BRs: 6.1.6",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV113Date,
-		Lint:          NewRsaParsedTestsExpInRange,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_rsa_public_exponent_not_in_range",
+			Description:   "RSA: Public exponent SHOULD be in the range between 2^16 + 1 and 2^256 - 1",
+			Citation:      "BRs: 6.1.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV113Date,
+		},
+		Lint: NewRsaParsedTestsExpInRange,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_rsa_public_exponent_not_odd.go
+++ b/v3/lints/cabf_br/lint_rsa_public_exponent_not_odd.go
@@ -30,13 +30,15 @@ RSA: The CA SHALL confirm that the value of the public exponent is an odd number
 *******************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rsa_public_exponent_not_odd",
-		Description:   "RSA: Value of public exponent is an odd number equal to 3 or more.",
-		Citation:      "BRs: 6.1.6",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV113Date,
-		Lint:          NewRsaParsedTestsKeyExpOdd,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rsa_public_exponent_not_odd",
+			Description:   "RSA: Value of public exponent is an odd number equal to 3 or more.",
+			Citation:      "BRs: 6.1.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV113Date,
+		},
+		Lint: NewRsaParsedTestsKeyExpOdd,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_rsa_public_exponent_too_small.go
+++ b/v3/lints/cabf_br/lint_rsa_public_exponent_too_small.go
@@ -30,13 +30,15 @@ RSA: The CA SHALL confirm that the value of the public exponent is an odd number
 *******************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rsa_public_exponent_too_small",
-		Description:   "RSA: Value of public exponent is an odd number equal to 3 or more.",
-		Citation:      "BRs: 6.1.6",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV113Date,
-		Lint:          NewRsaParsedTestsExpBounds,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rsa_public_exponent_too_small",
+			Description:   "RSA: Value of public exponent is an odd number equal to 3 or more.",
+			Citation:      "BRs: 6.1.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV113Date,
+		},
+		Lint: NewRsaParsedTestsExpBounds,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_san_dns_name_onion_invalid.go
+++ b/v3/lints/cabf_br/lint_san_dns_name_onion_invalid.go
@@ -78,13 +78,15 @@ See also https://github.com/cabforum/documents/issues/191
 *******************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_san_dns_name_onion_invalid",
-		Description:   "certificates with a .onion subject name must be issued in accordance with the Tor address/rendezvous specification",
-		Citation:      "RFC 7686, EVGs v1.7.2: Appendix F, BRs v1.6.9: Appendix C",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.OnionOnlyEVDate,
-		Lint:          NewOnionNotValid,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_san_dns_name_onion_invalid",
+			Description:   "certificates with a .onion subject name must be issued in accordance with the Tor address/rendezvous specification",
+			Citation:      "RFC 7686, EVGs v1.7.2: Appendix F, BRs v1.6.9: Appendix C",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.OnionOnlyEVDate,
+		},
+		Lint: NewOnionNotValid,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_san_dns_name_onion_not_ev_cert.go
+++ b/v3/lints/cabf_br/lint_san_dns_name_onion_not_ev_cert.go
@@ -25,13 +25,15 @@ import (
 type onionNotEV struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_san_dns_name_onion_not_ev_cert",
-		Description:   "certificates with a .onion subject name must be issued in accordance with EV Guidelines",
-		Citation:      "CABF Ballot 144",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.OnionOnlyEVDate,
-		Lint:          NewOnionNotEV,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_san_dns_name_onion_not_ev_cert",
+			Description:   "certificates with a .onion subject name must be issued in accordance with EV Guidelines",
+			Citation:      "CABF Ballot 144",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.OnionOnlyEVDate,
+		},
+		Lint: NewOnionNotEV,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_signature_algorithm_not_supported.go
+++ b/v3/lints/cabf_br/lint_signature_algorithm_not_supported.go
@@ -55,13 +55,15 @@ var (
 type signatureAlgorithmNotSupported struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_signature_algorithm_not_supported",
-		Description:   "Certificates MUST meet the following requirements for algorithm Source: SHA-1*, SHA-256, SHA-384, SHA-512",
-		Citation:      "BRs: 6.1.5",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSignatureAlgorithmNotSupported,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_signature_algorithm_not_supported",
+			Description:   "Certificates MUST meet the following requirements for algorithm Source: SHA-1*, SHA-256, SHA-384, SHA-512",
+			Citation:      "BRs: 6.1.5",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSignatureAlgorithmNotSupported,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
+++ b/v3/lints/cabf_br/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
@@ -33,13 +33,15 @@ It SHOULD contain the HTTP URL of the Issuing CA’s certificate (accessMethod =
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_sub_ca_aia_does_not_contain_issuing_ca_url",
-		Description:   "Subordinate CA Certificate: authorityInformationAccess SHOULD also contain the HTTP URL of the Issuing CA's certificate.",
-		Citation:      "BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCaIssuerUrl,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_sub_ca_aia_does_not_contain_issuing_ca_url",
+			Description:   "Subordinate CA Certificate: authorityInformationAccess SHOULD also contain the HTTP URL of the Issuing CA's certificate.",
+			Citation:      "BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCaIssuerUrl,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_ca_aia_marked_critical.go
+++ b/v3/lints/cabf_br/lint_sub_ca_aia_marked_critical.go
@@ -23,13 +23,15 @@ import (
 type subCaAIAMarkedCritical struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_ca_aia_marked_critical",
-		Description:   "Subordinate CA Certificate: authorityInformationAccess MUST NOT be marked critical",
-		Citation:      "BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSubCaAIAMarkedCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_ca_aia_marked_critical",
+			Description:   "Subordinate CA Certificate: authorityInformationAccess MUST NOT be marked critical",
+			Citation:      "BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSubCaAIAMarkedCritical,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_ca_certificate_policies_marked_critical.go
+++ b/v3/lints/cabf_br/lint_sub_ca_certificate_policies_marked_critical.go
@@ -28,13 +28,15 @@ This extension MUST be present and SHOULD NOT be marked critical.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_sub_ca_certificate_policies_marked_critical",
-		Description:   "Subordinate CA certificates certificatePolicies extension should not be marked as critical",
-		Citation:      "BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCACertPolicyCrit,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_sub_ca_certificate_policies_marked_critical",
+			Description:   "Subordinate CA certificates certificatePolicies extension should not be marked as critical",
+			Citation:      "BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCACertPolicyCrit,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_ca_certificate_policies_missing.go
+++ b/v3/lints/cabf_br/lint_sub_ca_certificate_policies_missing.go
@@ -28,13 +28,15 @@ This extension MUST be present and SHOULD NOT be marked critical.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_ca_certificate_policies_missing",
-		Description:   "Subordinate CA certificates must have a certificatePolicies extension",
-		Citation:      "BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCACertPolicyMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_ca_certificate_policies_missing",
+			Description:   "Subordinate CA certificates must have a certificatePolicies extension",
+			Citation:      "BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCACertPolicyMissing,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
+++ b/v3/lints/cabf_br/lint_sub_ca_crl_distribution_points_does_not_contain_url.go
@@ -31,13 +31,15 @@ It MUST contain the HTTP URL of the CA’s CRL service.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_ca_crl_distribution_points_does_not_contain_url",
-		Description:   "Subordinate CA Certificate: cRLDistributionPoints MUST contain the HTTP URL of the CA's CRL service.",
-		Citation:      "BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCACRLDistNoUrl,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_ca_crl_distribution_points_does_not_contain_url",
+			Description:   "Subordinate CA Certificate: cRLDistributionPoints MUST contain the HTTP URL of the CA's CRL service.",
+			Citation:      "BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCACRLDistNoUrl,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_ca_crl_distribution_points_marked_critical.go
+++ b/v3/lints/cabf_br/lint_sub_ca_crl_distribution_points_marked_critical.go
@@ -29,13 +29,15 @@ It MUST contain the HTTP URL of the CA’s CRL service.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_ca_crl_distribution_points_marked_critical",
-		Description:   "Subordinate CA Certificate: cRLDistributionPoints MUST be present and MUST NOT be marked critical.",
-		Citation:      "BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCACRLDistCrit,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_ca_crl_distribution_points_marked_critical",
+			Description:   "Subordinate CA Certificate: cRLDistributionPoints MUST be present and MUST NOT be marked critical.",
+			Citation:      "BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCACRLDistCrit,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_ca_crl_distribution_points_missing.go
+++ b/v3/lints/cabf_br/lint_sub_ca_crl_distribution_points_missing.go
@@ -29,13 +29,15 @@ It MUST contain the HTTP URL of the CA’s CRL service.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_ca_crl_distribution_points_missing",
-		Description:   "Subordinate CA Certificate: cRLDistributionPoints MUST be present and MUST NOT be marked critical.",
-		Citation:      "BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCACRLDistMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_ca_crl_distribution_points_missing",
+			Description:   "Subordinate CA Certificate: cRLDistributionPoints MUST be present and MUST NOT be marked critical.",
+			Citation:      "BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCACRLDistMissing,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_ca_eku_critical.go
+++ b/v3/lints/cabf_br/lint_sub_ca_eku_critical.go
@@ -31,13 +31,15 @@ If present, this extension SHOULD be marked non‐critical.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_sub_ca_eku_critical",
-		Description:   "Subordinate CA certificate extkeyUsage extension should be marked non-critical if present",
-		Citation:      "BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV116Date,
-		Lint:          NewSubCAEKUCrit,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_sub_ca_eku_critical",
+			Description:   "Subordinate CA certificate extkeyUsage extension should be marked non-critical if present",
+			Citation:      "BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV116Date,
+		},
+		Lint: NewSubCAEKUCrit,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_ca_eku_missing.go
+++ b/v3/lints/cabf_br/lint_sub_ca_eku_missing.go
@@ -23,13 +23,15 @@ import (
 type subCAEKUMissing struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "n_sub_ca_eku_missing",
-		Description:   "To be considered Technically Constrained, the Subordinate CA certificate MUST have extkeyUsage extension",
-		Citation:      "BRs: 7.1.5",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCAEKUMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "n_sub_ca_eku_missing",
+			Description:   "To be considered Technically Constrained, the Subordinate CA certificate MUST have extkeyUsage extension",
+			Citation:      "BRs: 7.1.5",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCAEKUMissing,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_ca_eku_valid_fields.go
+++ b/v3/lints/cabf_br/lint_sub_ca_eku_valid_fields.go
@@ -23,13 +23,15 @@ import (
 type subCAEKUValidFields struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "n_sub_ca_eku_not_technically_constrained",
-		Description:   "Subordinate CA extkeyUsage, either id-kp-serverAuth or id-kp-clientAuth or both values MUST be present to be technically constrained.",
-		Citation:      "BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV116Date,
-		Lint:          NewSubCAEKUValidFields,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "n_sub_ca_eku_not_technically_constrained",
+			Description:   "Subordinate CA extkeyUsage, either id-kp-serverAuth or id-kp-clientAuth or both values MUST be present to be technically constrained.",
+			Citation:      "BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV116Date,
+		},
+		Lint: NewSubCAEKUValidFields,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_ca_name_constraints_not_critical.go
+++ b/v3/lints/cabf_br/lint_sub_ca_name_constraints_not_critical.go
@@ -34,13 +34,15 @@ substantial portion of Relying Parties worldwide
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_sub_ca_name_constraints_not_critical",
-		Description:   "Subordinate CA Certificate: NameConstraints if present, SHOULD be marked critical.",
-		Citation:      "BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABV102Date,
-		Lint:          NewSubCANameConstraintsNotCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_sub_ca_name_constraints_not_critical",
+			Description:   "Subordinate CA Certificate: NameConstraints if present, SHOULD be marked critical.",
+			Citation:      "BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABV102Date,
+		},
+		Lint: NewSubCANameConstraintsNotCritical,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_aia_contains_internal_names.go
+++ b/v3/lints/cabf_br/lint_sub_cert_aia_contains_internal_names.go
@@ -36,13 +36,15 @@ id-ad-caIssuers   A HTTP URL of the Issuing CA's Certificate.
 *************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_sub_cert_aia_contains_internal_names",
-		Description:   "Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the issuing CA’s certificate, for public certificates this should not be an internal name",
-		Citation:      "BRs: 7.1.2.10.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCertAIAInternalName,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_sub_cert_aia_contains_internal_names",
+			Description:   "Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the issuing CA’s certificate, for public certificates this should not be an internal name",
+			Citation:      "BRs: 7.1.2.10.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCertAIAInternalName,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
+++ b/v3/lints/cabf_br/lint_sub_cert_aia_does_not_contain_issuing_ca_url.go
@@ -32,13 +32,15 @@ HTTP URL of the CA’s CRL service.
 *************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_sub_cert_aia_does_not_contain_issuing_ca_url",
-		Description:   "Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the issuing CA’s certificate",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCertIssuerUrl,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_sub_cert_aia_does_not_contain_issuing_ca_url",
+			Description:   "Subscriber certificates authorityInformationAccess extension should contain the HTTP URL of the issuing CA’s certificate",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCertIssuerUrl,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_aia_does_not_contain_ocsp_url.go
+++ b/v3/lints/cabf_br/lint_sub_cert_aia_does_not_contain_ocsp_url.go
@@ -34,13 +34,15 @@ It SHOULD also contain the HTTP URL of the Issuing CA’s certificate (accessMet
 ***************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_aia_does_not_contain_ocsp_url",
-		Description:   "Subscriber Certificate: authorityInformationAccess MUST contain the HTTP URL of the Issuing CA's OSCP responder.",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCertOcspUrl,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_aia_does_not_contain_ocsp_url",
+			Description:   "Subscriber Certificate: authorityInformationAccess MUST contain the HTTP URL of the Issuing CA's OSCP responder.",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCertOcspUrl,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_aia_marked_critical.go
+++ b/v3/lints/cabf_br/lint_sub_cert_aia_marked_critical.go
@@ -23,13 +23,15 @@ import (
 type subCertAiaMarkedCritical struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_aia_marked_critical",
-		Description:   "Subscriber Certificate: authorityInformationAccess MUST NOT be marked critical",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCertAiaMarkedCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_aia_marked_critical",
+			Description:   "Subscriber Certificate: authorityInformationAccess MUST NOT be marked critical",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCertAiaMarkedCritical,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_aia_missing.go
+++ b/v3/lints/cabf_br/lint_sub_cert_aia_missing.go
@@ -32,13 +32,15 @@ marked critical, and it MUST contain the HTTP URL of the Issuing CA’s OCSP res
 ***************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_aia_missing",
-		Description:   "Subscriber Certificate: authorityInformationAccess MUST be present.",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCertAiaMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_aia_missing",
+			Description:   "Subscriber Certificate: authorityInformationAccess MUST be present.",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCertAiaMissing,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_basic_constraints_not_critical.go
+++ b/v3/lints/cabf_br/lint_sub_cert_basic_constraints_not_critical.go
@@ -33,13 +33,15 @@ CA/Browser Forum BRs: 7.1.2.7.6 Subscriber Certificate Extensions
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_basic_constraints_not_critical",
-		Description:   "basicConstraints MAY appear in the certificate, and when it is included MUST be marked as critical",
-		Citation:      "CA/Browser Forum BRs: 7.1.2.7.6",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.SC62EffectiveDate,
-		Lint:          NewSubCertBasicConstCrit,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_basic_constraints_not_critical",
+			Description:   "basicConstraints MAY appear in the certificate, and when it is included MUST be marked as critical",
+			Citation:      "CA/Browser Forum BRs: 7.1.2.7.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.SC62EffectiveDate,
+		},
+		Lint: NewSubCertBasicConstCrit,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_cert_policy_empty.go
+++ b/v3/lints/cabf_br/lint_sub_cert_cert_policy_empty.go
@@ -23,13 +23,15 @@ import (
 type subCertPolicyEmpty struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_cert_policy_empty",
-		Description:   "Subscriber certificates must contain at least one policy identifier that indicates adherence to CAB standards",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCertPolicyEmpty,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_cert_policy_empty",
+			Description:   "Subscriber certificates must contain at least one policy identifier that indicates adherence to CAB standards",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCertPolicyEmpty,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_certificate_policies_marked_critical.go
+++ b/v3/lints/cabf_br/lint_sub_cert_certificate_policies_marked_critical.go
@@ -29,13 +29,15 @@ This extension MUST be present and SHOULD NOT be marked critical.
 ******************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_sub_cert_certificate_policies_marked_critical",
-		Description:   "Subscriber Certificate: certificatePolicies MUST be present and SHOULD NOT be marked critical.",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCertPolicyCrit,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_sub_cert_certificate_policies_marked_critical",
+			Description:   "Subscriber Certificate: certificatePolicies MUST be present and SHOULD NOT be marked critical.",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCertPolicyCrit,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_certificate_policies_missing.go
+++ b/v3/lints/cabf_br/lint_sub_cert_certificate_policies_missing.go
@@ -29,13 +29,15 @@ This extension MUST be present and SHOULD NOT be marked critical.
 ******************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_certificate_policies_missing",
-		Description:   "Subscriber Certificate: certificatePolicies MUST be present and SHOULD NOT be marked critical.",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCertPolicy,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_certificate_policies_missing",
+			Description:   "Subscriber Certificate: certificatePolicies MUST be present and SHOULD NOT be marked critical.",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCertPolicy,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_country_name_must_appear.go
+++ b/v3/lints/cabf_br/lint_sub_cert_country_name_must_appear.go
@@ -23,13 +23,15 @@ import (
 type subCertCountryNameMustAppear struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_country_name_must_appear",
-		Description:   "Subscriber Certificate: subject:countryName MUST appear if the subject:organizationName field, subject:givenName field, or subject:surname fields are present.",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABGivenNameDate,
-		Lint:          NewSubCertCountryNameMustAppear,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_country_name_must_appear",
+			Description:   "Subscriber Certificate: subject:countryName MUST appear if the subject:organizationName field, subject:givenName field, or subject:surname fields are present.",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABGivenNameDate,
+		},
+		Lint: NewSubCertCountryNameMustAppear,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
+++ b/v3/lints/cabf_br/lint_sub_cert_crl_distribution_points_does_not_contain_url.go
@@ -32,13 +32,15 @@ URL of the CA’s CRL service.
 *******************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_crl_distribution_points_does_not_contain_url",
-		Description:   "Subscriber certificate cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCRLDistNoURL,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_crl_distribution_points_does_not_contain_url",
+			Description:   "Subscriber certificate cRLDistributionPoints extension must contain the HTTP URL of the CA’s CRL service",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCRLDistNoURL,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_crl_distribution_points_marked_critical.go
+++ b/v3/lints/cabf_br/lint_sub_cert_crl_distribution_points_marked_critical.go
@@ -30,13 +30,15 @@ URL of the CA’s CRL service.
 *******************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_crl_distribution_points_marked_critical",
-		Description:   "Subscriber Certificate: cRLDistributionPoints MUST NOT be marked critical, and MUST contain the HTTP URL of the CA's CRL service.",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCrlDistCrit,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_crl_distribution_points_marked_critical",
+			Description:   "Subscriber Certificate: cRLDistributionPoints MUST NOT be marked critical, and MUST contain the HTTP URL of the CA's CRL service.",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCrlDistCrit,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_eku_extra_values.go
+++ b/v3/lints/cabf_br/lint_sub_cert_eku_extra_values.go
@@ -32,13 +32,15 @@ present.
 *******************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_sub_cert_eku_extra_values",
-		Description:   "Subscriber Certificate: extKeyUsage values other than id-kp-serverAuth, id-kp-clientAuth, and id-kp-emailProtection SHOULD NOT be present.",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubExtKeyUsageLegalUsage,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_sub_cert_eku_extra_values",
+			Description:   "Subscriber Certificate: extKeyUsage values other than id-kp-serverAuth, id-kp-clientAuth, and id-kp-emailProtection SHOULD NOT be present.",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubExtKeyUsageLegalUsage,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_eku_missing.go
+++ b/v3/lints/cabf_br/lint_sub_cert_eku_missing.go
@@ -31,13 +31,15 @@ present.
 *******************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_eku_missing",
-		Description:   "Subscriber certificates MUST have the extended key usage extension present",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubExtKeyUsage,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_eku_missing",
+			Description:   "Subscriber certificates MUST have the extended key usage extension present",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubExtKeyUsage,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_eku_server_auth_client_auth_missing.go
+++ b/v3/lints/cabf_br/lint_sub_cert_eku_server_auth_client_auth_missing.go
@@ -32,13 +32,15 @@ present.
 *******************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_eku_server_auth_client_auth_missing",
-		Description:   "Subscriber certificates MUST have either id-kp-serverAuth or id-kp-clientAuth or both present in extKeyUsage",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubExtKeyUsageClientOrServer,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_eku_server_auth_client_auth_missing",
+			Description:   "Subscriber certificates MUST have either id-kp-serverAuth or id-kp-clientAuth or both present in extKeyUsage",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubExtKeyUsageClientOrServer,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_gn_sn_contains_policy.go
+++ b/v3/lints/cabf_br/lint_sub_cert_gn_sn_contains_policy.go
@@ -23,13 +23,15 @@ import (
 type subCertSubjectGnOrSnContainsPolicy struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_given_name_surname_contains_correct_policy",
-		Description:   "Subscriber Certificate: A certificate containing a subject:givenName field or subject:surname field MUST contain the (2.23.140.1.2.3) certPolicy OID.",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABGivenNameDate,
-		Lint:          NewSubCertSubjectGnOrSnContainsPolicy,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_given_name_surname_contains_correct_policy",
+			Description:   "Subscriber Certificate: A certificate containing a subject:givenName field or subject:surname field MUST contain the (2.23.140.1.2.3) certPolicy OID.",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABGivenNameDate,
+		},
+		Lint: NewSubCertSubjectGnOrSnContainsPolicy,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_is_ca.go
+++ b/v3/lints/cabf_br/lint_sub_cert_is_ca.go
@@ -24,13 +24,15 @@ import (
 type subCertNotCA struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_not_is_ca",
-		Description:   "Subscriber Certificate: basicContrainsts cA field MUST NOT be true.",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCertNotCA,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_not_is_ca",
+			Description:   "Subscriber Certificate: basicContrainsts cA field MUST NOT be true.",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCertNotCA,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_key_usage_cert_sign_bit_set.go
+++ b/v3/lints/cabf_br/lint_sub_cert_key_usage_cert_sign_bit_set.go
@@ -29,13 +29,15 @@ If present, bit positions for keyCertSign and cRLSign MUST NOT be set.
 ***************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_key_usage_cert_sign_bit_set",
-		Description:   "Subscriber Certificate: keyUsage if present, bit positions for keyCertSign and cRLSign MUST NOT be set.",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCertKeyUsageBitSet,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_key_usage_cert_sign_bit_set",
+			Description:   "Subscriber Certificate: keyUsage if present, bit positions for keyCertSign and cRLSign MUST NOT be set.",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCertKeyUsageBitSet,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_key_usage_crl_sign_bit_set.go
+++ b/v3/lints/cabf_br/lint_sub_cert_key_usage_crl_sign_bit_set.go
@@ -29,13 +29,15 @@ If present, bit positions for keyCertSign and cRLSign MUST NOT be set.
 ***************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_key_usage_crl_sign_bit_set",
-		Description:   "Subscriber Certificate: keyUsage if present, bit positions for keyCertSign and cRLSign MUST NOT be set.",
-		Citation:      "BRs: 7.1.2.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubCrlSignAllowed,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_key_usage_crl_sign_bit_set",
+			Description:   "Subscriber Certificate: keyUsage if present, bit positions for keyCertSign and cRLSign MUST NOT be set.",
+			Citation:      "BRs: 7.1.2.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubCrlSignAllowed,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_locality_name_must_appear.go
+++ b/v3/lints/cabf_br/lint_sub_cert_locality_name_must_appear.go
@@ -23,13 +23,15 @@ import (
 type subCertLocalityNameMustAppear struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_locality_name_must_appear",
-		Description:   "Subscriber Certificate: subject:localityName MUST appear if subject:organizationName, subject:givenName, or subject:surname fields are present but the subject:stateOrProvinceName field is absent.",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABGivenNameDate,
-		Lint:          NewSubCertLocalityNameMustAppear,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_locality_name_must_appear",
+			Description:   "Subscriber Certificate: subject:localityName MUST appear if subject:organizationName, subject:givenName, or subject:surname fields are present but the subject:stateOrProvinceName field is absent.",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABGivenNameDate,
+		},
+		Lint: NewSubCertLocalityNameMustAppear,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_locality_name_must_not_appear.go
+++ b/v3/lints/cabf_br/lint_sub_cert_locality_name_must_not_appear.go
@@ -23,13 +23,15 @@ import (
 type subCertLocalityNameMustNotAppear struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_locality_name_must_not_appear",
-		Description:   "Subscriber Certificate: subject:localityName MUST NOT appear if subject:organizationName, subject:givenName, and subject:surname fields are absent.",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABGivenNameDate,
-		Lint:          NewSubCertLocalityNameMustNotAppear,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_locality_name_must_not_appear",
+			Description:   "Subscriber Certificate: subject:localityName MUST NOT appear if subject:organizationName, subject:givenName, and subject:surname fields are absent.",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABGivenNameDate,
+		},
+		Lint: NewSubCertLocalityNameMustNotAppear,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_or_sub_ca_using_sha1.go
+++ b/v3/lints/cabf_br/lint_sub_cert_or_sub_ca_using_sha1.go
@@ -28,13 +28,15 @@ SHA‐1 MAY be used with RSA keys in accordance with the criteria defined in Sec
 **************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_or_sub_ca_using_sha1",
-		Description:   "CAs MUST NOT issue any new Subscriber certificates or Subordinate CA certificates using SHA-1 after 1 January 2016",
-		Citation:      "BRs: 7.1.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.NO_SHA1,
-		Lint:          NewSigAlgTestsSHA1,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_or_sub_ca_using_sha1",
+			Description:   "CAs MUST NOT issue any new Subscriber certificates or Subordinate CA certificates using SHA-1 after 1 January 2016",
+			Citation:      "BRs: 7.1.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.NO_SHA1,
+		},
+		Lint: NewSigAlgTestsSHA1,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_postal_code_prohibited.go
+++ b/v3/lints/cabf_br/lint_sub_cert_postal_code_prohibited.go
@@ -23,13 +23,15 @@ import (
 type subCertPostalCodeMustNotAppear struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_postal_code_must_not_appear",
-		Description:   "Subscriber Certificate: subject:postalCode MUST NOT appear if the subject:organizationName field, subject:givenName field, or subject:surname fields are absent.",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABGivenNameDate,
-		Lint:          NewSubCertPostalCodeMustNotAppear,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_postal_code_must_not_appear",
+			Description:   "Subscriber Certificate: subject:postalCode MUST NOT appear if the subject:organizationName field, subject:givenName field, or subject:surname fields are absent.",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABGivenNameDate,
+		},
+		Lint: NewSubCertPostalCodeMustNotAppear,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_province_must_appear.go
+++ b/v3/lints/cabf_br/lint_sub_cert_province_must_appear.go
@@ -23,13 +23,15 @@ import (
 type subCertProvinceMustAppear struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_province_must_appear",
-		Description:   "Subscriber Certificate: subject:stateOrProvinceName MUST appear if the subject:organizationName, subject:givenName, or subject:surname fields are present and subject:localityName is absent.",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABGivenNameDate,
-		Lint:          NewSubCertProvinceMustAppear,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_province_must_appear",
+			Description:   "Subscriber Certificate: subject:stateOrProvinceName MUST appear if the subject:organizationName, subject:givenName, or subject:surname fields are present and subject:localityName is absent.",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABGivenNameDate,
+		},
+		Lint: NewSubCertProvinceMustAppear,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_province_must_not_appear.go
+++ b/v3/lints/cabf_br/lint_sub_cert_province_must_not_appear.go
@@ -23,13 +23,15 @@ import (
 type subCertProvinceMustNotAppear struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_province_must_not_appear",
-		Description:   "Subscriber Certificate: subject:stateOrProvinceName MUST NOT appear if the subject:organizationName, subject:givenName, and subject:surname fields are absent.",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABGivenNameDate,
-		Lint:          NewSubCertProvinceMustNotAppear,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_province_must_not_appear",
+			Description:   "Subscriber Certificate: subject:stateOrProvinceName MUST NOT appear if the subject:organizationName, subject:givenName, and subject:surname fields are absent.",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABGivenNameDate,
+		},
+		Lint: NewSubCertProvinceMustNotAppear,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_sha1_expiration_too_long.go
+++ b/v3/lints/cabf_br/lint_sub_cert_sha1_expiration_too_long.go
@@ -32,13 +32,15 @@ CAs and Subscribers using such certificates do so at their own risk.
 ****************************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_sub_cert_sha1_expiration_too_long",
-		Description:   "Subscriber certificates using the SHA-1 algorithm SHOULD NOT have an expiration date later than 1 Jan 2017",
-		Citation:      "BRs: 7.1.3",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABFBRs_1_2_1_Date,
-		Lint:          NewSha1ExpireLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_sub_cert_sha1_expiration_too_long",
+			Description:   "Subscriber certificates using the SHA-1 algorithm SHOULD NOT have an expiration date later than 1 Jan 2017",
+			Citation:      "BRs: 7.1.3",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABFBRs_1_2_1_Date,
+		},
+		Lint: NewSha1ExpireLong,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_street_address_should_not_exist.go
+++ b/v3/lints/cabf_br/lint_sub_cert_street_address_should_not_exist.go
@@ -23,13 +23,15 @@ import (
 type subCertStreetAddressShouldNotExist struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_street_address_should_not_exist",
-		Description:   "Subscriber Certificate: subject:streetAddress MUST NOT appear if subject:organizationName, subject:givenName, and subject:surname fields are absent.",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABGivenNameDate,
-		Lint:          NewSubCertStreetAddressShouldNotExist,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_street_address_should_not_exist",
+			Description:   "Subscriber Certificate: subject:streetAddress MUST NOT appear if subject:organizationName, subject:givenName, and subject:surname fields are absent.",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABGivenNameDate,
+		},
+		Lint: NewSubCertStreetAddressShouldNotExist,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_valid_time_longer_than_39_months.go
+++ b/v3/lints/cabf_br/lint_sub_cert_valid_time_longer_than_39_months.go
@@ -23,13 +23,15 @@ import (
 type subCertValidTimeLongerThan39Months struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_valid_time_longer_than_39_months",
-		Description:   "Subscriber Certificates issued after 1 July 2016 but prior to 1 March 2018 MUST have a Validity Period no greater than 39 months.",
-		Citation:      "BRs: 6.3.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.SubCert39Month,
-		Lint:          NewSubCertValidTimeLongerThan39Months,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_valid_time_longer_than_39_months",
+			Description:   "Subscriber Certificates issued after 1 July 2016 but prior to 1 March 2018 MUST have a Validity Period no greater than 39 months.",
+			Citation:      "BRs: 6.3.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.SubCert39Month,
+		},
+		Lint: NewSubCertValidTimeLongerThan39Months,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_sub_cert_valid_time_longer_than_825_days.go
+++ b/v3/lints/cabf_br/lint_sub_cert_valid_time_longer_than_825_days.go
@@ -23,13 +23,15 @@ import (
 type subCertValidTimeLongerThan825Days struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_sub_cert_valid_time_longer_than_825_days",
-		Description:   "Subscriber Certificates issued after 1 March 2018, but prior to 1 September 2020, MUST NOT have a Validity Period greater than 825 days.",
-		Citation:      "BRs: 6.3.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.SubCert825Days,
-		Lint:          NewSubCertValidTimeLongerThan825Days,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_sub_cert_valid_time_longer_than_825_days",
+			Description:   "Subscriber Certificates issued after 1 March 2018, but prior to 1 September 2020, MUST NOT have a Validity Period greater than 825 days.",
+			Citation:      "BRs: 6.3.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.SubCert825Days,
+		},
+		Lint: NewSubCertValidTimeLongerThan825Days,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_subject_common_name_included.go
+++ b/v3/lints/cabf_br/lint_subject_common_name_included.go
@@ -28,14 +28,16 @@ Required/Optional: Deprecated (Discouraged, but not prohibited)
 ***************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:            "n_subject_common_name_included",
-		Description:     "Subscriber Certificate: commonName is deprecated.",
-		Citation:        "BRs: 7.1.4.2.2",
-		Source:          lint.CABFBaselineRequirements,
-		EffectiveDate:   util.CABEffectiveDate,
-		IneffectiveDate: util.SC62EffectiveDate,
-		Lint:            NewCommonNames,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:            "n_subject_common_name_included",
+			Description:     "Subscriber Certificate: commonName is deprecated.",
+			Citation:        "BRs: 7.1.4.2.2",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.SC62EffectiveDate,
+		},
+		Lint: NewCommonNames,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_subject_common_name_included_sc62.go
+++ b/v3/lints/cabf_br/lint_subject_common_name_included_sc62.go
@@ -28,13 +28,15 @@ Required/Optional: NOT RECOMMENDED
 ***************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_subject_common_name_included",
-		Description:   "Subscriber Certificate: commonName is NOT RECOMMENDED.",
-		Citation:      "BRs: 7.1.2.7.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.SC62EffectiveDate,
-		Lint:          NewCommonNamesSC62,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_subject_common_name_included",
+			Description:   "Subscriber Certificate: commonName is NOT RECOMMENDED.",
+			Citation:      "BRs: 7.1.2.7.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.SC62EffectiveDate,
+		},
+		Lint: NewCommonNamesSC62,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_subject_common_name_not_exactly_from_san.go
+++ b/v3/lints/cabf_br/lint_subject_common_name_not_exactly_from_san.go
@@ -34,13 +34,15 @@ the subjectAltName extension.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_common_name_not_exactly_from_san",
-		Description:   "The common name field in subscriber certificates must include only names from the SAN extension",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABFBRs_1_8_0_Date,
-		Lint:          NewSubjectCommonNameNotExactlyFromSAN,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_common_name_not_exactly_from_san",
+			Description:   "The common name field in subscriber certificates must include only names from the SAN extension",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABFBRs_1_8_0_Date,
+		},
+		Lint: NewSubjectCommonNameNotExactlyFromSAN,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_subject_common_name_not_from_san.go
+++ b/v3/lints/cabf_br/lint_subject_common_name_not_from_san.go
@@ -32,14 +32,16 @@ contained in the Certificate’s subjectAltName extension (see Section 7.1.4.2.1
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:            "e_subject_common_name_not_from_san",
-		Description:     "The common name field in subscriber certificates must include only names from the SAN extension",
-		Citation:        "BRs: 7.1.4.2.2",
-		Source:          lint.CABFBaselineRequirements,
-		EffectiveDate:   util.CABEffectiveDate,
-		IneffectiveDate: util.CABFBRs_1_8_0_Date,
-		Lint:            NewSubjectCommonNameNotFromSAN,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:            "e_subject_common_name_not_from_san",
+			Description:     "The common name field in subscriber certificates must include only names from the SAN extension",
+			Citation:        "BRs: 7.1.4.2.2",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.CABFBRs_1_8_0_Date,
+		},
+		Lint: NewSubjectCommonNameNotFromSAN,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_subject_contains_malformed_arpa_ip.go
+++ b/v3/lints/cabf_br/lint_subject_contains_malformed_arpa_ip.go
@@ -32,23 +32,25 @@ import (
 type arpaMalformedIP struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name: "w_subject_contains_malformed_arpa_ip",
-		Description: "Checks no subject domain name contains a rDNS entry in the " +
-			"registry-controlled .arpa zone with the wrong number of labels, or " +
-			"an invalid IP address (RFC 3596, BCP49)",
-		// NOTE(@cpu): 3.2.2.6 is particular to wildcard domain validation for names
-		// in a registry controlled zone (like .arpa), which would be an appropriate
-		// citation for when this lint finds a rDNS entry with the wrong
-		// number of labels/invalid IP because of the presence of a wildcard
-		// character. There is a larger on-going discussion[0] on the BRs stance on
-		// the .arpa zone entries that may produce a better citation to use here.
-		//
-		// [0]: https://github.com/cabforum/documents/issues/153
-		Citation:      "BRs: 3.2.2.6",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewArpaMalformedIP,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name: "w_subject_contains_malformed_arpa_ip",
+			Description: "Checks no subject domain name contains a rDNS entry in the " +
+				"registry-controlled .arpa zone with the wrong number of labels, or " +
+				"an invalid IP address (RFC 3596, BCP49)",
+			// NOTE(@cpu): 3.2.2.6 is particular to wildcard domain validation for names
+			// in a registry controlled zone (like .arpa), which would be an appropriate
+			// citation for when this lint finds a rDNS entry with the wrong
+			// number of labels/invalid IP because of the presence of a wildcard
+			// character. There is a larger on-going discussion[0] on the BRs stance on
+			// the .arpa zone entries that may produce a better citation to use here.
+			//
+			// [0]: https://github.com/cabforum/documents/issues/153
+			Citation:      "BRs: 3.2.2.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewArpaMalformedIP,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_subject_contains_noninformational_value.go
+++ b/v3/lints/cabf_br/lint_subject_contains_noninformational_value.go
@@ -34,13 +34,15 @@ be used.
 **********************************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_contains_noninformational_value",
-		Description:   "Subject name fields must not contain '.','-',' ' or any other indication that the field has been omitted",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewIllegalChar,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_contains_noninformational_value",
+			Description:   "Subject name fields must not contain '.','-',' ' or any other indication that the field has been omitted",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewIllegalChar,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_subject_contains_organizational_unit_name_and_no_organization_name.go
+++ b/v3/lints/cabf_br/lint_subject_contains_organizational_unit_name_and_no_organization_name.go
@@ -32,13 +32,15 @@ This lint check the first requirement, i.e.: Prohibited if the subject:organizat
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_contains_organizational_unit_name_and_no_organization_name",
-		Description:   "If a subject organization name is absent then an organizational unit name MUST NOT be included in subject",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABFBRs_1_7_9_Date,
-		Lint:          NewSubjectContainsOrganizationalUnitNameButNoOrganizationName,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_contains_organizational_unit_name_and_no_organization_name",
+			Description:   "If a subject organization name is absent then an organizational unit name MUST NOT be included in subject",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABFBRs_1_7_9_Date,
+		},
+		Lint: NewSubjectContainsOrganizationalUnitNameButNoOrganizationName,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_subject_contains_reserved_arpa_ip.go
+++ b/v3/lints/cabf_br/lint_subject_contains_reserved_arpa_ip.go
@@ -55,13 +55,15 @@ const (
 type arpaReservedIP struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_contains_reserved_arpa_ip",
-		Description:   "Checks no subject domain name contains a rDNS entry in an .arpa zone specifying a reserved IP address",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewArpaReservedIP,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_contains_reserved_arpa_ip",
+			Description:   "Checks no subject domain name contains a rDNS entry in an .arpa zone specifying a reserved IP address",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewArpaReservedIP,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_subject_contains_reserved_ip.go
+++ b/v3/lints/cabf_br/lint_subject_contains_reserved_ip.go
@@ -34,13 +34,15 @@ Address or Internal Name.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_contains_reserved_ip",
-		Description:   "Certificates expiring later than 11 Jan 2015 MUST NOT contain a reserved IP address in the common name field",
-		Citation:      "BRs: 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSubjectReservedIP,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_contains_reserved_ip",
+			Description:   "Certificates expiring later than 11 Jan 2015 MUST NOT contain a reserved IP address in the common name field",
+			Citation:      "BRs: 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSubjectReservedIP,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_subject_country_not_iso.go
+++ b/v3/lints/cabf_br/lint_subject_country_not_iso.go
@@ -33,13 +33,15 @@ place of business is located.
 **************************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_country_not_iso",
-		Description:   "The country name field MUST contain the two-letter ISO code for the country or XX",
-		Citation:      "BRs: 7.1.4.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewCountryNotIso,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_country_not_iso",
+			Description:   "The country name field MUST contain the two-letter ISO code for the country or XX",
+			Citation:      "BRs: 7.1.4.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewCountryNotIso,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_subject_public_key_info_improper_algorithm_object_identifier_encoding.go
+++ b/v3/lints/cabf_br/lint_subject_public_key_info_improper_algorithm_object_identifier_encoding.go
@@ -42,14 +42,16 @@ For P‐521 keys: 301006072a8648ce3d020106052b81040023
 ***********************************************
 */
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name: "e_algorithm_identifier_improper_encoding",
-		Description: "Encoded AlgorithmObjectIdentifier objects inside a SubjectPublicKeyInfo field " +
-			"MUST comply with specified byte sequences.",
-		Citation:      "BRs: 7.1.3.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABFBRs_1_7_1_Date,
-		Lint:          NewAlgorithmObjectIdentifierEncoding,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name: "e_algorithm_identifier_improper_encoding",
+			Description: "Encoded AlgorithmObjectIdentifier objects inside a SubjectPublicKeyInfo field " +
+				"MUST comply with specified byte sequences.",
+			Citation:      "BRs: 7.1.3.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABFBRs_1_7_1_Date,
+		},
+		Lint: NewAlgorithmObjectIdentifierEncoding,
 	})
 }
 

--- a/v3/lints/cabf_br/lint_underscore_not_permissible_in_dnsname.go
+++ b/v3/lints/cabf_br/lint_underscore_not_permissible_in_dnsname.go
@@ -25,13 +25,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_underscore_not_permissible_in_dnsname",
-		Description:   "DNSNames MUST NOT contain underscore characters",
-		Citation:      "BR 7.1.4.2.1",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABFBRs_1_6_2_UnderscorePermissibilitySunsetDate,
-		Lint:          func() lint.LintInterface { return &UnderscoreNotPermissibleInDNSName{} },
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_underscore_not_permissible_in_dnsname",
+			Description:   "DNSNames MUST NOT contain underscore characters",
+			Citation:      "BR 7.1.4.2.1",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABFBRs_1_6_2_UnderscorePermissibilitySunsetDate,
+		},
+		Lint: func() lint.LintInterface { return &UnderscoreNotPermissibleInDNSName{} },
 	})
 }
 

--- a/v3/lints/cabf_br/lint_underscore_permissible_in_dnsname_if_valid_when_replaced.go
+++ b/v3/lints/cabf_br/lint_underscore_permissible_in_dnsname_if_valid_when_replaced.go
@@ -24,14 +24,16 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:            "e_underscore_permissible_in_dnsname_if_valid_when_replaced",
-		Description:     "From December 10th 2018 to April 1st 2019 DNSNames may contain underscores if-and-only-if every label within each DNS name is a valid LDH label after replacing all underscores with hyphens",
-		Citation:        "BR 7.1.4.2.1",
-		Source:          lint.CABFBaselineRequirements,
-		EffectiveDate:   util.CABFBRs_1_6_2_Date,
-		IneffectiveDate: util.CABFBRs_1_6_2_UnderscorePermissibilitySunsetDate,
-		Lint:            func() lint.LintInterface { return &UnderscorePermissibleInDNSNameIfValidWhenReplaced{} },
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:            "e_underscore_permissible_in_dnsname_if_valid_when_replaced",
+			Description:     "From December 10th 2018 to April 1st 2019 DNSNames may contain underscores if-and-only-if every label within each DNS name is a valid LDH label after replacing all underscores with hyphens",
+			Citation:        "BR 7.1.4.2.1",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABFBRs_1_6_2_Date,
+			IneffectiveDate: util.CABFBRs_1_6_2_UnderscorePermissibilitySunsetDate,
+		},
+		Lint: func() lint.LintInterface { return &UnderscorePermissibleInDNSNameIfValidWhenReplaced{} },
 	})
 }
 

--- a/v3/lints/cabf_br/lint_underscore_present_with_too_long_validity.go
+++ b/v3/lints/cabf_br/lint_underscore_present_with_too_long_validity.go
@@ -24,14 +24,16 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:            "e_underscore_present_with_too_long_validity",
-		Description:     "From 2018-12-10 to 2019-04-01, DNSNames may contain underscores if-and-only-if the certificate is valid for less than thirty days.",
-		Citation:        "BR 7.1.4.2.1",
-		Source:          lint.CABFBaselineRequirements,
-		EffectiveDate:   util.CABFBRs_1_6_2_Date,
-		IneffectiveDate: util.CABFBRs_1_6_2_UnderscorePermissibilitySunsetDate,
-		Lint:            func() lint.LintInterface { return &UnderscorePresentWithTooLongValidity{} },
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:            "e_underscore_present_with_too_long_validity",
+			Description:     "From 2018-12-10 to 2019-04-01, DNSNames may contain underscores if-and-only-if the certificate is valid for less than thirty days.",
+			Citation:        "BR 7.1.4.2.1",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABFBRs_1_6_2_Date,
+			IneffectiveDate: util.CABFBRs_1_6_2_UnderscorePermissibilitySunsetDate,
+		},
+		Lint: func() lint.LintInterface { return &UnderscorePresentWithTooLongValidity{} },
 	})
 }
 

--- a/v3/lints/cabf_br/lint_w_sub_ca_aia_missing.go
+++ b/v3/lints/cabf_br/lint_w_sub_ca_aia_missing.go
@@ -31,13 +31,15 @@ It SHOULD contain the HTTP URL of the Issuing CA’s certificate (accessMethod =
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_sub_ca_aia_missing",
-		Description:   "Subordinate CA Certificate: authorityInformationAccess SHOULD be present.",
-		Citation:      "BRs: 7.1.2.2",
-		Source:        lint.CABFBaselineRequirements,
-		EffectiveDate: util.CABFBRs_1_7_1_Date,
-		Lint:          NewCaAiaShouldNotBeMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_sub_ca_aia_missing",
+			Description:   "Subordinate CA Certificate: authorityInformationAccess SHOULD be present.",
+			Citation:      "BRs: 7.1.2.2",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.CABFBRs_1_7_1_Date,
+		},
+		Lint: NewCaAiaShouldNotBeMissing,
 	})
 }
 

--- a/v3/lints/cabf_ev/lint_ev_business_category_missing.go
+++ b/v3/lints/cabf_ev/lint_ev_business_category_missing.go
@@ -23,13 +23,15 @@ import (
 type evNoBiz struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ev_business_category_missing",
-		Description:   "EV certificates must include businessCategory in subject",
-		Citation:      "EVGs: 9.2.3",
-		Source:        lint.CABFEVGuidelines,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewEvNoBiz,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ev_business_category_missing",
+			Description:   "EV certificates must include businessCategory in subject",
+			Citation:      "EVGs: 9.2.3",
+			Source:        lint.CABFEVGuidelines,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewEvNoBiz,
 	})
 }
 

--- a/v3/lints/cabf_ev/lint_ev_country_name_missing.go
+++ b/v3/lints/cabf_ev/lint_ev_country_name_missing.go
@@ -23,13 +23,15 @@ import (
 type evCountryMissing struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ev_country_name_missing",
-		Description:   "EV certificates must include countryName in subject",
-		Citation:      "EVGs: 9.2.4",
-		Source:        lint.CABFEVGuidelines,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewEvCountryMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ev_country_name_missing",
+			Description:   "EV certificates must include countryName in subject",
+			Citation:      "EVGs: 9.2.4",
+			Source:        lint.CABFEVGuidelines,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewEvCountryMissing,
 	})
 }
 

--- a/v3/lints/cabf_ev/lint_ev_not_wildcard.go
+++ b/v3/lints/cabf_ev/lint_ev_not_wildcard.go
@@ -24,13 +24,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ev_not_wildcard",
-		Description:   "Wildcard certificates are not allowed for EV Certificates except for those with .onion as the TLD.",
-		Citation:      "CABF EV Guidelines 1.7.8 Section 9.8.1",
-		Source:        lint.CABFEVGuidelines,
-		EffectiveDate: util.OnionOnlyEVDate,
-		Lint:          NewEvNotWildCard,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ev_not_wildcard",
+			Description:   "Wildcard certificates are not allowed for EV Certificates except for those with .onion as the TLD.",
+			Citation:      "CABF EV Guidelines 1.7.8 Section 9.8.1",
+			Source:        lint.CABFEVGuidelines,
+			EffectiveDate: util.OnionOnlyEVDate,
+		},
+		Lint: NewEvNotWildCard,
 	})
 }
 

--- a/v3/lints/cabf_ev/lint_ev_organization_id_missing.go
+++ b/v3/lints/cabf_ev/lint_ev_organization_id_missing.go
@@ -23,14 +23,16 @@ import (
 type evOrgIdExtMissing struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name: "e_ev_organization_id_missing",
-		Description: "Effective January 31, 2020, if the subject:organizationIdentifier field is " +
-			"present, this [cabfOrganizationIdentifier] field MUST be present.",
-		Citation:      "CA/Browser Forum EV Guidelines v1.7.0, Sec. 9.8.2",
-		Source:        lint.CABFEVGuidelines,
-		EffectiveDate: util.CABFEV_9_8_2,
-		Lint:          NewEvOrgIdExtMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name: "e_ev_organization_id_missing",
+			Description: "Effective January 31, 2020, if the subject:organizationIdentifier field is " +
+				"present, this [cabfOrganizationIdentifier] field MUST be present.",
+			Citation:      "CA/Browser Forum EV Guidelines v1.7.0, Sec. 9.8.2",
+			Source:        lint.CABFEVGuidelines,
+			EffectiveDate: util.CABFEV_9_8_2,
+		},
+		Lint: NewEvOrgIdExtMissing,
 	})
 }
 

--- a/v3/lints/cabf_ev/lint_ev_organization_name_missing.go
+++ b/v3/lints/cabf_ev/lint_ev_organization_name_missing.go
@@ -23,13 +23,15 @@ import (
 type evOrgMissing struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ev_organization_name_missing",
-		Description:   "EV certificates must include organizationName in subject",
-		Citation:      "EVGs: 9.2.1",
-		Source:        lint.CABFEVGuidelines,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewEvOrgMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ev_organization_name_missing",
+			Description:   "EV certificates must include organizationName in subject",
+			Citation:      "EVGs: 9.2.1",
+			Source:        lint.CABFEVGuidelines,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewEvOrgMissing,
 	})
 }
 

--- a/v3/lints/cabf_ev/lint_ev_san_ip_address_present.go
+++ b/v3/lints/cabf_ev/lint_ev_san_ip_address_present.go
@@ -21,13 +21,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ev_san_ip_address_present",
-		Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' name types.",
-		Citation:      "CABF EV Guidelines 1.7.8 Section 9.8.1",
-		Source:        lint.CABFEVGuidelines,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewEvSanIpAddressPresent,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ev_san_ip_address_present",
+			Description:   "The Subject Alternate Name extension MUST contain only 'dnsName' name types.",
+			Citation:      "CABF EV Guidelines 1.7.8 Section 9.8.1",
+			Source:        lint.CABFEVGuidelines,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewEvSanIpAddressPresent,
 	})
 }
 

--- a/v3/lints/cabf_ev/lint_ev_serial_number_missing.go
+++ b/v3/lints/cabf_ev/lint_ev_serial_number_missing.go
@@ -23,13 +23,15 @@ import (
 type evSNMissing struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ev_serial_number_missing",
-		Description:   "EV certificates must include serialNumber in subject",
-		Citation:      "EVGs: 9.2.6",
-		Source:        lint.CABFEVGuidelines,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewEvSNMissing,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ev_serial_number_missing",
+			Description:   "EV certificates must include serialNumber in subject",
+			Citation:      "EVGs: 9.2.6",
+			Source:        lint.CABFEVGuidelines,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewEvSNMissing,
 	})
 }
 

--- a/v3/lints/cabf_ev/lint_ev_valid_time_too_long.go
+++ b/v3/lints/cabf_ev/lint_ev_valid_time_too_long.go
@@ -23,13 +23,15 @@ import (
 type evValidTooLong struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ev_valid_time_too_long",
-		Description:   "EV certificates must be 27 months in validity or less",
-		Citation:      "EVGs 1.0: 8(a), EVGs 1.6.1: 9.4",
-		Source:        lint.CABFEVGuidelines,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewEvValidTooLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ev_valid_time_too_long",
+			Description:   "EV certificates must be 27 months in validity or less",
+			Citation:      "EVGs 1.0: 8(a), EVGs 1.6.1: 9.4",
+			Source:        lint.CABFEVGuidelines,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewEvValidTooLong,
 	})
 }
 

--- a/v3/lints/cabf_ev/lint_onion_subject_validity_time_too_large.go
+++ b/v3/lints/cabf_ev/lint_onion_subject_validity_time_too_large.go
@@ -33,15 +33,17 @@ const (
 type torValidityTooLarge struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name: "e_onion_subject_validity_time_too_large",
-		Description: fmt.Sprintf(
-			"certificates with .onion names can not be valid for more than %d months",
-			maxOnionValidityMonths),
-		Citation:      "EVGs: Appendix F",
-		Source:        lint.CABFEVGuidelines,
-		EffectiveDate: util.OnionOnlyEVDate,
-		Lint:          NewTorValidityTooLarge,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name: "e_onion_subject_validity_time_too_large",
+			Description: fmt.Sprintf(
+				"certificates with .onion names can not be valid for more than %d months",
+				maxOnionValidityMonths),
+			Citation:      "EVGs: Appendix F",
+			Source:        lint.CABFEVGuidelines,
+			EffectiveDate: util.OnionOnlyEVDate,
+		},
+		Lint: NewTorValidityTooLarge,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_ecpublickey_key_usages.go
+++ b/v3/lints/cabf_smime_br/lint_ecpublickey_key_usages.go
@@ -21,13 +21,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ecpublickey_key_usages",
-		Description:   "For signing only, bit positions SHALL be set for digitalSignature and MAY be set for nonRepudiation. For key management only, bit positions SHALL be set for keyEncipherment.For dual use, bit positions SHALL be set for digitalSignature and keyEncipherment and MAY be set for nonRepudiation.",
-		Citation:      "7.1.2.3.e",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          NewECPublicKeyKeyUsages,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ecpublickey_key_usages",
+			Description:   "For signing only, bit positions SHALL be set for digitalSignature and MAY be set for nonRepudiation. For key management only, bit positions SHALL be set for keyEncipherment.For dual use, bit positions SHALL be set for digitalSignature and keyEncipherment and MAY be set for nonRepudiation.",
+			Citation:      "7.1.2.3.e",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewECPublicKeyKeyUsages,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_ecpublickey_other_key_usages.go
+++ b/v3/lints/cabf_smime_br/lint_ecpublickey_other_key_usages.go
@@ -21,13 +21,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ec_other_key_usages",
-		Description:   "Other bit positions SHALL NOT be set.",
-		Citation:      "7.1.2.3.e",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          NewECOtherKeyUsages,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ec_other_key_usages",
+			Description:   "Other bit positions SHALL NOT be set.",
+			Citation:      "7.1.2.3.e",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewECOtherKeyUsages,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_edwardspublickey_key_usages.go
+++ b/v3/lints/cabf_smime_br/lint_edwardspublickey_key_usages.go
@@ -21,13 +21,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_edwardspublickey_key_usages",
-		Description:   "Bit positions SHALL be set for digitalSignature and MAY be set for nonRepudiation.",
-		Citation:      "7.1.2.3.e",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          NewEdwardsPublicKeyKeyUsages,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_edwardspublickey_key_usages",
+			Description:   "Bit positions SHALL be set for digitalSignature and MAY be set for nonRepudiation.",
+			Citation:      "7.1.2.3.e",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewEdwardsPublicKeyKeyUsages,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_key_usage_criticality.go
+++ b/v3/lints/cabf_smime_br/lint_key_usage_criticality.go
@@ -21,13 +21,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_key_usage_criticality",
-		Description:   "keyUsage... This extension SHOULD be marked critical",
-		Citation:      "7.1.2.3.e",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          NewKeyUsageCriticality,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_key_usage_criticality",
+			Description:   "keyUsage... This extension SHOULD be marked critical",
+			Citation:      "7.1.2.3.e",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewKeyUsageCriticality,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_key_usage_presence.go
+++ b/v3/lints/cabf_smime_br/lint_key_usage_presence.go
@@ -21,13 +21,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_key_usage_presence",
-		Description:   "keyUsage (SHALL be present)",
-		Citation:      "7.1.2.3.e",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          NewKeyUsagePresence,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_key_usage_presence",
+			Description:   "keyUsage (SHALL be present)",
+			Citation:      "7.1.2.3.e",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewKeyUsagePresence,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_legacy_aia_contains_internal_names.go
@@ -38,13 +38,15 @@ For Legacy: When provided, at least one accessMethod SHALL have the URI scheme H
 *************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_smime_legacy_aia_contains_internal_names",
-		Description:   "SMIME Legacy certificates authorityInformationAccess When provided, at least one accessMethod SHALL have the URI scheme HTTP. Other schemes (LDAP, FTP, ...) MAY be present.",
-		Citation:      "BRs: 7.1.2.3c",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSMIMELegacyAIAInternalName,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_smime_legacy_aia_contains_internal_names",
+			Description:   "SMIME Legacy certificates authorityInformationAccess When provided, at least one accessMethod SHALL have the URI scheme HTTP. Other schemes (LDAP, FTP, ...) MAY be present.",
+			Citation:      "BRs: 7.1.2.3c",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSMIMELegacyAIAInternalName,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_rsa_key_usage_legacy_multipurpose.go
+++ b/v3/lints/cabf_smime_br/lint_rsa_key_usage_legacy_multipurpose.go
@@ -23,13 +23,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rsa_key_usage_legacy_multipurpose",
-		Description:   "For signing only, bit positions SHALL be set for digitalSignature and MAY be set for nonRepudiation. For key management only, bit positions SHALL be set for keyEncipherment and MAY be set for dataEncipherment. For dual use, bit positions SHALL be set for digitalSignature and keyEncipherment and MAY be set for nonRepudiation and dataEncipherment.",
-		Citation:      "7.1.2.3.e",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          NewRSAKeyUsageLegacyMultipurpose,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rsa_key_usage_legacy_multipurpose",
+			Description:   "For signing only, bit positions SHALL be set for digitalSignature and MAY be set for nonRepudiation. For key management only, bit positions SHALL be set for keyEncipherment and MAY be set for dataEncipherment. For dual use, bit positions SHALL be set for digitalSignature and keyEncipherment and MAY be set for nonRepudiation and dataEncipherment.",
+			Citation:      "7.1.2.3.e",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewRSAKeyUsageLegacyMultipurpose,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_rsa_key_usage_strict.go
+++ b/v3/lints/cabf_smime_br/lint_rsa_key_usage_strict.go
@@ -23,13 +23,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rsa_key_usage_strict",
-		Description:   "For signing only, bit positions SHALL be set for digitalSignature and MAY be set for nonRepudiation. For key management only, bit positions SHALL be set for keyEncipherment. For dual use, bit positions SHALL be set for digitalSignature and keyEncipherment and MAY be set for nonRepudiation.",
-		Citation:      "7.1.2.3.e",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          NewRSAKeyUsageStrict,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rsa_key_usage_strict",
+			Description:   "For signing only, bit positions SHALL be set for digitalSignature and MAY be set for nonRepudiation. For key management only, bit positions SHALL be set for keyEncipherment. For dual use, bit positions SHALL be set for digitalSignature and keyEncipherment and MAY be set for nonRepudiation.",
+			Citation:      "7.1.2.3.e",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewRSAKeyUsageStrict,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_rsa_other_key_usages.go
+++ b/v3/lints/cabf_smime_br/lint_rsa_other_key_usages.go
@@ -23,13 +23,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rsa_other_key_usages",
-		Description:   "Other bit positions SHALL NOT be set.",
-		Citation:      "7.1.2.3.e",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          NewRSAOtherKeyUsages,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rsa_other_key_usages",
+			Description:   "Other bit positions SHALL NOT be set.",
+			Citation:      "7.1.2.3.e",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewRSAOtherKeyUsages,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_san_shall_be_present.go
+++ b/v3/lints/cabf_smime_br/lint_san_shall_be_present.go
@@ -21,13 +21,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_san_shall_be_present",
-		Description:   "Subject alternative name SHALL be present",
-		Citation:      "7.1.2.3.h",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          NewSubjectAlternativeNameShallBePresent,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_san_shall_be_present",
+			Description:   "Subject alternative name SHALL be present",
+			Citation:      "7.1.2.3.h",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewSubjectAlternativeNameShallBePresent,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_san_should_not_be_critical.go
+++ b/v3/lints/cabf_smime_br/lint_san_should_not_be_critical.go
@@ -24,13 +24,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_san_should_not_be_critical",
-		Description:   "subjectAlternativeName SHOULD NOT be marked critical unless the subject field is an empty sequence.",
-		Citation:      "7.1.2.3.h",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          NewSubjectAlternativeNameNotCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_san_should_not_be_critical",
+			Description:   "subjectAlternativeName SHOULD NOT be marked critical unless the subject field is an empty sequence.",
+			Citation:      "7.1.2.3.h",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewSubjectAlternativeNameNotCritical,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_single_email_if_present.go
+++ b/v3/lints/cabf_smime_br/lint_single_email_if_present.go
@@ -23,13 +23,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_single_email_if_present",
-		Description:   "If present, the subject:emailAddress SHALL contain a single Mailbox Address",
-		Citation:      "7.1.4.2.h",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          func() lint.LintInterface { return &singleEmailIfPresent{} },
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_single_email_if_present",
+			Description:   "If present, the subject:emailAddress SHALL contain a single Mailbox Address",
+			Citation:      "7.1.4.2.h",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: func() lint.LintInterface { return &singleEmailIfPresent{} },
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
+++ b/v3/lints/cabf_smime_br/lint_strict_aia_contains_internal_names.go
@@ -38,13 +38,15 @@ For Strict and Multipurpose: When provided, every accessMethod SHALL have the UR
 *************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_smime_strict_aia_contains_internal_names",
-		Description:   "SMIME Strict certificates authorityInformationAccess When provided, every accessMethod SHALL have the URI scheme HTTP. Other schemes SHALL NOT be present.",
-		Citation:      "BRs: 7.1.2.3c",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewSMIMEStrictAIAInternalName,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_smime_strict_aia_contains_internal_names",
+			Description:   "SMIME Strict certificates authorityInformationAccess When provided, every accessMethod SHALL have the URI scheme HTTP. Other schemes SHALL NOT be present.",
+			Citation:      "BRs: 7.1.2.3c",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewSMIMEStrictAIAInternalName,
 	})
 }
 

--- a/v3/lints/cabf_smime_br/lint_subscribers_shall_have_crl_distribution_points.go
+++ b/v3/lints/cabf_smime_br/lint_subscribers_shall_have_crl_distribution_points.go
@@ -21,13 +21,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subscribers_shall_have_crl_distribution_points",
-		Description:   "cRLDistributionPoints SHALL be present.",
-		Citation:      "7.1.2.3.b",
-		Source:        lint.CABFSMIMEBaselineRequirements,
-		EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
-		Lint:          NewSubscriberCrlDistributionPoints,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subscribers_shall_have_crl_distribution_points",
+			Description:   "cRLDistributionPoints SHALL be present.",
+			Citation:      "7.1.2.3.b",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewSubscriberCrlDistributionPoints,
 	})
 }
 

--- a/v3/lints/community/lint_ian_bare_wildcard.go
+++ b/v3/lints/community/lint_ian_bare_wildcard.go
@@ -25,13 +25,15 @@ import (
 type brIANBareWildcard struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ian_bare_wildcard",
-		Description:   "A wildcard MUST be accompanied by other data to its right (Only checks IANDNSNames)",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewBrIANBareWildcard,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ian_bare_wildcard",
+			Description:   "A wildcard MUST be accompanied by other data to its right (Only checks IANDNSNames)",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewBrIANBareWildcard,
 	})
 }
 

--- a/v3/lints/community/lint_ian_dns_name_includes_null_char.go
+++ b/v3/lints/community/lint_ian_dns_name_includes_null_char.go
@@ -23,13 +23,15 @@ import (
 type IANDNSNull struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ian_dns_name_includes_null_char",
-		Description:   "DNSName MUST NOT include a null character",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewIANDNSNull,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ian_dns_name_includes_null_char",
+			Description:   "DNSName MUST NOT include a null character",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewIANDNSNull,
 	})
 }
 

--- a/v3/lints/community/lint_ian_dns_name_starts_with_period.go
+++ b/v3/lints/community/lint_ian_dns_name_starts_with_period.go
@@ -25,13 +25,15 @@ import (
 type IANDNSPeriod struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ian_dns_name_starts_with_period",
-		Description:   "DNSName MUST NOT start with a period",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewIANDNSPeriod,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ian_dns_name_starts_with_period",
+			Description:   "DNSName MUST NOT start with a period",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewIANDNSPeriod,
 	})
 }
 

--- a/v3/lints/community/lint_ian_iana_pub_suffix_empty.go
+++ b/v3/lints/community/lint_ian_iana_pub_suffix_empty.go
@@ -25,13 +25,15 @@ import (
 type IANPubSuffix struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ian_iana_pub_suffix_empty",
-		Description:   "Domain SHOULD NOT have a bare public suffix",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewIANPubSuffix,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ian_iana_pub_suffix_empty",
+			Description:   "Domain SHOULD NOT have a bare public suffix",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewIANPubSuffix,
 	})
 }
 

--- a/v3/lints/community/lint_ian_wildcard_not_first.go
+++ b/v3/lints/community/lint_ian_wildcard_not_first.go
@@ -23,13 +23,15 @@ import (
 type brIANWildcardFirst struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ian_wildcard_not_first",
-		Description:   "A wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks IANDNSNames)",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewBrIANWildcardFirst,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ian_wildcard_not_first",
+			Description:   "A wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks IANDNSNames)",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewBrIANWildcardFirst,
 	})
 }
 

--- a/v3/lints/community/lint_is_redacted_cert.go
+++ b/v3/lints/community/lint_is_redacted_cert.go
@@ -25,13 +25,15 @@ import (
 type DNSNameRedacted struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "n_contains_redacted_dnsname",
-		Description:   "Some precerts are redacted and of the form ?.?.a.com or *.?.a.com",
-		Source:        lint.Community,
-		Citation:      "IETF Draft: https://tools.ietf.org/id/draft-strad-trans-redaction-00.html",
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewDNSNameRedacted,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "n_contains_redacted_dnsname",
+			Description:   "Some precerts are redacted and of the form ?.?.a.com or *.?.a.com",
+			Source:        lint.Community,
+			Citation:      "IETF Draft: https://tools.ietf.org/id/draft-strad-trans-redaction-00.html",
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewDNSNameRedacted,
 	})
 }
 

--- a/v3/lints/community/lint_issuer_dn_leading_whitespace.go
+++ b/v3/lints/community/lint_issuer_dn_leading_whitespace.go
@@ -23,13 +23,15 @@ import (
 type IssuerDNLeadingSpace struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_issuer_dn_leading_whitespace",
-		Description:   "AttributeValue in issuer RelativeDistinguishedName sequence SHOULD NOT have leading whitespace",
-		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewIssuerDNLeadingSpace,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_issuer_dn_leading_whitespace",
+			Description:   "AttributeValue in issuer RelativeDistinguishedName sequence SHOULD NOT have leading whitespace",
+			Citation:      "lint.AWSLabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewIssuerDNLeadingSpace,
 	})
 }
 

--- a/v3/lints/community/lint_issuer_dn_trailing_whitespace.go
+++ b/v3/lints/community/lint_issuer_dn_trailing_whitespace.go
@@ -23,13 +23,15 @@ import (
 type IssuerDNTrailingSpace struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_issuer_dn_trailing_whitespace",
-		Description:   "AttributeValue in issuer RelativeDistinguishedName sequence SHOULD NOT have trailing whitespace",
-		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewIssuerDNTrailingSpace,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_issuer_dn_trailing_whitespace",
+			Description:   "AttributeValue in issuer RelativeDistinguishedName sequence SHOULD NOT have trailing whitespace",
+			Citation:      "lint.AWSLabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewIssuerDNTrailingSpace,
 	})
 }
 

--- a/v3/lints/community/lint_issuer_multiple_rdn.go
+++ b/v3/lints/community/lint_issuer_multiple_rdn.go
@@ -25,13 +25,15 @@ import (
 type IssuerRDNHasMultipleAttribute struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_multiple_issuer_rdn",
-		Description:   "Certificates should not have multiple attributes in a single RDN (issuer)",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewIssuerRDNHasMultipleAttribute,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_multiple_issuer_rdn",
+			Description:   "Certificates should not have multiple attributes in a single RDN (issuer)",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewIssuerRDNHasMultipleAttribute,
 	})
 }
 

--- a/v3/lints/community/lint_rsa_exp_negative.go
+++ b/v3/lints/community/lint_rsa_exp_negative.go
@@ -25,13 +25,15 @@ import (
 type rsaExpNegative struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rsa_exp_negative",
-		Description:   "RSA public key exponent MUST be positive",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewRsaExpNegative,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rsa_exp_negative",
+			Description:   "RSA public key exponent MUST be positive",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewRsaExpNegative,
 	})
 }
 

--- a/v3/lints/community/lint_rsa_fermat_factorization.go
+++ b/v3/lints/community/lint_rsa_fermat_factorization.go
@@ -29,15 +29,17 @@ type fermatFactorization struct {
 }
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name: "e_rsa_fermat_factorization",
-		Description: "RSA key pairs that are too close to each other are susceptible to the Fermat Factorization " +
-			"Method (for more information please see https://en.wikipedia.org/wiki/Fermat%27s_factorization_method " +
-			"and https://fermatattack.secvuln.info/)",
-		Citation:      "Pierre de Fermat",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewFermatFactorization,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name: "e_rsa_fermat_factorization",
+			Description: "RSA key pairs that are too close to each other are susceptible to the Fermat Factorization " +
+				"Method (for more information please see https://en.wikipedia.org/wiki/Fermat%27s_factorization_method " +
+				"and https://fermatattack.secvuln.info/)",
+			Citation:      "Pierre de Fermat",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewFermatFactorization,
 	})
 }
 

--- a/v3/lints/community/lint_rsa_no_public_key.go
+++ b/v3/lints/community/lint_rsa_no_public_key.go
@@ -25,13 +25,15 @@ import (
 type rsaParsedPubKeyExist struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rsa_no_public_key",
-		Description:   "The RSA public key should be present",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewRsaParsedPubKeyExist,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rsa_no_public_key",
+			Description:   "The RSA public key should be present",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewRsaParsedPubKeyExist,
 	})
 }
 

--- a/v3/lints/community/lint_san_bare_wildcard.go
+++ b/v3/lints/community/lint_san_bare_wildcard.go
@@ -25,13 +25,15 @@ import (
 type brSANBareWildcard struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_san_bare_wildcard",
-		Description:   "A wildcard MUST be accompanied by other data to its right (Only checks DNSName)",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewBrSANBareWildcard,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_san_bare_wildcard",
+			Description:   "A wildcard MUST be accompanied by other data to its right (Only checks DNSName)",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewBrSANBareWildcard,
 	})
 }
 

--- a/v3/lints/community/lint_san_dns_name_duplicate.go
+++ b/v3/lints/community/lint_san_dns_name_duplicate.go
@@ -25,13 +25,15 @@ import (
 type SANDNSDuplicate struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "n_san_dns_name_duplicate",
-		Description:   "SAN DNSName contains duplicate values",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSANDNSDuplicate,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "n_san_dns_name_duplicate",
+			Description:   "SAN DNSName contains duplicate values",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSANDNSDuplicate,
 	})
 }
 

--- a/v3/lints/community/lint_san_dns_name_includes_null_char.go
+++ b/v3/lints/community/lint_san_dns_name_includes_null_char.go
@@ -23,13 +23,15 @@ import (
 type SANDNSNull struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_san_dns_name_includes_null_char",
-		Description:   "DNSName MUST NOT include a null character",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSANDNSNull,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_san_dns_name_includes_null_char",
+			Description:   "DNSName MUST NOT include a null character",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSANDNSNull,
 	})
 }
 

--- a/v3/lints/community/lint_san_dns_name_starts_with_period.go
+++ b/v3/lints/community/lint_san_dns_name_starts_with_period.go
@@ -25,13 +25,15 @@ import (
 type SANDNSPeriod struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_san_dns_name_starts_with_period",
-		Description:   "DNSName MUST NOT start with a period",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSANDNSPeriod,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_san_dns_name_starts_with_period",
+			Description:   "DNSName MUST NOT start with a period",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSANDNSPeriod,
 	})
 }
 

--- a/v3/lints/community/lint_san_iana_pub_suffix_empty.go
+++ b/v3/lints/community/lint_san_iana_pub_suffix_empty.go
@@ -26,13 +26,15 @@ import (
 type pubSuffix struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "n_san_iana_pub_suffix_empty",
-		Description:   "The domain SHOULD NOT have a bare public suffix",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewPubSuffix,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "n_san_iana_pub_suffix_empty",
+			Description:   "The domain SHOULD NOT have a bare public suffix",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewPubSuffix,
 	})
 }
 

--- a/v3/lints/community/lint_san_wildcard_not_first.go
+++ b/v3/lints/community/lint_san_wildcard_not_first.go
@@ -23,13 +23,15 @@ import (
 type SANWildCardFirst struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_san_wildcard_not_first",
-		Description:   "A wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks DNSName)",
-		Citation:      "awslabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSANWildCardFirst,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_san_wildcard_not_first",
+			Description:   "A wildcard MUST be in the first label of FQDN (ie not: www.*.com) (Only checks DNSName)",
+			Citation:      "awslabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSANWildCardFirst,
 	})
 }
 

--- a/v3/lints/community/lint_subject_dn_leading_whitespace.go
+++ b/v3/lints/community/lint_subject_dn_leading_whitespace.go
@@ -23,13 +23,15 @@ import (
 type SubjectDNLeadingSpace struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_subject_dn_leading_whitespace",
-		Description:   "AttributeValue in subject RelativeDistinguishedName sequence SHOULD NOT have leading whitespace",
-		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSubjectDNLeadingSpace,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_subject_dn_leading_whitespace",
+			Description:   "AttributeValue in subject RelativeDistinguishedName sequence SHOULD NOT have leading whitespace",
+			Citation:      "lint.AWSLabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSubjectDNLeadingSpace,
 	})
 }
 

--- a/v3/lints/community/lint_subject_dn_trailing_whitespace.go
+++ b/v3/lints/community/lint_subject_dn_trailing_whitespace.go
@@ -23,13 +23,15 @@ import (
 type SubjectDNTrailingSpace struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_subject_dn_trailing_whitespace",
-		Description:   "AttributeValue in subject RelativeDistinguishedName sequence SHOULD NOT have trailing whitespace",
-		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSubjectDNTrailingSpace,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_subject_dn_trailing_whitespace",
+			Description:   "AttributeValue in subject RelativeDistinguishedName sequence SHOULD NOT have trailing whitespace",
+			Citation:      "lint.AWSLabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSubjectDNTrailingSpace,
 	})
 }
 

--- a/v3/lints/community/lint_subject_multiple_rdn.go
+++ b/v3/lints/community/lint_subject_multiple_rdn.go
@@ -25,13 +25,15 @@ import (
 type SubjectRDNHasMultipleAttribute struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "n_multiple_subject_rdn",
-		Description:   "Certificates typically do not have multiple attributes in a single RDN (subject). This may be an error.",
-		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSubjectRDNHasMultipleAttribute,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "n_multiple_subject_rdn",
+			Description:   "Certificates typically do not have multiple attributes in a single RDN (subject). This may be an error.",
+			Citation:      "lint.AWSLabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSubjectRDNHasMultipleAttribute,
 	})
 }
 

--- a/v3/lints/community/lint_validity_time_not_positive.go
+++ b/v3/lints/community/lint_validity_time_not_positive.go
@@ -23,13 +23,15 @@ import (
 type validityNegative struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_validity_time_not_positive",
-		Description:   "Certificates MUST have a positive time for which they are valid",
-		Citation:      "lint.AWSLabs certlint",
-		Source:        lint.Community,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewValidityNegative,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_validity_time_not_positive",
+			Description:   "Certificates MUST have a positive time for which they are valid",
+			Citation:      "lint.AWSLabs certlint",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewValidityNegative,
 	})
 }
 

--- a/v3/lints/etsi/lint_qcstatem_etsi_present_qcs_critical.go
+++ b/v3/lints/etsi/lint_qcstatem_etsi_present_qcs_critical.go
@@ -23,13 +23,15 @@ import (
 type qcStatemQcEtsiPresentQcsCritical struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_qcstatem_etsi_present_qcs_critical",
-		Description:   "Checks that a QC Statement which contains any of the id-etsi-qcs-... QC Statements is not marked critical",
-		Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.1",
-		Source:        lint.EtsiEsi,
-		EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
-		Lint:          NewQcStatemQcEtsiPresentQcsCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_qcstatem_etsi_present_qcs_critical",
+			Description:   "Checks that a QC Statement which contains any of the id-etsi-qcs-... QC Statements is not marked critical",
+			Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.1",
+			Source:        lint.EtsiEsi,
+			EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
+		},
+		Lint: NewQcStatemQcEtsiPresentQcsCritical,
 	})
 }
 

--- a/v3/lints/etsi/lint_qcstatem_etsi_type_as_statem.go
+++ b/v3/lints/etsi/lint_qcstatem_etsi_type_as_statem.go
@@ -26,13 +26,15 @@ import (
 type qcStatemEtsiTypeAsStatem struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_qcstatem_etsi_type_as_statem",
-		Description:   "Checks for erroneous QC Statement OID that actually are represented by ETSI ESI QC type OID.",
-		Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.2.3",
-		Source:        lint.EtsiEsi,
-		EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
-		Lint:          NewQcStatemEtsiTypeAsStatem,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_qcstatem_etsi_type_as_statem",
+			Description:   "Checks for erroneous QC Statement OID that actually are represented by ETSI ESI QC type OID.",
+			Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.2.3",
+			Source:        lint.EtsiEsi,
+			EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
+		},
+		Lint: NewQcStatemEtsiTypeAsStatem,
 	})
 }
 

--- a/v3/lints/etsi/lint_qcstatem_mandatory_etsi_statems.go
+++ b/v3/lints/etsi/lint_qcstatem_mandatory_etsi_statems.go
@@ -24,13 +24,15 @@ import (
 type qcStatemQcmandatoryEtsiStatems struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_qcstatem_mandatory_etsi_statems",
-		Description:   "Checks that a QC Statement that contains at least one of the ETSI ESI statements, also features the set of mandatory ETSI ESI QC statements.",
-		Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 5",
-		Source:        lint.EtsiEsi,
-		EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
-		Lint:          NewQcStatemQcmandatoryEtsiStatems,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_qcstatem_mandatory_etsi_statems",
+			Description:   "Checks that a QC Statement that contains at least one of the ETSI ESI statements, also features the set of mandatory ETSI ESI QC statements.",
+			Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 5",
+			Source:        lint.EtsiEsi,
+			EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
+		},
+		Lint: NewQcStatemQcmandatoryEtsiStatems,
 	})
 }
 

--- a/v3/lints/etsi/lint_qcstatem_qccompliance_valid.go
+++ b/v3/lints/etsi/lint_qcstatem_qccompliance_valid.go
@@ -24,13 +24,15 @@ import (
 type qcStatemQcComplianceValid struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_qcstatem_qccompliance_valid",
-		Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcCompliance has the correct form",
-		Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.2.1",
-		Source:        lint.EtsiEsi,
-		EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
-		Lint:          NewQcStatemQcComplianceValid,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_qcstatem_qccompliance_valid",
+			Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcCompliance has the correct form",
+			Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.2.1",
+			Source:        lint.EtsiEsi,
+			EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
+		},
+		Lint: NewQcStatemQcComplianceValid,
 	})
 }
 

--- a/v3/lints/etsi/lint_qcstatem_qclimitvalue_valid.go
+++ b/v3/lints/etsi/lint_qcstatem_qclimitvalue_valid.go
@@ -26,13 +26,15 @@ import (
 type qcStatemQcLimitValueValid struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_qcstatem_qclimitvalue_valid",
-		Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcLimitValue has the correct form",
-		Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.3.2",
-		Source:        lint.EtsiEsi,
-		EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
-		Lint:          NewQcStatemQcLimitValueValid,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_qcstatem_qclimitvalue_valid",
+			Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcLimitValue has the correct form",
+			Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.3.2",
+			Source:        lint.EtsiEsi,
+			EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
+		},
+		Lint: NewQcStatemQcLimitValueValid,
 	})
 }
 

--- a/v3/lints/etsi/lint_qcstatem_qcpds_lang_case.go
+++ b/v3/lints/etsi/lint_qcstatem_qcpds_lang_case.go
@@ -27,13 +27,15 @@ import (
 type qcStatemQcPdsLangCase struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_qcstatem_qcpds_lang_case",
-		Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcPDS features a language code comprised of only lower case letters",
-		Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.3.4",
-		Source:        lint.EtsiEsi,
-		EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
-		Lint:          NewQcStatemQcPdsLangCase,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_qcstatem_qcpds_lang_case",
+			Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcPDS features a language code comprised of only lower case letters",
+			Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.3.4",
+			Source:        lint.EtsiEsi,
+			EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
+		},
+		Lint: NewQcStatemQcPdsLangCase,
 	})
 }
 

--- a/v3/lints/etsi/lint_qcstatem_qcpds_valid.go
+++ b/v3/lints/etsi/lint_qcstatem_qcpds_valid.go
@@ -27,13 +27,15 @@ import (
 type qcStatemQcPdsValid struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_qcstatem_qcpds_valid",
-		Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcPDS has the correct form",
-		Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.3.4",
-		Source:        lint.EtsiEsi,
-		EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
-		Lint:          NewQcStatemQcPdsValid,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_qcstatem_qcpds_valid",
+			Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcPDS has the correct form",
+			Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.3.4",
+			Source:        lint.EtsiEsi,
+			EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
+		},
+		Lint: NewQcStatemQcPdsValid,
 	})
 }
 

--- a/v3/lints/etsi/lint_qcstatem_qcretentionperiod_valid.go
+++ b/v3/lints/etsi/lint_qcstatem_qcretentionperiod_valid.go
@@ -24,13 +24,15 @@ import (
 type qcStatemQcRetentionPeriodValid struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_qcstatem_qcretentionperiod_valid",
-		Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcRetentionPeriod has the correct form",
-		Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11)/ Section 4.3.3",
-		Source:        lint.EtsiEsi,
-		EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
-		Lint:          NewQcStatemQcRetentionPeriodValid,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_qcstatem_qcretentionperiod_valid",
+			Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcRetentionPeriod has the correct form",
+			Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11)/ Section 4.3.3",
+			Source:        lint.EtsiEsi,
+			EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
+		},
+		Lint: NewQcStatemQcRetentionPeriodValid,
 	})
 }
 

--- a/v3/lints/etsi/lint_qcstatem_qcsscd_valid.go
+++ b/v3/lints/etsi/lint_qcstatem_qcsscd_valid.go
@@ -24,13 +24,15 @@ import (
 type qcStatemQcSscdValid struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_qcstatem_qcsscd_valid",
-		Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcSSCD has the correct form",
-		Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.2.2",
-		Source:        lint.EtsiEsi,
-		EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
-		Lint:          NewQcStatemQcSscdValid,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_qcstatem_qcsscd_valid",
+			Description:   "Checks that a QC Statement of the type id-etsi-qcs-QcSSCD has the correct form",
+			Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.2.2",
+			Source:        lint.EtsiEsi,
+			EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
+		},
+		Lint: NewQcStatemQcSscdValid,
 	})
 }
 

--- a/v3/lints/etsi/lint_qcstatem_qctype_valid.go
+++ b/v3/lints/etsi/lint_qcstatem_qctype_valid.go
@@ -26,13 +26,15 @@ import (
 type qcStatemQctypeValid struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_qcstatem_qctype_valid",
-		Description:   "Checks that a QC Statement of the type Id-etsi-qcs-QcType features a non-empty list of only the allowed QcType OIDs",
-		Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.2.3",
-		Source:        lint.EtsiEsi,
-		EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
-		Lint:          NewQcStatemQctypeValid,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_qcstatem_qctype_valid",
+			Description:   "Checks that a QC Statement of the type Id-etsi-qcs-QcType features a non-empty list of only the allowed QcType OIDs",
+			Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.2.3",
+			Source:        lint.EtsiEsi,
+			EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
+		},
+		Lint: NewQcStatemQctypeValid,
 	})
 }
 

--- a/v3/lints/etsi/lint_qcstatem_qctype_web.go
+++ b/v3/lints/etsi/lint_qcstatem_qctype_web.go
@@ -26,13 +26,15 @@ import (
 type qcStatemQctypeWeb struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_qcstatem_qctype_web",
-		Description:   "Checks that a QC Statement of the type Id-etsi-qcs-QcType features at least the type IdEtsiQcsQctWeb",
-		Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.2.3",
-		Source:        lint.EtsiEsi,
-		EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
-		Lint:          NewQcStatemQctypeWeb,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_qcstatem_qctype_web",
+			Description:   "Checks that a QC Statement of the type Id-etsi-qcs-QcType features at least the type IdEtsiQcsQctWeb",
+			Citation:      "ETSI EN 319 412 - 5 V2.2.1 (2017 - 11) / Section 4.2.3",
+			Source:        lint.EtsiEsi,
+			EffectiveDate: util.EtsiEn319_412_5_V2_2_1_Date,
+		},
+		Lint: NewQcStatemQctypeWeb,
 	})
 }
 

--- a/v3/lints/mozilla/lint_e_prohibit_dsa_usage.go
+++ b/v3/lints/mozilla/lint_e_prohibit_dsa_usage.go
@@ -35,13 +35,15 @@ Root certificates in our root program, and any certificate which chains up to th
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_prohibit_dsa_usage",
-		Description:   "DSA is not an explicitly allowed signature algorithm, therefore it is forbidden.",
-		Citation:      "Mozilla Root Store Policy / Section 5.1",
-		Source:        lint.MozillaRootStorePolicy,
-		EffectiveDate: util.MozillaPolicy241Date,
-		Lint:          NewProhibitDSAUsage,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_prohibit_dsa_usage",
+			Description:   "DSA is not an explicitly allowed signature algorithm, therefore it is forbidden.",
+			Citation:      "Mozilla Root Store Policy / Section 5.1",
+			Source:        lint.MozillaRootStorePolicy,
+			EffectiveDate: util.MozillaPolicy241Date,
+		},
+		Lint: NewProhibitDSAUsage,
 	})
 }
 

--- a/v3/lints/mozilla/lint_mp_allowed_eku.go
+++ b/v3/lints/mozilla/lint_mp_allowed_eku.go
@@ -37,13 +37,15 @@ intermediates.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "n_mp_allowed_eku",
-		Description:   "A SubCA certificate must not have key usage that allows for both server auth and email protection, and must not use anyExtendedKeyUsage",
-		Citation:      "Mozilla Root Store Policy / Section 5.3",
-		Source:        lint.MozillaRootStorePolicy,
-		EffectiveDate: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
-		Lint:          NewAllowedEKU,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "n_mp_allowed_eku",
+			Description:   "A SubCA certificate must not have key usage that allows for both server auth and email protection, and must not use anyExtendedKeyUsage",
+			Citation:      "Mozilla Root Store Policy / Section 5.3",
+			Source:        lint.MozillaRootStorePolicy,
+			EffectiveDate: time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		Lint: NewAllowedEKU,
 	})
 }
 

--- a/v3/lints/mozilla/lint_mp_authority_key_identifier_correct.go
+++ b/v3/lints/mozilla/lint_mp_authority_key_identifier_correct.go
@@ -39,13 +39,15 @@ CAs MUST NOT issue certificates that have:
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_mp_authority_key_identifier_correct",
-		Description:   "CAs MUST NOT issue certificates that have authority key IDs that include both the key ID and the issuer's issuer name and serial number",
-		Citation:      "Mozilla Root Store Policy / Section 5.2",
-		Source:        lint.MozillaRootStorePolicy,
-		EffectiveDate: util.MozillaPolicy22Date,
-		Lint:          NewAuthorityKeyIdentifierCorrect,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_mp_authority_key_identifier_correct",
+			Description:   "CAs MUST NOT issue certificates that have authority key IDs that include both the key ID and the issuer's issuer name and serial number",
+			Citation:      "Mozilla Root Store Policy / Section 5.2",
+			Source:        lint.MozillaRootStorePolicy,
+			EffectiveDate: util.MozillaPolicy22Date,
+		},
+		Lint: NewAuthorityKeyIdentifierCorrect,
 	})
 }
 

--- a/v3/lints/mozilla/lint_mp_ecdsa_pub_key_encoding_correct.go
+++ b/v3/lints/mozilla/lint_mp_ecdsa_pub_key_encoding_correct.go
@@ -44,13 +44,15 @@ curve OID. Certificates MUST NOT use the implicit or specified curve forms.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_mp_ecdsa_pub_key_encoding_correct",
-		Description:   "The encoded algorithm identifiers for ECDSA public keys MUST match specific bytes",
-		Citation:      "Mozilla Root Store Policy / Section 5.1.2",
-		Source:        lint.MozillaRootStorePolicy,
-		EffectiveDate: util.MozillaPolicy27Date,
-		Lint:          NewEcdsaPubKeyAidEncoding,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_mp_ecdsa_pub_key_encoding_correct",
+			Description:   "The encoded algorithm identifiers for ECDSA public keys MUST match specific bytes",
+			Citation:      "Mozilla Root Store Policy / Section 5.1.2",
+			Source:        lint.MozillaRootStorePolicy,
+			EffectiveDate: util.MozillaPolicy27Date,
+		},
+		Lint: NewEcdsaPubKeyAidEncoding,
 	})
 }
 

--- a/v3/lints/mozilla/lint_mp_ecdsa_signature_encoding_correct.go
+++ b/v3/lints/mozilla/lint_mp_ecdsa_signature_encoding_correct.go
@@ -45,13 +45,15 @@ an explicit NULL.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_mp_ecdsa_signature_encoding_correct",
-		Description:   "The encoded algorithm identifiers for ECDSA signatures MUST match specific hex-encoded bytes",
-		Citation:      "Mozilla Root Store Policy / Section 5.1.2",
-		Source:        lint.MozillaRootStorePolicy,
-		EffectiveDate: util.MozillaPolicy27Date,
-		Lint:          NewEcdsaSignatureAidEncoding,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_mp_ecdsa_signature_encoding_correct",
+			Description:   "The encoded algorithm identifiers for ECDSA signatures MUST match specific hex-encoded bytes",
+			Citation:      "Mozilla Root Store Policy / Section 5.1.2",
+			Source:        lint.MozillaRootStorePolicy,
+			EffectiveDate: util.MozillaPolicy27Date,
+		},
+		Lint: NewEcdsaSignatureAidEncoding,
 	})
 }
 

--- a/v3/lints/mozilla/lint_mp_exponent_cannot_be_one.go
+++ b/v3/lints/mozilla/lint_mp_exponent_cannot_be_one.go
@@ -31,13 +31,15 @@ CAs MUST NOT issue certificates that have:
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_mp_exponent_cannot_be_one",
-		Description:   "CAs MUST NOT issue certificates that have invalid public keys (e.g., RSA certificates with public exponent equal to 1)",
-		Citation:      "Mozilla Root Store Policy / Section 5.2",
-		Source:        lint.MozillaRootStorePolicy,
-		EffectiveDate: util.MozillaPolicy24Date,
-		Lint:          NewExponentCannotBeOne,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_mp_exponent_cannot_be_one",
+			Description:   "CAs MUST NOT issue certificates that have invalid public keys (e.g., RSA certificates with public exponent equal to 1)",
+			Citation:      "Mozilla Root Store Policy / Section 5.2",
+			Source:        lint.MozillaRootStorePolicy,
+			EffectiveDate: util.MozillaPolicy24Date,
+		},
+		Lint: NewExponentCannotBeOne,
 	})
 }
 

--- a/v3/lints/mozilla/lint_mp_modulus_must_be_2048_bits_or_more.go
+++ b/v3/lints/mozilla/lint_mp_modulus_must_be_2048_bits_or_more.go
@@ -30,13 +30,15 @@ RSA keys whose modulus size in bits is divisible by 8, and is at least 2048.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_mp_modulus_must_be_2048_bits_or_more",
-		Description:   "RSA keys must have modulus size of at least 2048 bits",
-		Citation:      "Mozilla Root Store Policy / Section 5.1",
-		Source:        lint.MozillaRootStorePolicy,
-		EffectiveDate: util.MozillaPolicy24Date,
-		Lint:          NewModulus2048OrMore,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_mp_modulus_must_be_2048_bits_or_more",
+			Description:   "RSA keys must have modulus size of at least 2048 bits",
+			Citation:      "Mozilla Root Store Policy / Section 5.1",
+			Source:        lint.MozillaRootStorePolicy,
+			EffectiveDate: util.MozillaPolicy24Date,
+		},
+		Lint: NewModulus2048OrMore,
 	})
 }
 

--- a/v3/lints/mozilla/lint_mp_modulus_must_be_divisible_by_8.go
+++ b/v3/lints/mozilla/lint_mp_modulus_must_be_divisible_by_8.go
@@ -30,13 +30,15 @@ RSA keys whose modulus size in bits is divisible by 8, and is at least 2048.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_mp_modulus_must_be_divisible_by_8",
-		Description:   "RSA keys must have a modulus size divisible by 8",
-		Citation:      "Mozilla Root Store Policy / Section 5.1",
-		Source:        lint.MozillaRootStorePolicy,
-		EffectiveDate: util.MozillaPolicy24Date,
-		Lint:          NewModulusDivisibleBy8,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_mp_modulus_must_be_divisible_by_8",
+			Description:   "RSA keys must have a modulus size divisible by 8",
+			Citation:      "Mozilla Root Store Policy / Section 5.1",
+			Source:        lint.MozillaRootStorePolicy,
+			EffectiveDate: util.MozillaPolicy24Date,
+		},
+		Lint: NewModulusDivisibleBy8,
 	})
 }
 

--- a/v3/lints/mozilla/lint_mp_pss_parameters_encoding_correct.go
+++ b/v3/lints/mozilla/lint_mp_pss_parameters_encoding_correct.go
@@ -58,13 +58,15 @@ The encoded AlgorithmIdentifier MUST match the following hex-encoded bytes:
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_mp_rsassa-pss_parameters_encoding_in_signature_algorithm_correct",
-		Description:   "The encoded AlgorithmIdentifier for RSASSA-PSS in the signature algorithm MUST match specific bytes",
-		Citation:      "Mozilla Root Store Policy / Section 5.1.1",
-		Source:        lint.MozillaRootStorePolicy,
-		EffectiveDate: util.MozillaPolicy27Date,
-		Lint:          NewRsaPssAidEncoding,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_mp_rsassa-pss_parameters_encoding_in_signature_algorithm_correct",
+			Description:   "The encoded AlgorithmIdentifier for RSASSA-PSS in the signature algorithm MUST match specific bytes",
+			Citation:      "Mozilla Root Store Policy / Section 5.1.1",
+			Source:        lint.MozillaRootStorePolicy,
+			EffectiveDate: util.MozillaPolicy27Date,
+		},
+		Lint: NewRsaPssAidEncoding,
 	})
 }
 

--- a/v3/lints/mozilla/lint_mp_rsassa-pss_in_spki.go
+++ b/v3/lints/mozilla/lint_mp_rsassa-pss_in_spki.go
@@ -33,13 +33,15 @@ CAs MUST NOT use the id-RSASSA-PSS OID (1.2.840.113549.1.1.10) within a SubjectP
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_mp_rsassa-pss_in_spki",
-		Description:   "CAs MUST NOT use the id-RSASSA-PSS OID (1.2.840.113549.1.1.10) within a SubjectPublicKeyInfo to represent a RSA key.",
-		Citation:      "Mozilla Root Store Policy / Section 5.1.1",
-		Source:        lint.MozillaRootStorePolicy,
-		EffectiveDate: util.MozillaPolicy27Date,
-		Lint:          NewRsaPssInSPKI,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_mp_rsassa-pss_in_spki",
+			Description:   "CAs MUST NOT use the id-RSASSA-PSS OID (1.2.840.113549.1.1.10) within a SubjectPublicKeyInfo to represent a RSA key.",
+			Citation:      "Mozilla Root Store Policy / Section 5.1.1",
+			Source:        lint.MozillaRootStorePolicy,
+			EffectiveDate: util.MozillaPolicy27Date,
+		},
+		Lint: NewRsaPssInSPKI,
 	})
 }
 

--- a/v3/lints/rfc/lint_basic_constraints_not_critical.go
+++ b/v3/lints/rfc/lint_basic_constraints_not_critical.go
@@ -35,13 +35,15 @@ management public keys used with certificate.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_basic_constraints_not_critical",
-		Description:   "basicConstraints MUST appear as a critical extension",
-		Citation:      "RFC 5280: 4.2.1.9",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewBasicConstCrit,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_basic_constraints_not_critical",
+			Description:   "basicConstraints MUST appear as a critical extension",
+			Citation:      "RFC 5280: 4.2.1.9",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewBasicConstCrit,
 	})
 }
 

--- a/v3/lints/rfc/lint_ca_subject_field_empty.go
+++ b/v3/lints/rfc/lint_ca_subject_field_empty.go
@@ -35,13 +35,15 @@ The subject field identifies the entity associated with the public
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ca_subject_field_empty",
-		Description:   "The subject field of a CA certificate MUST have a non-empty distinguished name",
-		Citation:      "RFC 5280: 4.1.2.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewCaSubjectEmpty,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ca_subject_field_empty",
+			Description:   "The subject field of a CA certificate MUST have a non-empty distinguished name",
+			Citation:      "RFC 5280: 4.1.2.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewCaSubjectEmpty,
 	})
 }
 

--- a/v3/lints/rfc/lint_cert_contains_unique_identifier.go
+++ b/v3/lints/rfc/lint_cert_contains_unique_identifier.go
@@ -36,13 +36,15 @@ type CertContainsUniqueIdentifier struct{}
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cert_contains_unique_identifier",
-		Description:   "CAs MUST NOT generate certificate with unique identifiers",
-		Source:        lint.RFC5280,
-		Citation:      "RFC 5280: 4.1.2.8",
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewCertContainsUniqueIdentifier,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cert_contains_unique_identifier",
+			Description:   "CAs MUST NOT generate certificate with unique identifiers",
+			Source:        lint.RFC5280,
+			Citation:      "RFC 5280: 4.1.2.8",
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewCertContainsUniqueIdentifier,
 	})
 }
 

--- a/v3/lints/rfc/lint_cert_extensions_version_not_3.go
+++ b/v3/lints/rfc/lint_cert_extensions_version_not_3.go
@@ -42,13 +42,15 @@ type CertExtensionsVersonNot3 struct{}
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cert_extensions_version_not_3",
-		Description:   "The extensions field MUST only appear in version 3 certificates",
-		Citation:      "RFC 5280: 4.1.2.9",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewCertExtensionsVersonNot3,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cert_extensions_version_not_3",
+			Description:   "The extensions field MUST only appear in version 3 certificates",
+			Citation:      "RFC 5280: 4.1.2.9",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewCertExtensionsVersonNot3,
 	})
 }
 

--- a/v3/lints/rfc/lint_cert_unique_identifier_version_not_2_or_3.go
+++ b/v3/lints/rfc/lint_cert_unique_identifier_version_not_2_or_3.go
@@ -37,13 +37,15 @@ RFC 5280: 4.1.2.8
 ****************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cert_unique_identifier_version_not_2_or_3",
-		Description:   "Unique identifiers MUST only appear if the X.509 version is 2 or 3",
-		Citation:      "RFC 5280: 4.1.2.8",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewCertUniqueIdVersion,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cert_unique_identifier_version_not_2_or_3",
+			Description:   "Unique identifiers MUST only appear if the X.509 version is 2 or 3",
+			Citation:      "RFC 5280: 4.1.2.8",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewCertUniqueIdVersion,
 	})
 }
 

--- a/v3/lints/rfc/lint_distribution_point_incomplete.go
+++ b/v3/lints/rfc/lint_distribution_point_incomplete.go
@@ -49,13 +49,15 @@ the distributionPoint field.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_distribution_point_incomplete",
-		Description:   "A DistributionPoint from the CRLDistributionPoints extension MUST NOT consist of only the reasons field; either distributionPoint or CRLIssuer must be present",
-		Citation:      "RFC 5280: 4.2.1.13",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewDpIncomplete,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_distribution_point_incomplete",
+			Description:   "A DistributionPoint from the CRLDistributionPoints extension MUST NOT consist of only the reasons field; either distributionPoint or CRLIssuer must be present",
+			Citation:      "RFC 5280: 4.2.1.13",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewDpIncomplete,
 	})
 }
 

--- a/v3/lints/rfc/lint_distribution_point_missing_ldap_or_uri.go
+++ b/v3/lints/rfc/lint_distribution_point_missing_ldap_or_uri.go
@@ -30,13 +30,15 @@ When present, DistributionPointName SHOULD include at least one LDAP or HTTP URI
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_distribution_point_missing_ldap_or_uri",
-		Description:   "When present in the CRLDistributionPoints extension, DistributionPointName SHOULD include at least one LDAP or HTTP URI",
-		Citation:      "RFC 5280: 4.2.1.13",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewDistribNoLDAPorURI,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_distribution_point_missing_ldap_or_uri",
+			Description:   "When present in the CRLDistributionPoints extension, DistributionPointName SHOULD include at least one LDAP or HTTP URI",
+			Citation:      "RFC 5280: 4.2.1.13",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewDistribNoLDAPorURI,
 	})
 }
 

--- a/v3/lints/rfc/lint_dnsname_contains_empty_label.go
+++ b/v3/lints/rfc/lint_dnsname_contains_empty_label.go
@@ -25,13 +25,15 @@ import (
 type DNSNameEmptyLabel struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rfc_dnsname_empty_label",
-		Description:   "DNSNames should not have an empty label.",
-		Citation:      "RFC5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewDNSNameEmptyLabel,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rfc_dnsname_empty_label",
+			Description:   "DNSNames should not have an empty label.",
+			Citation:      "RFC5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewDNSNameEmptyLabel,
 	})
 }
 

--- a/v3/lints/rfc/lint_dnsname_hyphen_in_sld.go
+++ b/v3/lints/rfc/lint_dnsname_hyphen_in_sld.go
@@ -25,13 +25,15 @@ import (
 type DNSNameHyphenInSLD struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rfc_dnsname_hyphen_in_sld",
-		Description:   "DNSName should not have a hyphen beginning or ending the SLD",
-		Citation:      "RFC5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewDNSNameHyphenInSLD,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rfc_dnsname_hyphen_in_sld",
+			Description:   "DNSName should not have a hyphen beginning or ending the SLD",
+			Citation:      "RFC5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewDNSNameHyphenInSLD,
 	})
 }
 

--- a/v3/lints/rfc/lint_dnsname_label_too_long.go
+++ b/v3/lints/rfc/lint_dnsname_label_too_long.go
@@ -25,13 +25,15 @@ import (
 type DNSNameLabelLengthTooLong struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rfc_dnsname_label_too_long",
-		Description:   "DNSName labels MUST be less than or equal to 63 characters",
-		Citation:      "RFC 5280: 4.2.1.6, citing RFC 1035",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewDNSNameLabelLengthTooLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rfc_dnsname_label_too_long",
+			Description:   "DNSName labels MUST be less than or equal to 63 characters",
+			Citation:      "RFC 5280: 4.2.1.6, citing RFC 1035",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewDNSNameLabelLengthTooLong,
 	})
 }
 

--- a/v3/lints/rfc/lint_dnsname_underscore_in_sld.go
+++ b/v3/lints/rfc/lint_dnsname_underscore_in_sld.go
@@ -25,13 +25,15 @@ import (
 type DNSNameUnderscoreInSLD struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rfc_dnsname_underscore_in_sld",
-		Description:   "DNSName MUST NOT contain underscore characters",
-		Citation:      "RFC5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewDNSNameUnderscoreInSLD,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rfc_dnsname_underscore_in_sld",
+			Description:   "DNSName MUST NOT contain underscore characters",
+			Citation:      "RFC5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewDNSNameUnderscoreInSLD,
 	})
 }
 

--- a/v3/lints/rfc/lint_dnsname_underscore_in_trd.go
+++ b/v3/lints/rfc/lint_dnsname_underscore_in_trd.go
@@ -25,13 +25,15 @@ import (
 type DNSNameUnderscoreInTRD struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_rfc_dnsname_underscore_in_trd",
-		Description:   "DNSName MUST NOT contain underscore characters",
-		Citation:      "RFC5280: 4.1.2.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewDNSNameUnderscoreInTRD,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_rfc_dnsname_underscore_in_trd",
+			Description:   "DNSName MUST NOT contain underscore characters",
+			Citation:      "RFC5280: 4.1.2.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewDNSNameUnderscoreInTRD,
 	})
 }
 

--- a/v3/lints/rfc/lint_ecdsa_allowed_ku.go
+++ b/v3/lints/rfc/lint_ecdsa_allowed_ku.go
@@ -40,13 +40,15 @@ If the keyUsage extension is present in a certificate that indicates
 ***********************************************
 */
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ecdsa_allowed_ku",
-		Description:   "Key usage values keyEncipherment or dataEncipherment MUST NOT be present in certificates with ECDSA public keys",
-		Citation:      "RFC 8813 Section 3",
-		Source:        lint.RFC8813,
-		EffectiveDate: util.RFC8813Date,
-		Lint:          NewEcdsaAllowedKU,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ecdsa_allowed_ku",
+			Description:   "Key usage values keyEncipherment or dataEncipherment MUST NOT be present in certificates with ECDSA public keys",
+			Citation:      "RFC 8813 Section 3",
+			Source:        lint.RFC8813,
+			EffectiveDate: util.RFC8813Date,
+		},
+		Lint: NewEcdsaAllowedKU,
 	})
 }
 

--- a/v3/lints/rfc/lint_ecdsa_ee_invalid_ku.go
+++ b/v3/lints/rfc/lint_ecdsa_ee_invalid_ku.go
@@ -27,13 +27,15 @@ import (
 type ecdsaInvalidKU struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "n_ecdsa_ee_invalid_ku",
-		Description:   "ECDSA end-entity certificates MAY have key usages: digitalSignature, nonRepudiation and keyAgreement",
-		Citation:      "RFC 5480 Section 3",
-		Source:        lint.RFC5480,
-		EffectiveDate: util.CABEffectiveDate,
-		Lint:          NewEcdsaInvalidKU,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "n_ecdsa_ee_invalid_ku",
+			Description:   "ECDSA end-entity certificates MAY have key usages: digitalSignature, nonRepudiation and keyAgreement",
+			Citation:      "RFC 5480 Section 3",
+			Source:        lint.RFC5480,
+			EffectiveDate: util.CABEffectiveDate,
+		},
+		Lint: NewEcdsaInvalidKU,
 	})
 }
 

--- a/v3/lints/rfc/lint_eku_critical_improperly.go
+++ b/v3/lints/rfc/lint_eku_critical_improperly.go
@@ -36,13 +36,15 @@ If a CA includes extended key usages to satisfy such applications,
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_eku_critical_improperly",
-		Description:   "Conforming CAs SHOULD NOT mark extended key usage extension as critical if the anyExtendedKeyUsage KeyPurposedID is present",
-		Citation:      "RFC 5280: 4.2.1.12",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewEkuBadCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_eku_critical_improperly",
+			Description:   "Conforming CAs SHOULD NOT mark extended key usage extension as critical if the anyExtendedKeyUsage KeyPurposedID is present",
+			Citation:      "RFC 5280: 4.2.1.12",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewEkuBadCritical,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_aia_access_location_missing.go
+++ b/v3/lints/rfc/lint_ext_aia_access_location_missing.go
@@ -36,13 +36,15 @@ An authorityInfoAccess extension may include multiple instances of
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_aia_access_location_missing",
-		Description:   "When the id-ad-caIssuers accessMethod is used, at least one instance SHOULD specify an accessLocation that is an HTTP or LDAP URI",
-		Citation:      "RFC 5280: 4.2.2.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewAiaNoHTTPorLDAP,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_aia_access_location_missing",
+			Description:   "When the id-ad-caIssuers accessMethod is used, at least one instance SHOULD specify an accessLocation that is an HTTP or LDAP URI",
+			Citation:      "RFC 5280: 4.2.2.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewAiaNoHTTPorLDAP,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_aia_marked_critical.go
+++ b/v3/lints/rfc/lint_ext_aia_marked_critical.go
@@ -29,13 +29,15 @@ Authority Information Access
 //See also: BRs: 7.1.2.3 & CAB: 7.1.2.2
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_aia_marked_critical",
-		Description:   "Conforming CAs must mark the Authority Information Access extension as non-critical",
-		Citation:      "RFC 5280: 4.2.2.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewExtAiaMarkedCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_aia_marked_critical",
+			Description:   "Conforming CAs must mark the Authority Information Access extension as non-critical",
+			Citation:      "RFC 5280: 4.2.2.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewExtAiaMarkedCritical,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_authority_key_identifier_critical.go
+++ b/v3/lints/rfc/lint_ext_authority_key_identifier_critical.go
@@ -28,13 +28,15 @@ Conforming CAs MUST mark this extension as non-critical.
 **********************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_authority_key_identifier_critical",
-		Description:   "The authority key identifier extension must be non-critical",
-		Citation:      "RFC 5280: 4.2.1.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewAuthorityKeyIdCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_authority_key_identifier_critical",
+			Description:   "The authority key identifier extension must be non-critical",
+			Citation:      "RFC 5280: 4.2.1.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewAuthorityKeyIdCritical,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_authority_key_identifier_no_key_identifier.go
+++ b/v3/lints/rfc/lint_ext_authority_key_identifier_no_key_identifier.go
@@ -38,13 +38,15 @@ The keyIdentifier field of the authorityKeyIdentifier extension MUST
 ***********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_authority_key_identifier_no_key_identifier",
-		Description:   "CAs must include keyIdentifer field of AKI in all non-self-issued certificates",
-		Citation:      "RFC 5280: 4.2.1.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewAuthorityKeyIdNoKeyIdField,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_authority_key_identifier_no_key_identifier",
+			Description:   "CAs must include keyIdentifer field of AKI in all non-self-issued certificates",
+			Citation:      "RFC 5280: 4.2.1.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewAuthorityKeyIdNoKeyIdField,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_cert_policy_contains_noticeref.go
+++ b/v3/lints/rfc/lint_ext_cert_policy_contains_noticeref.go
@@ -29,13 +29,15 @@ option.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_cert_policy_contains_noticeref",
-		Description:   "Compliant certificates SHOULD NOT use the noticeRef option",
-		Citation:      "RFC 5280: 4.2.1.4",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewNoticeRefPres,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_cert_policy_contains_noticeref",
+			Description:   "Compliant certificates SHOULD NOT use the noticeRef option",
+			Citation:      "RFC 5280: 4.2.1.4",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewNoticeRefPres,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_cert_policy_disallowed_any_policy_qualifier.go
+++ b/v3/lints/rfc/lint_ext_cert_policy_disallowed_any_policy_qualifier.go
@@ -42,13 +42,15 @@ qualifiers returned as a result of path validation are considered.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_cert_policy_disallowed_any_policy_qualifier",
-		Description:   "When qualifiers are used with the special policy anyPolicy, they must be limited to qualifiers identified in this section: (4.2.1.4)",
-		Citation:      "RFC 5280: 4.2.1.4",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewUnrecommendedQualifier,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_cert_policy_disallowed_any_policy_qualifier",
+			Description:   "When qualifiers are used with the special policy anyPolicy, they must be limited to qualifiers identified in this section: (4.2.1.4)",
+			Citation:      "RFC 5280: 4.2.1.4",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewUnrecommendedQualifier,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_cert_policy_duplicate.go
+++ b/v3/lints/rfc/lint_ext_cert_policy_duplicate.go
@@ -31,13 +31,15 @@ type ExtCertPolicyDuplicate struct{}
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_cert_policy_duplicate",
-		Description:   "A certificate policy OID must not appear more than once in the extension",
-		Citation:      "RFC 5280: 4.2.1.4",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewExtCertPolicyDuplicate,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_cert_policy_duplicate",
+			Description:   "A certificate policy OID must not appear more than once in the extension",
+			Citation:      "RFC 5280: 4.2.1.4",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewExtCertPolicyDuplicate,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_cert_policy_explicit_text_ia5_string.go
+++ b/v3/lints/rfc/lint_ext_cert_policy_explicit_text_ia5_string.go
@@ -37,13 +37,15 @@ to Unicode normalization form C (NFC) [NFC].
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_cert_policy_explicit_text_ia5_string",
-		Description:   "Compliant certificates must not encode explicitTest as an IA5String",
-		Citation:      "RFC 6818: 3",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC6818Date,
-		Lint:          NewExplicitTextIA5String,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_cert_policy_explicit_text_ia5_string",
+			Description:   "Compliant certificates must not encode explicitTest as an IA5String",
+			Citation:      "RFC 6818: 3",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC6818Date,
+		},
+		Lint: NewExplicitTextIA5String,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_cert_policy_explicit_text_includes_control.go
+++ b/v3/lints/rfc/lint_ext_cert_policy_explicit_text_includes_control.go
@@ -35,13 +35,15 @@ normalized according to Unicode normalization form C (NFC) [NFC].
 *********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_cert_policy_explicit_text_includes_control",
-		Description:   "Explicit text should not include any control characters",
-		Citation:      "RFC 6818: 3",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC6818Date,
-		Lint:          NewControlChar,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_cert_policy_explicit_text_includes_control",
+			Description:   "Explicit text should not include any control characters",
+			Citation:      "RFC 6818: 3",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC6818Date,
+		},
+		Lint: NewControlChar,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_cert_policy_explicit_text_not_nfc.go
+++ b/v3/lints/rfc/lint_ext_cert_policy_explicit_text_not_nfc.go
@@ -29,13 +29,15 @@ type ExtCertPolicyExplicitTextNotNFC struct{}
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_cert_policy_explicit_text_not_nfc",
-		Description:   "When utf8string or bmpstring encoding is used for explicitText field in certificate policy, it SHOULD be normalized by NFC format",
-		Citation:      "RFC6181 3",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC6818Date,
-		Lint:          NewExtCertPolicyExplicitTextNotNFC,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_cert_policy_explicit_text_not_nfc",
+			Description:   "When utf8string or bmpstring encoding is used for explicitText field in certificate policy, it SHOULD be normalized by NFC format",
+			Citation:      "RFC6181 3",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC6818Date,
+		},
+		Lint: NewExtCertPolicyExplicitTextNotNFC,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_cert_policy_explicit_text_not_utf8.go
+++ b/v3/lints/rfc/lint_ext_cert_policy_explicit_text_not_utf8.go
@@ -38,13 +38,15 @@ to Unicode normalization form C (NFC) [NFC].
 *******************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_cert_policy_explicit_text_not_utf8",
-		Description:   "Compliant certificates should use the utf8string encoding for explicitText",
-		Citation:      "RFC 6818: 3",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC6818Date,
-		Lint:          NewExplicitTextUtf8,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_cert_policy_explicit_text_not_utf8",
+			Description:   "Compliant certificates should use the utf8string encoding for explicitText",
+			Citation:      "RFC 6818: 3",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC6818Date,
+		},
+		Lint: NewExplicitTextUtf8,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_cert_policy_explicit_text_too_long.go
+++ b/v3/lints/rfc/lint_ext_cert_policy_explicit_text_too_long.go
@@ -36,13 +36,15 @@ to Unicode normalization form C (NFC) [NFC].
 *******************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_cert_policy_explicit_text_too_long",
-		Description:   "Explicit text has a maximum size of 200 characters",
-		Citation:      "RFC 6818: 3",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC6818Date,
-		Lint:          NewExplicitTextTooLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_cert_policy_explicit_text_too_long",
+			Description:   "Explicit text has a maximum size of 200 characters",
+			Citation:      "RFC 6818: 3",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC6818Date,
+		},
+		Lint: NewExplicitTextTooLong,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_crl_distribution_marked_critical.go
+++ b/v3/lints/rfc/lint_ext_crl_distribution_marked_critical.go
@@ -27,13 +27,15 @@ The CRL distribution points extension identifies how CRL information is obtained
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_crl_distribution_marked_critical",
-		Description:   "If included, the CRL Distribution Points extension SHOULD NOT be marked critical",
-		Citation:      "RFC 5280: 4.2.1.13",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewExtCrlDistributionMarkedCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_crl_distribution_marked_critical",
+			Description:   "If included, the CRL Distribution Points extension SHOULD NOT be marked critical",
+			Citation:      "RFC 5280: 4.2.1.13",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewExtCrlDistributionMarkedCritical,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_duplicate_extension.go
+++ b/v3/lints/rfc/lint_ext_duplicate_extension.go
@@ -30,13 +30,15 @@ type extDuplicateExtension struct{}
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_duplicate_extension",
-		Description:   "A certificate MUST NOT include more than one instance of a particular extension",
-		Citation:      "RFC 5280: 4.2",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewExtDuplicateExtension,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_duplicate_extension",
+			Description:   "A certificate MUST NOT include more than one instance of a particular extension",
+			Citation:      "RFC 5280: 4.2",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewExtDuplicateExtension,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_freshest_crl_marked_critical.go
+++ b/v3/lints/rfc/lint_ext_freshest_crl_marked_critical.go
@@ -28,13 +28,15 @@ The freshest CRL extension identifies how delta CRL information is obtained. The
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_freshest_crl_marked_critical",
-		Description:   "Freshest CRL MUST be marked as non-critical by conforming CAs",
-		Citation:      "RFC 5280: 4.2.1.15",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewExtFreshestCrlMarkedCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_freshest_crl_marked_critical",
+			Description:   "Freshest CRL MUST be marked as non-critical by conforming CAs",
+			Citation:      "RFC 5280: 4.2.1.15",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewExtFreshestCrlMarkedCritical,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_ian_critical.go
+++ b/v3/lints/rfc/lint_ext_ian_critical.go
@@ -29,13 +29,15 @@ Issuer Alternative Name
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_ian_critical",
-		Description:   "Issuer alternate name should be marked as non-critical",
-		Citation:      "RFC 5280: 4.2.1.7",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewExtIANCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_ian_critical",
+			Description:   "Issuer alternate name should be marked as non-critical",
+			Citation:      "RFC 5280: 4.2.1.7",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewExtIANCritical,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_ian_dns_not_ia5_string.go
+++ b/v3/lints/rfc/lint_ext_ian_dns_not_ia5_string.go
@@ -39,13 +39,15 @@ encoding internationalized domain names are specified in Section 7.2.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_ian_dns_not_ia5_string",
-		Description:   "DNSNames MUST be IA5 strings",
-		Citation:      "RFC 5280: 4.2.1.7",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewIANDNSNotIA5String,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_ian_dns_not_ia5_string",
+			Description:   "DNSNames MUST be IA5 strings",
+			Citation:      "RFC 5280: 4.2.1.7",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewIANDNSNotIA5String,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_ian_empty_name.go
+++ b/v3/lints/rfc/lint_ext_ian_empty_name.go
@@ -36,13 +36,15 @@ path is not defined by this profile.
 ******************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_ian_empty_name",
-		Description:   "General name fields must not be empty in IAN",
-		Citation:      "RFC 5280: 4.2.1.7",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewIANEmptyName,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_ian_empty_name",
+			Description:   "General name fields must not be empty in IAN",
+			Citation:      "RFC 5280: 4.2.1.7",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewIANEmptyName,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_ian_no_entries.go
+++ b/v3/lints/rfc/lint_ext_ian_no_entries.go
@@ -35,13 +35,15 @@ If the issuerAltName extension is present, the sequence MUST contain
 ***********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_ian_no_entries",
-		Description:   "If present, the IAN extension must contain at least one entry",
-		Citation:      "RFC 5280: 4.2.1.7",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewIANNoEntry,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_ian_no_entries",
+			Description:   "If present, the IAN extension must contain at least one entry",
+			Citation:      "RFC 5280: 4.2.1.7",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewIANNoEntry,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_ian_rfc822_format_invalid.go
+++ b/v3/lints/rfc/lint_ext_ian_rfc822_format_invalid.go
@@ -37,13 +37,15 @@ RFC 5280: 4.2.1.6
 ************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_ian_rfc822_format_invalid",
-		Description:   "Email must not be surrounded with `<>`, and there MUST NOT be trailing comments in `()`",
-		Citation:      "RFC 5280: 4.2.1.7",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewIANEmail,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_ian_rfc822_format_invalid",
+			Description:   "Email must not be surrounded with `<>`, and there MUST NOT be trailing comments in `()`",
+			Citation:      "RFC 5280: 4.2.1.7",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewIANEmail,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_ian_space_dns_name.go
+++ b/v3/lints/rfc/lint_ext_ian_space_dns_name.go
@@ -39,13 +39,15 @@ encoding internationalized domain names are specified in Section 7.2.
 **********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_ian_space_dns_name",
-		Description:   "dNSName ' ' MUST NOT be used",
-		Citation:      "RFC 5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewIANSpace,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_ian_space_dns_name",
+			Description:   "dNSName ' ' MUST NOT be used",
+			Citation:      "RFC 5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewIANSpace,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_ian_uri_format_invalid.go
+++ b/v3/lints/rfc/lint_ext_ian_uri_format_invalid.go
@@ -30,13 +30,15 @@ scheme (e.g., "http" or "ftp") and a scheme-specific-part.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_ian_uri_format_invalid",
-		Description:   "URIs in the subjectAltName extension MUST have a scheme and scheme specific part",
-		Citation:      "RFC5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewIANURIFormat,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_ian_uri_format_invalid",
+			Description:   "URIs in the subjectAltName extension MUST have a scheme and scheme specific part",
+			Citation:      "RFC5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewIANURIFormat,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_ian_uri_host_not_fqdn_or_ip.go
+++ b/v3/lints/rfc/lint_ext_ian_uri_host_not_fqdn_or_ip.go
@@ -37,13 +37,15 @@ Section 7.4.
 *********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_ian_uri_host_not_fqdn_or_ip",
-		Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host",
-		Citation:      "RFC 5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewIANURIFQDNOrIP,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_ian_uri_host_not_fqdn_or_ip",
+			Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host",
+			Citation:      "RFC 5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewIANURIFQDNOrIP,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_ian_uri_not_ia5.go
+++ b/v3/lints/rfc/lint_ext_ian_uri_not_ia5.go
@@ -30,13 +30,15 @@ stored in the uniformResourceIdentifier (an IA5String).
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_ian_uri_not_ia5",
-		Description:   "When issuer alternative name contains a URI, the name MUST be an IA5 string",
-		Citation:      "RFC5280: 4.2.1.7",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewIANURIIA5String,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_ian_uri_not_ia5",
+			Description:   "When issuer alternative name contains a URI, the name MUST be an IA5 string",
+			Citation:      "RFC5280: 4.2.1.7",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewIANURIIA5String,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_ian_uri_relative.go
+++ b/v3/lints/rfc/lint_ext_ian_uri_relative.go
@@ -37,13 +37,15 @@ Section 7.4.
 *************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_ian_uri_relative",
-		Description:   "When issuerAltName extension is present and the URI is used, the name MUST NOT be a relative URI",
-		Citation:      "RFC 5280: 4.2.1.7",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewUriRelative,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_ian_uri_relative",
+			Description:   "When issuerAltName extension is present and the URI is used, the name MUST NOT be a relative URI",
+			Citation:      "RFC 5280: 4.2.1.7",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewUriRelative,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_key_usage_cert_sign_without_ca.go
+++ b/v3/lints/rfc/lint_ext_key_usage_cert_sign_without_ca.go
@@ -34,13 +34,15 @@ The cA boolean indicates whether the certified public key may be used
 ************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_key_usage_cert_sign_without_ca",
-		Description:   "if the keyCertSign bit is asserted, then the cA bit in the basic constraints extension MUST also be asserted",
-		Citation:      "RFC 5280: 4.2.1.3 & 4.2.1.9",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewKeyUsageCertSignNoCa,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_key_usage_cert_sign_without_ca",
+			Description:   "if the keyCertSign bit is asserted, then the cA bit in the basic constraints extension MUST also be asserted",
+			Citation:      "RFC 5280: 4.2.1.3 & 4.2.1.9",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewKeyUsageCertSignNoCa,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_key_usage_not_critical.go
+++ b/v3/lints/rfc/lint_ext_key_usage_not_critical.go
@@ -25,13 +25,15 @@ type checkKeyUsageCritical struct{}
 // "When present, conforming CAs SHOULD mark this extension as critical."
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_key_usage_not_critical",
-		Description:   "The keyUsage extension SHOULD be critical",
-		Citation:      "RFC 5280: 4.2.1.3",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewCheckKeyUsageCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_key_usage_not_critical",
+			Description:   "The keyUsage extension SHOULD be critical",
+			Citation:      "RFC 5280: 4.2.1.3",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewCheckKeyUsageCritical,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_key_usage_without_bits.go
+++ b/v3/lints/rfc/lint_ext_key_usage_without_bits.go
@@ -32,13 +32,15 @@ type keyUsageBitsSet struct{}
 ***********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_key_usage_without_bits",
-		Description:   "When the keyUsage extension is included, at least one bit MUST be set to 1",
-		Citation:      "RFC 5280: 4.2.1.3",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewKeyUsageBitsSet,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_key_usage_without_bits",
+			Description:   "When the keyUsage extension is included, at least one bit MUST be set to 1",
+			Citation:      "RFC 5280: 4.2.1.3",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewKeyUsageBitsSet,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_name_constraints_not_critical.go
+++ b/v3/lints/rfc/lint_ext_name_constraints_not_critical.go
@@ -35,13 +35,15 @@ Restrictions are defined in terms of permitted or excluded name
 ************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_name_constraints_not_critical",
-		Description:   "If it is included, conforming CAs MUST mark the name constraints extension as critical",
-		Citation:      "RFC 5280: 4.2.1.10",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewNameConstraintCrit,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_name_constraints_not_critical",
+			Description:   "If it is included, conforming CAs MUST mark the name constraints extension as critical",
+			Citation:      "RFC 5280: 4.2.1.10",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewNameConstraintCrit,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_name_constraints_not_in_ca.go
+++ b/v3/lints/rfc/lint_ext_name_constraints_not_in_ca.go
@@ -34,13 +34,15 @@ The name constraints extension, which MUST be used only in a CA
 ***********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_name_constraints_not_in_ca",
-		Description:   "The name constraints extension MUST only be used in CA certificates",
-		Citation:      "RFC 5280: 4.2.1.10",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewNameConstraintNotCa,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_name_constraints_not_in_ca",
+			Description:   "The name constraints extension MUST only be used in CA certificates",
+			Citation:      "RFC 5280: 4.2.1.10",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewNameConstraintNotCa,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_policy_constraints_empty.go
+++ b/v3/lints/rfc/lint_ext_policy_constraints_empty.go
@@ -33,13 +33,15 @@ Conforming CAs MUST NOT issue certificates where policy constraints
 *************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_policy_constraints_empty",
-		Description:   "Conforming CAs MUST NOT issue certificates where policy constraints is an empty sequence. That is, either the inhibitPolicyMapping field or the requireExplicityPolicy field MUST be present",
-		Citation:      "RFC 5280: 4.2.1.11",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewPolicyConstraintsContents,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_policy_constraints_empty",
+			Description:   "Conforming CAs MUST NOT issue certificates where policy constraints is an empty sequence. That is, either the inhibitPolicyMapping field or the requireExplicityPolicy field MUST be present",
+			Citation:      "RFC 5280: 4.2.1.11",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewPolicyConstraintsContents,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_policy_constraints_not_critical.go
+++ b/v3/lints/rfc/lint_ext_policy_constraints_not_critical.go
@@ -28,13 +28,15 @@ Conforming CAs MUST mark this extension as critical.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_policy_constraints_not_critical",
-		Description:   "Conforming CAs MUST mark the policy constraints extension as critical",
-		Citation:      "RFC 5280: 4.2.1.11",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewPolicyConstraintsCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_policy_constraints_not_critical",
+			Description:   "Conforming CAs MUST mark the policy constraints extension as critical",
+			Citation:      "RFC 5280: 4.2.1.11",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewPolicyConstraintsCritical,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_policy_map_any_policy.go
+++ b/v3/lints/rfc/lint_ext_policy_map_any_policy.go
@@ -31,13 +31,15 @@ Each issuerDomainPolicy named in the policy mappings extension SHOULD
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_policy_map_any_policy",
-		Description:   "Policies must not be mapped to or from the anyPolicy value",
-		Citation:      "RFC 5280: 4.2.1.5",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewPolicyMapAnyPolicy,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_policy_map_any_policy",
+			Description:   "Policies must not be mapped to or from the anyPolicy value",
+			Citation:      "RFC 5280: 4.2.1.5",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewPolicyMapAnyPolicy,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_policy_map_not_critical.go
+++ b/v3/lints/rfc/lint_ext_policy_map_not_critical.go
@@ -29,13 +29,15 @@ This extension MAY be supported by CAs and/or applications.
 **********************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_policy_map_not_critical",
-		Description:   "Policy mappings should be marked as critical",
-		Citation:      "RFC 5280: 4.2.1.5",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewPolicyMapCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_policy_map_not_critical",
+			Description:   "Policy mappings should be marked as critical",
+			Citation:      "RFC 5280: 4.2.1.5",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewPolicyMapCritical,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_policy_map_not_in_cert_policy.go
+++ b/v3/lints/rfc/lint_ext_policy_map_not_in_cert_policy.go
@@ -31,13 +31,15 @@ Each issuerDomainPolicy named in the policy mapping extension SHOULD
 *********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_policy_map_not_in_cert_policy",
-		Description:   "Each issuerDomainPolicy named in the policy mappings extension should also be asserted in a certificate policies extension",
-		Citation:      "RFC 5280: 4.2.1.5",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewPolicyMapMatchesCertPolicy,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_policy_map_not_in_cert_policy",
+			Description:   "Each issuerDomainPolicy named in the policy mappings extension should also be asserted in a certificate policies extension",
+			Citation:      "RFC 5280: 4.2.1.5",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewPolicyMapMatchesCertPolicy,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_san_dns_name_too_long.go
+++ b/v3/lints/rfc/lint_ext_san_dns_name_too_long.go
@@ -23,13 +23,15 @@ import (
 type SANDNSTooLong struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_dns_name_too_long",
-		Description:   "DNSName must be less than or equal to 253 bytes",
-		Citation:      "RFC 5280",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewSANDNSTooLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_dns_name_too_long",
+			Description:   "DNSName must be less than or equal to 253 bytes",
+			Citation:      "RFC 5280",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewSANDNSTooLong,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_san_dns_not_ia5_string.go
+++ b/v3/lints/rfc/lint_ext_san_dns_not_ia5_string.go
@@ -39,13 +39,15 @@ encoding internationalized domain names are specified in Section 7.2.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_dns_not_ia5_string",
-		Description:   "dNSNames MUST be IA5 strings",
-		Citation:      "RFC 5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSANDNSNotIA5String,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_dns_not_ia5_string",
+			Description:   "dNSNames MUST be IA5 strings",
+			Citation:      "RFC 5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSANDNSNotIA5String,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_san_empty_name.go
+++ b/v3/lints/rfc/lint_ext_san_empty_name.go
@@ -36,13 +36,15 @@ path is not defined by this profile.
 ******************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_empty_name",
-		Description:   "General name fields MUST NOT be empty in subjectAlternateNames",
-		Citation:      "RFC 5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSANEmptyName,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_empty_name",
+			Description:   "General name fields MUST NOT be empty in subjectAlternateNames",
+			Citation:      "RFC 5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSANEmptyName,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_san_no_entries.go
+++ b/v3/lints/rfc/lint_ext_san_no_entries.go
@@ -35,13 +35,15 @@ If the subjectAltName extension is present, the sequence MUST contain
 ***********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_no_entries",
-		Description:   "If present, the SAN extension MUST contain at least one entry",
-		Citation:      "RFC 5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSANNoEntry,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_no_entries",
+			Description:   "If present, the SAN extension MUST contain at least one entry",
+			Citation:      "RFC 5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSANNoEntry,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_san_not_critical_without_subject.go
+++ b/v3/lints/rfc/lint_ext_san_not_critical_without_subject.go
@@ -36,13 +36,15 @@ Further, if the only subject identity included in the certificate is
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_not_critical_without_subject",
-		Description:   "If there is an empty subject field, then the SAN extension MUST be critical",
-		Citation:      "RFC 5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewExtSANNotCritNoSubject,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_not_critical_without_subject",
+			Description:   "If there is an empty subject field, then the SAN extension MUST be critical",
+			Citation:      "RFC 5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewExtSANNotCritNoSubject,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_san_rfc822_format_invalid.go
+++ b/v3/lints/rfc/lint_ext_san_rfc822_format_invalid.go
@@ -37,13 +37,15 @@ RFC 5280: 4.2.1.6
 ************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_rfc822_format_invalid",
-		Description:   "Email MUST NOT be surrounded with `<>`, and there must be no trailing comments in `()`",
-		Citation:      "RFC 5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewInvalidEmail,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_rfc822_format_invalid",
+			Description:   "Email MUST NOT be surrounded with `<>`, and there must be no trailing comments in `()`",
+			Citation:      "RFC 5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewInvalidEmail,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_san_space_dns_name.go
+++ b/v3/lints/rfc/lint_ext_san_space_dns_name.go
@@ -39,13 +39,15 @@ When the subjectAltName extension contains a domain name system
 ************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_space_dns_name",
-		Description:   "The dNSName ` ` MUST NOT be used",
-		Citation:      "RFC 5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSANIsSpaceDNS,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_space_dns_name",
+			Description:   "The dNSName ` ` MUST NOT be used",
+			Citation:      "RFC 5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSANIsSpaceDNS,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_san_uri_format_invalid.go
+++ b/v3/lints/rfc/lint_ext_san_uri_format_invalid.go
@@ -30,13 +30,15 @@ scheme (e.g., "http" or "ftp") and a scheme-specific-part.
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_uri_format_invalid",
-		Description:   "URIs in SAN extension must have a scheme and scheme specific part",
-		Citation:      "RFC5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewExtSANURIFormatInvalid,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_uri_format_invalid",
+			Description:   "URIs in SAN extension must have a scheme and scheme specific part",
+			Citation:      "RFC5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewExtSANURIFormatInvalid,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_san_uri_host_not_fqdn_or_ip.go
+++ b/v3/lints/rfc/lint_ext_san_uri_host_not_fqdn_or_ip.go
@@ -37,13 +37,15 @@ Section 7.4.
 *********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_uri_host_not_fqdn_or_ip",
-		Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host",
-		Citation:      "RFC 5280: 4.2.1.7",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewSANURIHost,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_uri_host_not_fqdn_or_ip",
+			Description:   "URIs that include an authority ([RFC3986], Section 3.2) MUST include a fully qualified domain name or IP address as the host",
+			Citation:      "RFC 5280: 4.2.1.7",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewSANURIHost,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_san_uri_not_ia5.go
+++ b/v3/lints/rfc/lint_ext_san_uri_not_ia5.go
@@ -30,13 +30,15 @@ stored in the uniformResourceIdentifier (an IA5String).
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_uri_not_ia5",
-		Description:   "When subjectAlternateName contains a URI, the name MUST be an IA5 string",
-		Citation:      "RFC5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewExtSANURINotIA5,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_uri_not_ia5",
+			Description:   "When subjectAlternateName contains a URI, the name MUST be an IA5 string",
+			Citation:      "RFC5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewExtSANURINotIA5,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_san_uri_relative.go
+++ b/v3/lints/rfc/lint_ext_san_uri_relative.go
@@ -37,13 +37,15 @@ Section 7.4.
 *************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_san_uri_relative",
-		Description:   "When the subjectAlternateName extension is present and a URI is used, the name MUST NOT be a relative URI",
-		Citation:      "RFC 5280: 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewExtSANURIRelative,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_san_uri_relative",
+			Description:   "When the subjectAlternateName extension is present and a URI is used, the name MUST NOT be a relative URI",
+			Citation:      "RFC 5280: 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewExtSANURIRelative,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_subject_directory_attr_critical.go
+++ b/v3/lints/rfc/lint_ext_subject_directory_attr_critical.go
@@ -31,13 +31,15 @@ The subject directory attributes extension is used to convey
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_subject_directory_attr_critical",
-		Description:   "Conforming CAs MUST mark the Subject Directory Attributes extension as not critical",
-		Citation:      "RFC 5280: 4.2.1.8",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubDirAttrCrit,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_subject_directory_attr_critical",
+			Description:   "Conforming CAs MUST mark the Subject Directory Attributes extension as not critical",
+			Citation:      "RFC 5280: 4.2.1.8",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubDirAttrCrit,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_subject_key_identifier_critical.go
+++ b/v3/lints/rfc/lint_ext_subject_key_identifier_critical.go
@@ -28,13 +28,15 @@ RFC 5280: 4.2.1.2
 **********************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_subject_key_identifier_critical",
-		Description:   "The subject key identifier extension MUST be non-critical",
-		Citation:      "RFC 5280: 4.2.1.2",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectKeyIdCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_subject_key_identifier_critical",
+			Description:   "The subject key identifier extension MUST be non-critical",
+			Citation:      "RFC 5280: 4.2.1.2",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectKeyIdCritical,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_subject_key_identifier_missing_ca.go
+++ b/v3/lints/rfc/lint_ext_subject_key_identifier_missing_ca.go
@@ -43,13 +43,15 @@ type subjectKeyIdMissingCA struct{}
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_ext_subject_key_identifier_missing_ca",
-		Description:   "CAs MUST include a Subject Key Identifier in all CA certificates",
-		Citation:      "RFC 5280: 4.2 & 4.2.1.2",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectKeyIdMissingCA,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_ext_subject_key_identifier_missing_ca",
+			Description:   "CAs MUST include a Subject Key Identifier in all CA certificates",
+			Citation:      "RFC 5280: 4.2 & 4.2.1.2",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectKeyIdMissingCA,
 	})
 }
 

--- a/v3/lints/rfc/lint_ext_subject_key_identifier_missing_sub_cert.go
+++ b/v3/lints/rfc/lint_ext_subject_key_identifier_missing_sub_cert.go
@@ -43,13 +43,15 @@ type subjectKeyIdMissingSubscriber struct{}
 **********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_ext_subject_key_identifier_missing_sub_cert",
-		Description:   "Sub certificates SHOULD include Subject Key Identifier in end entity certs",
-		Citation:      "RFC 5280: 4.2 & 4.2.1.2",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectKeyIdMissingSubscriber,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_subject_key_identifier_missing_sub_cert",
+			Description:   "Sub certificates SHOULD include Subject Key Identifier in end entity certs",
+			Citation:      "RFC 5280: 4.2 & 4.2.1.2",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectKeyIdMissingSubscriber,
 	})
 }
 

--- a/v3/lints/rfc/lint_generalized_time_does_not_include_seconds.go
+++ b/v3/lints/rfc/lint_generalized_time_does_not_include_seconds.go
@@ -38,13 +38,15 @@ is zero.  GeneralizedTime values MUST NOT include fractional seconds.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_generalized_time_does_not_include_seconds",
-		Description:   "Generalized time values MUST include seconds",
-		Citation:      "RFC 5280: 4.1.2.5.2",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewGeneralizedNoSeconds,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_generalized_time_does_not_include_seconds",
+			Description:   "Generalized time values MUST include seconds",
+			Citation:      "RFC 5280: 4.1.2.5.2",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewGeneralizedNoSeconds,
 	})
 }
 

--- a/v3/lints/rfc/lint_generalized_time_includes_fraction_seconds.go
+++ b/v3/lints/rfc/lint_generalized_time_includes_fraction_seconds.go
@@ -38,13 +38,15 @@ is zero.  GeneralizedTime values MUST NOT include fractional seconds.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_generalized_time_includes_fraction_seconds",
-		Description:   "Generalized time values MUST NOT include fractional seconds",
-		Citation:      "RFC 5280: 4.1.2.5.2",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewGeneralizedTimeFraction,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_generalized_time_includes_fraction_seconds",
+			Description:   "Generalized time values MUST NOT include fractional seconds",
+			Citation:      "RFC 5280: 4.1.2.5.2",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewGeneralizedTimeFraction,
 	})
 }
 

--- a/v3/lints/rfc/lint_generalized_time_not_in_zulu.go
+++ b/v3/lints/rfc/lint_generalized_time_not_in_zulu.go
@@ -37,13 +37,15 @@ is zero.  GeneralizedTime values MUST NOT include fractional seconds.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_generalized_time_not_in_zulu",
-		Description:   "Generalized time values MUST be expressed in Greenwich Mean Time (Zulu)",
-		Citation:      "RFC 5280: 4.1.2.5.2",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewGeneralizedNotZulu,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_generalized_time_not_in_zulu",
+			Description:   "Generalized time values MUST be expressed in Greenwich Mean Time (Zulu)",
+			Citation:      "RFC 5280: 4.1.2.5.2",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewGeneralizedNotZulu,
 	})
 }
 

--- a/v3/lints/rfc/lint_idn_dnsname_malformed_unicode.go
+++ b/v3/lints/rfc/lint_idn_dnsname_malformed_unicode.go
@@ -25,13 +25,15 @@ import (
 type IDNMalformedUnicode struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_international_dns_name_not_unicode",
-		Description:   "Internationalized DNSNames punycode not valid Unicode",
-		Citation:      "RFC 3490",
-		EffectiveDate: util.RFC3490Date,
-		Source:        lint.RFC5280,
-		Lint:          NewIDNMalformedUnicode,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_international_dns_name_not_unicode",
+			Description:   "Internationalized DNSNames punycode not valid Unicode",
+			Citation:      "RFC 3490",
+			EffectiveDate: util.RFC3490Date,
+			Source:        lint.RFC5280,
+		},
+		Lint: NewIDNMalformedUnicode,
 	})
 }
 

--- a/v3/lints/rfc/lint_idn_dnsname_must_be_nfc.go
+++ b/v3/lints/rfc/lint_idn_dnsname_must_be_nfc.go
@@ -26,13 +26,15 @@ import (
 type IDNNotNFC struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_international_dns_name_not_nfc",
-		Description:   "Internationalized DNSNames must be normalized by Unicode normalization form C",
-		Citation:      "RFC 8399",
-		Source:        lint.RFC5891,
-		EffectiveDate: util.RFC8399Date,
-		Lint:          NewIDNNotNFC,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_international_dns_name_not_nfc",
+			Description:   "Internationalized DNSNames must be normalized by Unicode normalization form C",
+			Citation:      "RFC 8399",
+			Source:        lint.RFC5891,
+			EffectiveDate: util.RFC8399Date,
+		},
+		Lint: NewIDNNotNFC,
 	})
 }
 

--- a/v3/lints/rfc/lint_incorrect_ku_encoding.go
+++ b/v3/lints/rfc/lint_incorrect_ku_encoding.go
@@ -25,13 +25,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_incorrect_ku_encoding",
-		Description:   "RFC 5280 Section 4.2.1.3 describes the value of a KeyUsage to be a DER encoded BitString, which itself defines that all trailing 0 bits be counted as being \"unused\".",
-		Citation:      "Where ITU-T Rec. X.680 | ISO/IEC 8824-1, 21.7, applies, the bitstring shall have all trailing 0 bits removed before it is encoded.",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.ZeroDate,
-		Lint:          func() lint.LintInterface { return &incorrectKuEncoding{} },
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_incorrect_ku_encoding",
+			Description:   "RFC 5280 Section 4.2.1.3 describes the value of a KeyUsage to be a DER encoded BitString, which itself defines that all trailing 0 bits be counted as being \"unused\".",
+			Citation:      "Where ITU-T Rec. X.680 | ISO/IEC 8824-1, 21.7, applies, the bitstring shall have all trailing 0 bits removed before it is encoded.",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: func() lint.LintInterface { return &incorrectKuEncoding{} },
 	})
 }
 

--- a/v3/lints/rfc/lint_inhibit_any_policy_not_critical.go
+++ b/v3/lints/rfc/lint_inhibit_any_policy_not_critical.go
@@ -38,13 +38,15 @@ type InhibitAnyPolicyNotCritical struct{}
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_inhibit_any_policy_not_critical",
-		Description:   "CAs MUST mark the inhibitAnyPolicy extension as critical",
-		Citation:      "RFC 5280: 4.2.1.14",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewInhibitAnyPolicyNotCritical,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_inhibit_any_policy_not_critical",
+			Description:   "CAs MUST mark the inhibitAnyPolicy extension as critical",
+			Citation:      "RFC 5280: 4.2.1.14",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewInhibitAnyPolicyNotCritical,
 	})
 }
 

--- a/v3/lints/rfc/lint_issuer_dn_country_not_printable_string.go
+++ b/v3/lints/rfc/lint_issuer_dn_country_not_printable_string.go
@@ -24,13 +24,15 @@ import (
 type IssuerDNCountryNotPrintableString struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_issuer_dn_country_not_printable_string",
-		Description:   "X520 Distinguished Name Country MUST BE encoded as PrintableString",
-		Citation:      "RFC 5280: Appendix A",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewIssuerDNCountryNotPrintableString,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_issuer_dn_country_not_printable_string",
+			Description:   "X520 Distinguished Name Country MUST BE encoded as PrintableString",
+			Citation:      "RFC 5280: Appendix A",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewIssuerDNCountryNotPrintableString,
 	})
 }
 

--- a/v3/lints/rfc/lint_issuer_field_empty.go
+++ b/v3/lints/rfc/lint_issuer_field_empty.go
@@ -31,13 +31,15 @@ The issuer field identifies the entity that has signed and issued the
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_issuer_field_empty",
-		Description:   "Certificate issuer field MUST NOT be empty and must have a non-empty distinguished name",
-		Citation:      "RFC 5280: 4.1.2.4",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewIssuerFieldEmpty,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_issuer_field_empty",
+			Description:   "Certificate issuer field MUST NOT be empty and must have a non-empty distinguished name",
+			Citation:      "RFC 5280: 4.1.2.4",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewIssuerFieldEmpty,
 	})
 }
 

--- a/v3/lints/rfc/lint_key_usage_and_extended_key_usage_inconsistent.go
+++ b/v3/lints/rfc/lint_key_usage_and_extended_key_usage_inconsistent.go
@@ -26,13 +26,15 @@ import (
 type KUAndEKUInconsistent struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_key_usage_and_extended_key_usage_inconsistent",
-		Description:   "The certificate MUST only be used for a purpose consistent with both key usage extension and extended key usage extension.",
-		Citation:      "RFC 5280, Section 4.2.1.12.",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewKUAndEKUInconsistent,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_key_usage_and_extended_key_usage_inconsistent",
+			Description:   "The certificate MUST only be used for a purpose consistent with both key usage extension and extended key usage extension.",
+			Citation:      "RFC 5280, Section 4.2.1.12.",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewKUAndEKUInconsistent,
 	})
 }
 

--- a/v3/lints/rfc/lint_key_usage_incorrect_length.go
+++ b/v3/lints/rfc/lint_key_usage_incorrect_length.go
@@ -29,13 +29,15 @@ import (
 type keyUsageIncorrectLength struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_key_usage_incorrect_length",
-		Description:   "The key usage is a bit string with exactly nine possible flags",
-		Citation:      "RFC 5280: 4.2.1.3",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewKeyUsageIncorrectLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_key_usage_incorrect_length",
+			Description:   "The key usage is a bit string with exactly nine possible flags",
+			Citation:      "RFC 5280: 4.2.1.3",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewKeyUsageIncorrectLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_name_constraint_empty.go
+++ b/v3/lints/rfc/lint_name_constraint_empty.go
@@ -36,13 +36,15 @@ type nameConstraintEmpty struct{}
 ************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_name_constraint_empty",
-		Description:   "Conforming CAs MUST NOT issue certificates where name constraints is an empty sequence. That is, either the permittedSubtree or excludedSubtree fields must be present",
-		Citation:      "RFC 5280: 4.2.1.10",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewNameConstraintEmpty,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_name_constraint_empty",
+			Description:   "Conforming CAs MUST NOT issue certificates where name constraints is an empty sequence. That is, either the permittedSubtree or excludedSubtree fields must be present",
+			Citation:      "RFC 5280: 4.2.1.10",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewNameConstraintEmpty,
 	})
 }
 

--- a/v3/lints/rfc/lint_name_constraint_maximum_not_absent.go
+++ b/v3/lints/rfc/lint_name_constraint_maximum_not_absent.go
@@ -34,13 +34,15 @@ certificate.
 ************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_name_constraint_maximum_not_absent",
-		Description:   "Within the name constraints name form, the maximum field is not used and therefore MUST be absent",
-		Citation:      "RFC 5280: 4.2.1.10",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewNameConstraintMax,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_name_constraint_maximum_not_absent",
+			Description:   "Within the name constraints name form, the maximum field is not used and therefore MUST be absent",
+			Citation:      "RFC 5280: 4.2.1.10",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewNameConstraintMax,
 	})
 }
 

--- a/v3/lints/rfc/lint_name_constraint_minimum_non_zero.go
+++ b/v3/lints/rfc/lint_name_constraint_minimum_non_zero.go
@@ -34,13 +34,15 @@ certificate.
 ************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_name_constraint_minimum_non_zero",
-		Description:   "Within the name constraints name forms, the minimum field is not used and therefore MUST be zero",
-		Citation:      "RFC 5280: 4.2.1.10",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewNameConstMin,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_name_constraint_minimum_non_zero",
+			Description:   "Within the name constraints name forms, the minimum field is not used and therefore MUST be zero",
+			Citation:      "RFC 5280: 4.2.1.10",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewNameConstMin,
 	})
 }
 

--- a/v3/lints/rfc/lint_name_constraint_not_fqdn.go
+++ b/v3/lints/rfc/lint_name_constraint_not_fqdn.go
@@ -37,13 +37,15 @@ type nameConstraintNotFQDN struct{}
 ************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_name_constraint_not_fqdn",
-		Description:   "For URIs, the constraint MUST be specified as a fully qualified domain name [...] When the constraint begins with a period, it MAY be expanded with one or more labels.",
-		Citation:      "RFC 5280: 4.2.1.10",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewNameConstraintNotFQDN,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_name_constraint_not_fqdn",
+			Description:   "For URIs, the constraint MUST be specified as a fully qualified domain name [...] When the constraint begins with a period, it MAY be expanded with one or more labels.",
+			Citation:      "RFC 5280: 4.2.1.10",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewNameConstraintNotFQDN,
 	})
 }
 

--- a/v3/lints/rfc/lint_name_constraint_on_edi_party_name.go
+++ b/v3/lints/rfc/lint_name_constraint_on_edi_party_name.go
@@ -36,13 +36,15 @@ be present.
 *******************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_name_constraint_on_edi_party_name",
-		Description:   "The name constraints extension SHOULD NOT impose constraints on the ediPartyName name form",
-		Citation:      "RFC 5280: 4.2.1.10",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewNameConstraintOnEDI,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_name_constraint_on_edi_party_name",
+			Description:   "The name constraints extension SHOULD NOT impose constraints on the ediPartyName name form",
+			Citation:      "RFC 5280: 4.2.1.10",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewNameConstraintOnEDI,
 	})
 }
 

--- a/v3/lints/rfc/lint_name_constraint_on_registered_id.go
+++ b/v3/lints/rfc/lint_name_constraint_on_registered_id.go
@@ -36,13 +36,15 @@ be present.
 *******************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_name_constraint_on_registered_id",
-		Description:   "The name constraints extension SHOULD NOT impose constraints on the registeredID name form",
-		Citation:      "RFC 5280: 4.2.1.10",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewNameConstraintOnRegisteredId,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_name_constraint_on_registered_id",
+			Description:   "The name constraints extension SHOULD NOT impose constraints on the registeredID name form",
+			Citation:      "RFC 5280: 4.2.1.10",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewNameConstraintOnRegisteredId,
 	})
 }
 

--- a/v3/lints/rfc/lint_name_constraint_on_x400.go
+++ b/v3/lints/rfc/lint_name_constraint_on_x400.go
@@ -36,13 +36,15 @@ be present.
 *******************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "w_name_constraint_on_x400",
-		Description:   "The name constraints extension SHOULD NOT impose constraints on the x400Address name form",
-		Citation:      "RFC 5280: 4.2.1.10",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewNameConstraintOnX400,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_name_constraint_on_x400",
+			Description:   "The name constraints extension SHOULD NOT impose constraints on the x400Address name form",
+			Citation:      "RFC 5280: 4.2.1.10",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewNameConstraintOnX400,
 	})
 }
 

--- a/v3/lints/rfc/lint_path_len_constraint_improperly_included.go
+++ b/v3/lints/rfc/lint_path_len_constraint_improperly_included.go
@@ -31,13 +31,15 @@ keyCertSign bit.
 ******************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_path_len_constraint_improperly_included",
-		Description:   "CAs MUST NOT include the pathLenConstraint field unless the CA boolean is asserted and the keyCertSign bit is set",
-		Citation:      "RFC 5280: 4.2.1.9",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewPathLenIncluded,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_path_len_constraint_improperly_included",
+			Description:   "CAs MUST NOT include the pathLenConstraint field unless the CA boolean is asserted and the keyCertSign bit is set",
+			Citation:      "RFC 5280: 4.2.1.9",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewPathLenIncluded,
 	})
 }
 

--- a/v3/lints/rfc/lint_path_len_constraint_zero_or_less.go
+++ b/v3/lints/rfc/lint_path_len_constraint_zero_or_less.go
@@ -46,13 +46,15 @@ not appear, no limit is imposed.
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_path_len_constraint_zero_or_less",
-		Description:   "Where it appears, the pathLenConstraint field MUST be greater than or equal to zero",
-		Citation:      "RFC 5280: 4.2.1.9",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewPathLenNonPositive,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_path_len_constraint_zero_or_less",
+			Description:   "Where it appears, the pathLenConstraint field MUST be greater than or equal to zero",
+			Citation:      "RFC 5280: 4.2.1.9",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewPathLenNonPositive,
 	})
 }
 

--- a/v3/lints/rfc/lint_rsa_allowed_ku_ca.go
+++ b/v3/lints/rfc/lint_rsa_allowed_ku_ca.go
@@ -41,13 +41,15 @@ RFC 3279: 2.3.1  RSA Keys
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rsa_allowed_ku_ca",
-		Description:   "Key usage values digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment, keyCertSign, and cRLSign may only be present in a CA certificate with an RSA key",
-		Citation:      "RFC 3279: 2.3.1",
-		Source:        lint.RFC3279,
-		EffectiveDate: util.RFC3279Date,
-		Lint:          NewRsaAllowedKUCa,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rsa_allowed_ku_ca",
+			Description:   "Key usage values digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment, keyCertSign, and cRLSign may only be present in a CA certificate with an RSA key",
+			Citation:      "RFC 3279: 2.3.1",
+			Source:        lint.RFC3279,
+			EffectiveDate: util.RFC3279Date,
+		},
+		Lint: NewRsaAllowedKUCa,
 	})
 }
 

--- a/v3/lints/rfc/lint_rsa_allowed_ku_ee.go
+++ b/v3/lints/rfc/lint_rsa_allowed_ku_ee.go
@@ -39,13 +39,15 @@ RFC 3279: 2.3.1  RSA Keys
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rsa_allowed_ku_ee",
-		Description:   "Key usage values digitalSignature, nonRepudiation, keyEncipherment, and dataEncipherment may only be present in an end entity certificate with an RSA key",
-		Citation:      "RFC 3279: 2.3.1",
-		Source:        lint.RFC3279,
-		EffectiveDate: util.RFC3279Date,
-		Lint:          NewRsaAllowedKUEe,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rsa_allowed_ku_ee",
+			Description:   "Key usage values digitalSignature, nonRepudiation, keyEncipherment, and dataEncipherment may only be present in an end entity certificate with an RSA key",
+			Citation:      "RFC 3279: 2.3.1",
+			Source:        lint.RFC3279,
+			EffectiveDate: util.RFC3279Date,
+		},
+		Lint: NewRsaAllowedKUEe,
 	})
 }
 

--- a/v3/lints/rfc/lint_rsa_allowed_ku_no_encipherment_ca.go
+++ b/v3/lints/rfc/lint_rsa_allowed_ku_no_encipherment_ca.go
@@ -41,13 +41,15 @@ RFC 3279: 2.3.1  RSA Keys
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_rsa_allowed_ku_no_encipherment_ca",
-		Description:   "If Key usage value keyCertSign or cRLSign is present in a CA certificate both keyEncipherment and dataEncipherment SHOULD NOT be present",
-		Citation:      "RFC 3279: 2.3.1",
-		Source:        lint.RFC3279,
-		EffectiveDate: util.RFC3279Date,
-		Lint:          NewRsaAllowedKUCaNoEncipherment,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_rsa_allowed_ku_no_encipherment_ca",
+			Description:   "If Key usage value keyCertSign or cRLSign is present in a CA certificate both keyEncipherment and dataEncipherment SHOULD NOT be present",
+			Citation:      "RFC 3279: 2.3.1",
+			Source:        lint.RFC3279,
+			EffectiveDate: util.RFC3279Date,
+		},
+		Lint: NewRsaAllowedKUCaNoEncipherment,
 	})
 }
 

--- a/v3/lints/rfc/lint_serial_number_longer_than_20_octets.go
+++ b/v3/lints/rfc/lint_serial_number_longer_than_20_octets.go
@@ -43,13 +43,15 @@ RFC 5280: 4.1.2.2.  Serial Number
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_serial_number_longer_than_20_octets",
-		Description:   "Certificates must not have a DER encoded serial number longer than 20 octets",
-		Citation:      "RFC 5280: 4.1.2.2",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewSerialNumberTooLong,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_serial_number_longer_than_20_octets",
+			Description:   "Certificates must not have a DER encoded serial number longer than 20 octets",
+			Citation:      "RFC 5280: 4.1.2.2",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewSerialNumberTooLong,
 	})
 }
 

--- a/v3/lints/rfc/lint_serial_number_not_positive.go
+++ b/v3/lints/rfc/lint_serial_number_not_positive.go
@@ -40,13 +40,15 @@ type SerialNumberNotPositive struct{}
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_serial_number_not_positive",
-		Description:   "Certificates must have a positive serial number",
-		Citation:      "RFC 5280: 4.1.2.2",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewSerialNumberNotPositive,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_serial_number_not_positive",
+			Description:   "Certificates must have a positive serial number",
+			Citation:      "RFC 5280: 4.1.2.2",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewSerialNumberNotPositive,
 	})
 }
 

--- a/v3/lints/rfc/lint_spki_rsa_encryption_parameter_not_null.go
+++ b/v3/lints/rfc/lint_spki_rsa_encryption_parameter_not_null.go
@@ -30,13 +30,15 @@ RSA: Encoded algorithm identifier MUST have NULL parameters.
 *******************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_spki_rsa_encryption_parameter_not_null",
-		Description:   "RSA: Encoded public key algorithm identifier MUST have NULL parameters",
-		Citation:      "RFC 4055, Section 1.2",
-		Source:        lint.RFC5280, // RFC4055 is referenced in lint.RFC5280, Section 1
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewRsaSPKIEncryptionParamNotNULL,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_spki_rsa_encryption_parameter_not_null",
+			Description:   "RSA: Encoded public key algorithm identifier MUST have NULL parameters",
+			Citation:      "RFC 4055, Section 1.2",
+			Source:        lint.RFC5280, // RFC4055 is referenced in lint.RFC5280, Section 1
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewRsaSPKIEncryptionParamNotNULL,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_common_name_max_length.go
+++ b/v3/lints/rfc/lint_subject_common_name_max_length.go
@@ -32,13 +32,15 @@ RFC 5280: A.1
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_common_name_max_length",
-		Description:   "The commonName field of the subject MUST be less than 65 characters",
-		Citation:      "RFC 5280: A.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectCommonNameMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_common_name_max_length",
+			Description:   "The commonName field of the subject MUST be less than 65 characters",
+			Citation:      "RFC 5280: A.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectCommonNameMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_dn_country_not_printable_string.go
+++ b/v3/lints/rfc/lint_subject_dn_country_not_printable_string.go
@@ -24,13 +24,15 @@ import (
 type SubjectDNCountryNotPrintableString struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_dn_country_not_printable_string",
-		Description:   "X520 Distinguished Name Country MUST be encoded as PrintableString",
-		Citation:      "RFC 5280: Appendix A",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSubjectDNCountryNotPrintableString,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_dn_country_not_printable_string",
+			Description:   "X520 Distinguished Name Country MUST be encoded as PrintableString",
+			Citation:      "RFC 5280: Appendix A",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSubjectDNCountryNotPrintableString,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_dn_not_printable_characters.go
+++ b/v3/lints/rfc/lint_subject_dn_not_printable_characters.go
@@ -26,13 +26,15 @@ import (
 type subjectDNNotPrintableCharacters struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_dn_not_printable_characters",
-		Description:   "X520 Subject fields MUST only contain printable control characters",
-		Citation:      "RFC 5280: Appendix A",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSubjectDNNotPrintableCharacters,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_dn_not_printable_characters",
+			Description:   "X520 Subject fields MUST only contain printable control characters",
+			Citation:      "RFC 5280: Appendix A",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSubjectDNNotPrintableCharacters,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_dn_serial_number_max_length.go
+++ b/v3/lints/rfc/lint_subject_dn_serial_number_max_length.go
@@ -25,13 +25,15 @@ import (
 type SubjectDNSerialNumberMaxLength struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_dn_serial_number_max_length",
-		Description:   "The 'Serial Number' field of the subject MUST be less than 65 characters",
-		Citation:      "RFC 5280: Appendix A",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSubjectDNSerialNumberMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_dn_serial_number_max_length",
+			Description:   "The 'Serial Number' field of the subject MUST be less than 65 characters",
+			Citation:      "RFC 5280: Appendix A",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSubjectDNSerialNumberMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_dn_serial_number_not_printable_string.go
+++ b/v3/lints/rfc/lint_subject_dn_serial_number_not_printable_string.go
@@ -24,13 +24,15 @@ import (
 type SubjectDNSerialNumberNotPrintableString struct{}
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_dn_serial_number_not_printable_string",
-		Description:   "X520 Distinguished Name SerialNumber MUST be encoded as PrintableString",
-		Citation:      "RFC 5280: Appendix A",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.ZeroDate,
-		Lint:          NewSubjectDNSerialNumberNotPrintableString,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_dn_serial_number_not_printable_string",
+			Description:   "X520 Distinguished Name SerialNumber MUST be encoded as PrintableString",
+			Citation:      "RFC 5280: Appendix A",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSubjectDNSerialNumberNotPrintableString,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_email_max_length.go
+++ b/v3/lints/rfc/lint_subject_email_max_length.go
@@ -39,13 +39,15 @@ ub-emailaddress-length INTEGER ::= 255
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_email_max_length",
-		Description:   "The 'Email' field of the subject MUST be less than 256 characters",
-		Citation:      "RFC 5280: A.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectEmailMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_email_max_length",
+			Description:   "The 'Email' field of the subject MUST be less than 256 characters",
+			Citation:      "RFC 5280: A.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectEmailMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_empty_without_san.go
+++ b/v3/lints/rfc/lint_subject_empty_without_san.go
@@ -36,13 +36,15 @@ subjectAltName extension as non-critical.
 *************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_empty_without_san",
-		Description:   "CAs MUST support subject alternative name if the subject field is an empty sequence",
-		Citation:      "RFC 5280: 4.2 & 4.2.1.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewEmptyWithoutSAN,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_empty_without_san",
+			Description:   "CAs MUST support subject alternative name if the subject field is an empty sequence",
+			Citation:      "RFC 5280: 4.2 & 4.2.1.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewEmptyWithoutSAN,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_given_name_max_length.go
+++ b/v3/lints/rfc/lint_subject_given_name_max_length.go
@@ -50,13 +50,15 @@ ub-name INTEGER ::= 32768
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_given_name_max_length",
-		Description:   "The 'GivenName' field of the subject MUST be less than 32769 characters",
-		Citation:      "RFC 5280: A.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectGivenNameMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_given_name_max_length",
+			Description:   "The 'GivenName' field of the subject MUST be less than 32769 characters",
+			Citation:      "RFC 5280: A.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectGivenNameMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_given_name_recommended_max_length.go
+++ b/v3/lints/rfc/lint_subject_given_name_recommended_max_length.go
@@ -30,14 +30,16 @@ RFC 5280: A.1
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name: "w_subject_given_name_recommended_max_length",
-		Description: "X.411 (1988) describes ub-common-name-length to be 64 bytes long. As systems may have " +
-			"targeted this length, for compatibility purposes it may be prudent to limit given names to this length.",
-		Citation:      "ITU-T Rec. X.411 (11/1988), Annex B Reference Definition of MTS Parameter Upper Bounds",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectGivenNameRecommendedMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name: "w_subject_given_name_recommended_max_length",
+			Description: "X.411 (1988) describes ub-common-name-length to be 64 bytes long. As systems may have " +
+				"targeted this length, for compatibility purposes it may be prudent to limit given names to this length.",
+			Citation:      "ITU-T Rec. X.411 (11/1988), Annex B Reference Definition of MTS Parameter Upper Bounds",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectGivenNameRecommendedMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_info_access_marked_critical.go
+++ b/v3/lints/rfc/lint_subject_info_access_marked_critical.go
@@ -27,13 +27,15 @@ The subject information access extension indicates how to access information and
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_info_access_marked_critical",
-		Description:   "Conforming CAs MUST mark the Subject Info Access extension as non-critical",
-		Citation:      "RFC 5280: 4.2.2.2",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC3280Date,
-		Lint:          NewSiaCrit,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_info_access_marked_critical",
+			Description:   "Conforming CAs MUST mark the Subject Info Access extension as non-critical",
+			Citation:      "RFC 5280: 4.2.2.2",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC3280Date,
+		},
+		Lint: NewSiaCrit,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_locality_name_max_length.go
+++ b/v3/lints/rfc/lint_subject_locality_name_max_length.go
@@ -32,13 +32,15 @@ RFC 5280: A.1
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_locality_name_max_length",
-		Description:   "The 'Locality Name' field of the subject MUST be less than 129 characters",
-		Citation:      "RFC 5280: A.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectLocalityNameMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_locality_name_max_length",
+			Description:   "The 'Locality Name' field of the subject MUST be less than 129 characters",
+			Citation:      "RFC 5280: A.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectLocalityNameMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_not_dn.go
+++ b/v3/lints/rfc/lint_subject_not_dn.go
@@ -35,13 +35,15 @@ type subjectDN struct{}
 *************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_not_dn",
-		Description:   "When not empty, the subject field MUST be a distinguished name",
-		Citation:      "RFC 5280: 4.1.2.6",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectDN,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_not_dn",
+			Description:   "When not empty, the subject field MUST be a distinguished name",
+			Citation:      "RFC 5280: 4.1.2.6",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectDN,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_organization_name_max_length.go
+++ b/v3/lints/rfc/lint_subject_organization_name_max_length.go
@@ -32,13 +32,15 @@ RFC 5280: A.1
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_organization_name_max_length",
-		Description:   "The 'Organization Name' field of the subject MUST be less than 65 characters",
-		Citation:      "RFC 5280: A.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectOrganizationNameMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_organization_name_max_length",
+			Description:   "The 'Organization Name' field of the subject MUST be less than 65 characters",
+			Citation:      "RFC 5280: A.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectOrganizationNameMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_organizational_unit_name_max_length.go
+++ b/v3/lints/rfc/lint_subject_organizational_unit_name_max_length.go
@@ -32,13 +32,15 @@ RFC 5280: A.1
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_organizational_unit_name_max_length",
-		Description:   "The 'Organizational Unit Name' field of the subject MUST be less than 65 characters",
-		Citation:      "RFC 5280: A.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectOrganizationalUnitNameMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_organizational_unit_name_max_length",
+			Description:   "The 'Organizational Unit Name' field of the subject MUST be less than 65 characters",
+			Citation:      "RFC 5280: A.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectOrganizationalUnitNameMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_postal_code_max_length.go
+++ b/v3/lints/rfc/lint_subject_postal_code_max_length.go
@@ -33,13 +33,15 @@ RFC 5280: A.1
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_postal_code_max_length",
-		Description:   "The 'PostalCode' field of the subject MUST be less than 17 characters",
-		Citation:      "RFC 5280: A.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectPostalCodeMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_postal_code_max_length",
+			Description:   "The 'PostalCode' field of the subject MUST be less than 17 characters",
+			Citation:      "RFC 5280: A.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectPostalCodeMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_printable_string_badalpha.go
+++ b/v3/lints/rfc/lint_subject_printable_string_badalpha.go
@@ -26,13 +26,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_printable_string_badalpha",
-		Description:   "PrintableString type's alphabet only includes a-z, A-Z, 0-9, and 11 special characters",
-		Citation:      "RFC 5280: Appendix B. ASN.1 Notes",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectPrintableStringBadAlpha,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_printable_string_badalpha",
+			Description:   "PrintableString type's alphabet only includes a-z, A-Z, 0-9, and 11 special characters",
+			Citation:      "RFC 5280: Appendix B. ASN.1 Notes",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectPrintableStringBadAlpha,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_state_name_max_length.go
+++ b/v3/lints/rfc/lint_subject_state_name_max_length.go
@@ -32,13 +32,15 @@ RFC 5280: A.1
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_state_name_max_length",
-		Description:   "The 'State Name' field of the subject MUST be less than 129 characters",
-		Citation:      "RFC 5280: A.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectStateNameMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_state_name_max_length",
+			Description:   "The 'State Name' field of the subject MUST be less than 129 characters",
+			Citation:      "RFC 5280: A.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectStateNameMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_street_address_max_length.go
+++ b/v3/lints/rfc/lint_subject_street_address_max_length.go
@@ -31,13 +31,15 @@ ub-street-address INTEGER ::= 128
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_street_address_max_length",
-		Description:   "The 'StreetAddress' field of the subject MUST be less than 129 characters",
-		Citation:      "ITU-T X.520 (02/2001) UpperBounds",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectStreetAddressMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_street_address_max_length",
+			Description:   "The 'StreetAddress' field of the subject MUST be less than 129 characters",
+			Citation:      "ITU-T X.520 (02/2001) UpperBounds",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectStreetAddressMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_surname_max_length.go
+++ b/v3/lints/rfc/lint_subject_surname_max_length.go
@@ -50,13 +50,15 @@ ub-name INTEGER ::= 32768
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_subject_surname_max_length",
-		Description:   "The 'Surname' field of the subject MUST be less than 32769 characters",
-		Citation:      "RFC 5280: A.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectSurnameMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_subject_surname_max_length",
+			Description:   "The 'Surname' field of the subject MUST be less than 32769 characters",
+			Citation:      "RFC 5280: A.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectSurnameMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_subject_surname_recommended_max_length.go
+++ b/v3/lints/rfc/lint_subject_surname_recommended_max_length.go
@@ -30,14 +30,16 @@ RFC 5280: A.1
 ************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name: "w_subject_surname_recommended_max_length",
-		Description: "X.411 (1988) describes ub-common-name-length to be 64 bytes long. As systems may have " +
-			"targeted this length, for compatibility purposes it may be prudent to limit surnames to this length.",
-		Citation:      "ITU-T Rec. X.411 (11/1988), Annex B Reference Definition of MTS Parameter Upper Bounds",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewSubjectSurnameRecommendedMaxLength,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name: "w_subject_surname_recommended_max_length",
+			Description: "X.411 (1988) describes ub-common-name-length to be 64 bytes long. As systems may have " +
+				"targeted this length, for compatibility purposes it may be prudent to limit surnames to this length.",
+			Citation:      "ITU-T Rec. X.411 (11/1988), Annex B Reference Definition of MTS Parameter Upper Bounds",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewSubjectSurnameRecommendedMaxLength,
 	})
 }
 

--- a/v3/lints/rfc/lint_superfluous_ku_encoding.go
+++ b/v3/lints/rfc/lint_superfluous_ku_encoding.go
@@ -24,13 +24,15 @@ import (
 )
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_superfluous_ku_encoding",
-		Description:   "RFC 5280 Section 4.2.1.3 describes the value of a KeyUsage to be a DER encoded BitString, which itself must not have unnecessary trailing 00 bytes.",
-		Citation:      "1.2.2 Where Rec. ITU-T X.680 | ISO/IEC 8824-1, 22.7, applies, the bitstring shall have all trailing 0 bits removed before it is encoded.",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.ZeroDate,
-		Lint:          func() lint.LintInterface { return &superfluousKuEncoding{} },
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_superfluous_ku_encoding",
+			Description:   "RFC 5280 Section 4.2.1.3 describes the value of a KeyUsage to be a DER encoded BitString, which itself must not have unnecessary trailing 00 bytes.",
+			Citation:      "1.2.2 Where Rec. ITU-T X.680 | ISO/IEC 8824-1, 22.7, applies, the bitstring shall have all trailing 0 bits removed before it is encoded.",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: func() lint.LintInterface { return &superfluousKuEncoding{} },
 	})
 }
 

--- a/v3/lints/rfc/lint_tbs_signature_alg_matches_cert_signature_alg.go
+++ b/v3/lints/rfc/lint_tbs_signature_alg_matches_cert_signature_alg.go
@@ -34,13 +34,15 @@ tbsCertificate
 ********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_cert_sig_alg_not_match_tbs_sig_alg",
-		Description:   "Certificate signature field must match TBSCertificate signature field",
-		Citation:      "RFC 5280, Section 4.1.1.2",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewMismatchingSigAlg,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cert_sig_alg_not_match_tbs_sig_alg",
+			Description:   "Certificate signature field must match TBSCertificate signature field",
+			Citation:      "RFC 5280, Section 4.1.1.2",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewMismatchingSigAlg,
 	})
 }
 

--- a/v3/lints/rfc/lint_tbs_signature_rsa_encryption_parameter_not_null.go
+++ b/v3/lints/rfc/lint_tbs_signature_rsa_encryption_parameter_not_null.go
@@ -32,13 +32,15 @@ RSA: Encoded algorithm identifier MUST have NULL parameters.
 *******************************************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_tbs_signature_rsa_encryption_parameter_not_null",
-		Description:   "RSA: Encoded signature algorithm identifier MUST have NULL parameters",
-		Citation:      "RFC 4055, Section 5",
-		Source:        lint.RFC5280, // RFC4055 is referenced in RFC5280, Section 1
-		EffectiveDate: util.RFC5280Date,
-		Lint:          NewRsaTBSSignatureEncryptionParamNotNULL,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_tbs_signature_rsa_encryption_parameter_not_null",
+			Description:   "RSA: Encoded signature algorithm identifier MUST have NULL parameters",
+			Citation:      "RFC 4055, Section 5",
+			Source:        lint.RFC5280, // RFC4055 is referenced in RFC5280, Section 1
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewRsaTBSSignatureEncryptionParamNotNULL,
 	})
 }
 

--- a/v3/lints/rfc/lint_utc_time_does_not_include_seconds.go
+++ b/v3/lints/rfc/lint_utc_time_does_not_include_seconds.go
@@ -41,13 +41,15 @@ systems MUST interpret the year field (YY) as follows:
 ************************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_utc_time_does_not_include_seconds",
-		Description:   "UTCTime values MUST include seconds",
-		Citation:      "RFC 5280: 4.1.2.5.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewUtcNoSecond,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_utc_time_does_not_include_seconds",
+			Description:   "UTCTime values MUST include seconds",
+			Citation:      "RFC 5280: 4.1.2.5.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewUtcNoSecond,
 	})
 }
 

--- a/v3/lints/rfc/lint_utc_time_not_in_zulu.go
+++ b/v3/lints/rfc/lint_utc_time_not_in_zulu.go
@@ -44,13 +44,15 @@ type utcTimeGMT struct{}
 ***********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_utc_time_not_in_zulu",
-		Description:   "UTCTime values MUST be expressed in Greenwich Mean Time (Zulu)",
-		Citation:      "RFC 5280: 4.1.2.5.1",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewUtcTimeGMT,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_utc_time_not_in_zulu",
+			Description:   "UTCTime values MUST be expressed in Greenwich Mean Time (Zulu)",
+			Citation:      "RFC 5280: 4.1.2.5.1",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewUtcTimeGMT,
 	})
 }
 

--- a/v3/lints/rfc/lint_wrong_time_format_pre2050.go
+++ b/v3/lints/rfc/lint_wrong_time_format_pre2050.go
@@ -34,13 +34,15 @@ are encoded in either UTCTime or GeneralizedTime.
 *********************************************************************/
 
 func init() {
-	lint.RegisterLint(&lint.Lint{
-		Name:          "e_wrong_time_format_pre2050",
-		Description:   "Certificates valid through the year 2049 MUST be encoded in UTC time",
-		Citation:      "RFC 5280: 4.1.2.5",
-		Source:        lint.RFC5280,
-		EffectiveDate: util.RFC2459Date,
-		Lint:          NewGeneralizedPre2050,
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_wrong_time_format_pre2050",
+			Description:   "Certificates valid through the year 2049 MUST be encoded in UTC time",
+			Citation:      "RFC 5280: 4.1.2.5",
+			Source:        lint.RFC5280,
+			EffectiveDate: util.RFC2459Date,
+		},
+		Lint: NewGeneralizedPre2050,
 	})
 }
 


### PR DESCRIPTION
Partially addresses #765 

Using the code on: https://github.com/aaomidi/zlint-migration, I've converted all `lint.RegisterLint` to `lint.RegisterCertificateLint`. 

To make it easier for reviewers: look at the code here: https://github.com/aaomidi/zlint-migration, re-run this on the lints, it should create no diff compared to this PR.

Note that I've reviewed every file manually as well just in case, and I didn't spot anything. 