### PR TITLE
Metalint for checking against the deprecaetd lint.RegisterLint function

### DIFF
--- a/v3/integration/lints/lints/register_lint_deprecated.go
+++ b/v3/integration/lints/lints/register_lint_deprecated.go
@@ -1,0 +1,56 @@
+package lints
+
+/*
+ * ZLint Copyright 2023 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"github.com/zmap/zlint/v3/integration/lints/filters"
+	"github.com/zmap/zlint/v3/integration/lints/lint"
+	"go/ast"
+)
+
+type RegisterLintDeprecated struct{}
+
+func (r *RegisterLintDeprecated) CheckApplies(tree *ast.File, file *lint.File) bool {
+	return filters.IsALint(file)
+}
+
+func (r *RegisterLintDeprecated) Lint(tree *ast.File, file *lint.File) *lint.Result {
+	var result *lint.Result
+	visitor := &selectorExprVisitor{fn: func(expr *ast.SelectorExpr, node ast.Node) {
+		if expr.Sel.Name != "RegisterLint" {
+			return
+		}
+		result = lint.NewResult("lint.RegisterLint is deprecated and should not be used. "+
+			"Please use the register function specific to your lint classification (I.E. "+
+			"lint.RegisterCertificateLint for certificate lints and lint.RegisterRevocationListLint for CRL lints).").
+			AddCodeCitation(node.Pos(), node.End(), file).
+			SetCitations("https://github.com/zmap/zlint/issues/765")
+	}}
+	ast.Walk(visitor, tree)
+	return result
+}
+
+type selectorExprVisitor struct {
+	fn func(expr *ast.SelectorExpr, node ast.Node)
+}
+
+func (v *selectorExprVisitor) Visit(node ast.Node) ast.Visitor {
+	selectorExpr, ok := node.(*ast.SelectorExpr)
+	if !ok {
+		return v
+	}
+	v.fn(selectorExpr, node)
+	return nil
+}

--- a/v3/integration/lints/lints/register_lint_deprecated.go
+++ b/v3/integration/lints/lints/register_lint_deprecated.go
@@ -15,9 +15,10 @@ package lints
  */
 
 import (
+	"go/ast"
+
 	"github.com/zmap/zlint/v3/integration/lints/filters"
 	"github.com/zmap/zlint/v3/integration/lints/lint"
-	"go/ast"
 )
 
 type RegisterLintDeprecated struct{}

