### PR TITLE
SKI is now not recommended.

### DIFF
--- a/v3/lints/rfc/lint_ext_subject_key_identifier_missing_sub_cert.go
+++ b/v3/lints/rfc/lint_ext_subject_key_identifier_missing_sub_cert.go
@@ -23,6 +23,7 @@ import (
 type subjectKeyIdMissingSubscriber struct{}
 
 /**********************************************************************
+RFC5280 suggested the addition of SKI extension:
    To facilitate certification path construction, this extension MUST
    appear in all conforming CA certificates, that is, all certificates
    including the basic constraints extension (Section 4.2.1.9) where the
@@ -40,16 +41,20 @@ type subjectKeyIdMissingSubscriber struct{}
    quickly identify the set of certificates containing a particular public key.
    To assist applications in identifying the appropriate end entity certificate,
    this extension SHOULD be included in all end entity certificates.
+
+CABF BR SC62 marked the extension as NOT RECOMMENDED for subscriber
+certificates
 **********************************************************************/
 
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
-			Name:          "w_ext_subject_key_identifier_missing_sub_cert",
-			Description:   "Sub certificates SHOULD include Subject Key Identifier in end entity certs",
-			Citation:      "RFC 5280: 4.2 & 4.2.1.2",
-			Source:        lint.RFC5280,
-			EffectiveDate: util.RFC2459Date,
+			Name:            "w_ext_subject_key_identifier_missing_sub_cert",
+			Description:     "Sub certificates SHOULD include Subject Key Identifier in end entity certs",
+			Citation:        "RFC 5280: 4.2 & 4.2.1.2",
+			Source:          lint.RFC5280,
+			EffectiveDate:   util.RFC2459Date,
+			IneffectiveDate: util.SC62EffectiveDate,
 		},
 		Lint: NewSubjectKeyIdMissingSubscriber,
 	})


### PR DESCRIPTION
Ballot SC62 appears to have marked Subject Key Identifier as NOT RECOMMENDED.

https://cabforum.org/2023/03/17/ballot-sc62v2-certificate-profiles-update/

See section 7.1.2.7.6 Subscriber Certificate Extensions of the BR: https://cabforum.org/wp-content/uploads/CA-Browser-Forum-TLS-BR-2.0.2.pdf#page=79

I believe zlint should stop issuing warnings for certificates issued after SC62 was effective.