### PR TITLE
Fix goreleaser deprecation

### DIFF
--- a/v3/.goreleaser.yml
+++ b/v3/.goreleaser.yml
@@ -18,11 +18,14 @@ builds:
 archives:
   -
     wrap_in_directory: true
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
+    name_template: >-
+      {{- .ProjectName }}_
+      {{.Version}}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
 snapshot:
   name_template: "{{ .Tag }}-next"
 release:

--- a/v3/.goreleaser.yml
+++ b/v3/.goreleaser.yml
@@ -20,7 +20,7 @@ archives:
     wrap_in_directory: true
     name_template: >-
       {{- .ProjectName }}_
-      {{.Version}}_
+      {{- .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
The `replacements` section was hard deprecated on us. A migration path has been given to us from https://goreleaser.com/deprecations/#__tabbed_14_1