--- a/v3/integration/lints/lints/register_lint_deprecated_test.go
+++ b/v3/integration/lints/lints/register_lint_deprecated_test.go
@@ -1,8 +1,9 @@
 package lints
 
 import (
-	"github.com/zmap/zlint/v3/integration/lints/lint"
 	"testing"
+
+	"github.com/zmap/zlint/v3/integration/lints/lint"
 )
 
 func TestRegisterLintDeprecated_Lint(t *testing.T) {

--- a/v3/integration/lints/lints/register_lint_deprecated_test.go
+++ b/v3/integration/lints/lints/register_lint_deprecated_test.go
@@ -1,0 +1,35 @@
+package lints
+
+import (
+	"github.com/zmap/zlint/v3/integration/lints/lint"
+	"testing"
+)
+
+func TestRegisterLintDeprecated_Lint(t *testing.T) {
+
+	data := []struct {
+		inputFile  string
+		expectPass bool
+	}{
+		{inputFile: "testdata/lint_usesRegisterLint.go", expectPass: false},
+		{inputFile: "testdata/lint_usesRegisterCertificateLint.go", expectPass: true},
+		{inputFile: "testdata/lint_usesRegisterProfile.go", expectPass: true},
+		{inputFile: "testdata/lint_usesRegisterRevocationListLint.go", expectPass: true},
+	}
+	l := &RegisterLintDeprecated{}
+	for _, test := range data {
+		file := test.inputFile
+		want := test.expectPass
+		t.Run(file, func(t *testing.T) {
+			r, err := lint.RunLintForFile(file, l)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want && r != nil {
+				t.Errorf("got unexepcted error result, %s", r)
+			} else if !want && r == nil {
+				t.Errorf("expected failure but got nothing")
+			}
+		})
+	}
+}

--- a/v3/integration/lints/lints/testdata/lint_usesRegisterCertificateLint.go
+++ b/v3/integration/lints/lints/testdata/lint_usesRegisterCertificateLint.go
@@ -1,0 +1,21 @@
+package testdata
+
+import "github.com/zmap/zlint/v3/lint"
+
+/*
+ * ZLint Copyright 2023 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+func init() {
+	lint.RegisterCertificateLint(nil)
+}

--- a/v3/integration/lints/lints/testdata/lint_usesRegisterLint.go
+++ b/v3/integration/lints/lints/testdata/lint_usesRegisterLint.go
@@ -1,0 +1,21 @@
+package testdata
+
+import "github.com/zmap/zlint/v3/lint"
+
+/*
+ * ZLint Copyright 2023 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+func init() {
+	lint.RegisterLint(nil)
+}

--- a/v3/integration/lints/lints/testdata/lint_usesRegisterProfile.go
+++ b/v3/integration/lints/lints/testdata/lint_usesRegisterProfile.go
@@ -1,0 +1,21 @@
+package testdata
+
+import "github.com/zmap/zlint/v3/lint"
+
+/*
+ * ZLint Copyright 2023 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+func init() {
+	lint.RegisterProfile(lint.Profile{})
+}

--- a/v3/integration/lints/lints/testdata/lint_usesRegisterRevocationListLint.go
+++ b/v3/integration/lints/lints/testdata/lint_usesRegisterRevocationListLint.go
@@ -1,0 +1,21 @@
+package testdata
+
+import "github.com/zmap/zlint/v3/lint"
+
+/*
+ * ZLint Copyright 2023 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+func init() {
+	lint.RegisterRevocationListLint(nil)
+}

--- a/v3/integration/lints/main.go
+++ b/v3/integration/lints/main.go
@@ -27,6 +27,7 @@ import (
 var linters = []lint.Lint{
 	&lints.InitFirst{},
 	&lints.NotCommittingGenTestCerts{},
+	&lints.RegisterLintDeprecated{},
 }
 
 func main() {


### PR DESCRIPTION
This addresses the conversation in #765 regarding enforcing the deprecation of `lint.RegisterLint` via our own code linter.

---

@aaomidi I took your general idea from #770 and ported into the repo's custom code linter that was built just for this purpose. Thank you for the working code sample!

---

Given the sample input file...

```go
package cabf_ev

/*
 * ZLint Copyright 2023 Regents of the University of Michigan
 *
 * Licensed under the Apache License, Version 2.0 (the "License"); you may not
 * use this file except in compliance with the License. You may obtain a copy
 * of the License at http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 * implied. See the License for the specific language governing
 * permissions and limitations under the License.
 */

import (
	"github.com/zmap/zcrypto/x509"
	"github.com/zmap/zlint/v3/lint"
	"github.com/zmap/zlint/v3/util"
)

type evNoBiz struct{}

func init() {
	lint.RegisterLint(&lint.Lint{
		Name:          "e_ev_business_category_missing",
		Description:   "EV certificates must include businessCategory in subject",
		Citation:      "EVGs: 9.2.3",
		Source:        lint.CABFEVGuidelines,
		EffectiveDate: util.ZeroDate,
		Lint:          NewEvNoBiz,
	})
}

func NewEvNoBiz() lint.LintInterface {
	return &evNoBiz{}
}

func (l *evNoBiz) CheckApplies(c *x509.Certificate) bool {
	return util.IsEV(c.PolicyIdentifiers) && util.IsSubscriberCert(c)
}

func (l *evNoBiz) Execute(c *x509.Certificate) *lint.LintResult {
	if util.TypeInName(&c.Subject, util.BusinessOID) {
		return &lint.LintResult{Status: lint.Pass}
	} else {
		return &lint.LintResult{Status: lint.Error}
	}
}
```

CICD will print the output...

```
Found 1 linting errors
--------------------
Linting Error

lint.RegisterLint is deprecated and should not be used. Please use the register function specific to your lint classification (I.E. lint.RegisterCertificateLint for certificate lints and lint.RegisterRevocationListLint for CRL lints).

File /home/chris/projects/zlint/v3/lints/cabf_br/lint_ca_common_name_missing.go, line 26

lint.RegisterLint

For more information, please see the following citations.
	https://github.com/zmap/zlint/issues/765

exit status 1

```
