### PR TITLE
Subject Key Identifier is not recommended by CABF BR v2

### DIFF
--- a/v3/lints/cabf_br/lint_ext_subject_key_identifier_not_recommended_subscriber.go
+++ b/v3/lints/cabf_br/lint_ext_subject_key_identifier_not_recommended_subscriber.go
@@ -1,0 +1,70 @@
+package cabf_br
+
+/*
+ * ZLint Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+type subjectKeyIdNotRecommendedSubscriber struct{}
+
+/**********************************************************************
+RFC5280 suggested the addition of SKI extension, but CABF BR SC62
+marked the extension as NOT RECOMMENDED for subscriber certificates
+
+Warning:
+Users of zlint will trigger either
+`w_ext_subject_key_identifier_not_recommended_subscriber` (this lint)
+or `w_ext_subject_key_identifier_missing_sub_cert` the one enforcing
+RFC5280's behavior.
+
+Users are expected to specifically ignore one or the other lint
+depending on which one apply to them.
+
+See:
+ - https://github.com/zmap/zlint/issues/749
+ - https://github.com/zmap/zlint/issues/762
+**********************************************************************/
+
+func init() {
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "w_ext_subject_key_identifier_not_recommended_subscriber",
+			Description:   "Subcriber certificates use of Subject Key Identifier is NOT RECOMMENDED",
+			Citation:      "BRs v2: 7.1.2.7.6",
+			Source:        lint.CABFBaselineRequirements,
+			EffectiveDate: util.SC62EffectiveDate,
+		},
+		Lint: NewSubjectKeyIdNotRecommendedSubscriber,
+	})
+}
+
+func NewSubjectKeyIdNotRecommendedSubscriber() lint.LintInterface {
+	return &subjectKeyIdNotRecommendedSubscriber{}
+}
+
+func (l *subjectKeyIdNotRecommendedSubscriber) CheckApplies(cert *x509.Certificate) bool {
+	return util.IsSubscriberCert(cert)
+}
+
+func (l *subjectKeyIdNotRecommendedSubscriber) Execute(cert *x509.Certificate) *lint.LintResult {
+	if util.IsExtInCert(cert, util.SubjectKeyIdentityOID) {
+		return &lint.LintResult{Status: lint.Warn}
+	} else {
+		return &lint.LintResult{Status: lint.Pass}
+	}
+}

--- a/v3/lints/cabf_br/lint_ext_subject_key_identifier_not_recommended_subscriber_test.go
+++ b/v3/lints/cabf_br/lint_ext_subject_key_identifier_not_recommended_subscriber_test.go
@@ -1,0 +1,52 @@
+/*
+ * ZLint Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package cabf_br
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestSubjectKeyIdNotRecommendedSubscriber(t *testing.T) {
+	type Test struct {
+		input string
+		want  lint.LintStatus
+	}
+	data := []Test{
+		{
+			input: "warn_subject_key_identifier_not_recommended_subscriber.pem",
+			want:  lint.Warn,
+		},
+		{
+			input: "pass_subject_key_identifier_not_recommended_subscriber.pem",
+			want:  lint.Pass,
+		},
+		{
+			input: "ne_subject_key_identifier_not_recommended_subscriber.pem",
+			want:  lint.NE,
+		},
+	}
+	for _, in := range data {
+		in := in
+		t.Run(in.input, func(t *testing.T) {
+			out := test.TestLint("w_ext_subject_key_identifier_not_recommended_subscriber", in.input)
+			if out.Status != in.want {
+				t.Errorf("expected %s, got %s", in.want, out.Status)
+			}
+		})
+	}
+}

--- a/v3/testdata/ne_subject_key_identifier_not_recommended_subscriber.pem
+++ b/v3/testdata/ne_subject_key_identifier_not_recommended_subscriber.pem
@@ -1,0 +1,38 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer:
+        Validity
+            Not Before: Jul 31 00:00:00 2023 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject:
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:fe:de:4c:a1:5e:4f:8a:2d:f6:56:1f:b7:dd:d2:
+                    d5:7f:34:24:82:4a:53:bd:66:09:2c:e6:e1:1d:46:
+                    27:5f:fb:91:3e:d7:3b:fd:78:b8:a0:6d:fc:6b:a8:
+                    96:63:bb:97:cf:25:97:4e:3a:98:b0:af:ae:94:cf:
+                    24:41:ff:4f:43
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                01:02:03:04
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:44:02:20:01:2f:84:dd:00:95:ed:4c:92:12:2e:cb:dd:65:
+        6b:12:07:86:00:5e:c4:97:9b:66:1c:bd:0a:72:96:29:94:d6:
+        02:20:71:91:0e:ca:d5:1c:a9:d9:05:2f:d2:c2:f6:8f:6b:8d:
+        51:75:d7:66:8a:8a:e0:cb:75:14:75:6a:ce:71:b8:a3
+-----BEGIN CERTIFICATE-----
+MIIBADCBqKADAgECAgEDMAoGCCqGSM49BAMCMAAwIBcNMjMwNzMxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMAAwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT+3kyh
+Xk+KLfZWH7fd0tV/NCSCSlO9Zgks5uEdRidf+5E+1zv9eLigbfxrqJZju5fPJZdO
+Opiwr66UzyRB/09DoxEwDzANBgNVHQ4EBgQEAQIDBDAKBggqhkjOPQQDAgNHADBE
+AiABL4TdAJXtTJISLsvdZWsSB4YAXsSXm2YcvQpylimU1gIgcZEOytUcqdkFL9LC
+9o9rjVF112aKiuDLdRR1as5xuKM=
+-----END CERTIFICATE-----

--- a/v3/testdata/pass_subject_key_identifier_not_recommended_subscriber.pem
+++ b/v3/testdata/pass_subject_key_identifier_not_recommended_subscriber.pem
@@ -1,0 +1,35 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer:
+        Validity
+            Not Before: Sep 30 00:00:00 2023 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject:
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:62:b2:29:9e:2a:7b:12:a3:18:27:9e:cd:e6:a9:
+                    ee:b7:6b:a2:05:da:4f:1a:30:37:9e:db:1c:0a:58:
+                    6d:4f:7f:66:29:26:a4:c9:4c:a3:50:65:b1:7b:96:
+                    34:16:d9:2b:c0:8e:9d:70:dd:c5:bf:1d:07:bf:16:
+                    80:b8:de:76:8d
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:21:00:fb:9c:97:55:1f:f3:19:43:66:75:01:c0:ad:
+        2a:bd:2f:b9:21:24:7d:4d:1c:b2:e5:4f:10:58:47:6a:61:5b:
+        56:02:20:6c:a0:4c:87:9a:5c:66:f1:3a:cf:fc:77:22:5e:c7:
+        ce:d5:82:52:cf:44:71:5d:5c:4a:a5:7c:5c:fe:86:2b:16
+-----BEGIN CERTIFICATE-----
+MIHyMIGZoAMCAQICAQMwCgYIKoZIzj0EAwIwADAgFw0yMzA5MzAwMDAwMDBaGA85
+OTk4MTEzMDAwMDAwMFowADBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABGKyKZ4q
+exKjGCeezeap7rdrogXaTxowN57bHApYbU9/ZikmpMlMo1BlsXuWNBbZK8COnXDd
+xb8dB78WgLjedo2jAjAAMAoGCCqGSM49BAMCA0gAMEUCIQD7nJdVH/MZQ2Z1AcCt
+Kr0vuSEkfU0csuVPEFhHamFbVgIgbKBMh5pcZvE6z/x3Il7HztWCUs9EcV1cSqV8
+XP6GKxY=
+-----END CERTIFICATE-----

--- a/v3/testdata/warn_subject_key_identifier_not_recommended_subscriber.pem
+++ b/v3/testdata/warn_subject_key_identifier_not_recommended_subscriber.pem
@@ -1,0 +1,38 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer:
+        Validity
+            Not Before: Sep 30 00:00:00 2023 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject:
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:61:2b:e3:83:17:e5:3f:e9:df:88:f7:5f:13:1f:
+                    64:bc:f2:6c:bb:6d:10:f3:9c:be:42:ad:ef:e7:63:
+                    a4:0b:5b:b9:9d:c5:52:a8:ad:d9:9d:95:6c:c2:ed:
+                    e2:26:5e:45:04:bf:38:f5:a2:f9:69:0f:e6:bc:2d:
+                    79:85:5b:26:2d
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                01:02:03:04
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:46:02:21:00:cc:f5:b0:6b:3a:1d:5c:88:79:85:2d:d6:c4:
+        e3:da:ba:37:8c:19:5a:96:dc:1d:95:d6:2a:91:f6:5d:bf:9b:
+        3a:02:21:00:f2:f6:73:c4:60:52:96:d0:43:a9:25:f7:d5:49:
+        25:ca:0c:7f:20:df:6b:65:71:61:c6:06:90:1c:2b:99:73:15
+-----BEGIN CERTIFICATE-----
+MIIBAjCBqKADAgECAgEDMAoGCCqGSM49BAMCMAAwIBcNMjMwOTMwMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMAAwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARhK+OD
+F+U/6d+I918TH2S88my7bRDznL5Cre/nY6QLW7mdxVKordmdlWzC7eImXkUEvzj1
+ovlpD+a8LXmFWyYtoxEwDzANBgNVHQ4EBgQEAQIDBDAKBggqhkjOPQQDAgNJADBG
+AiEAzPWwazodXIh5hS3WxOPaujeMGVqW3B2V1iqR9l2/mzoCIQDy9nPEYFKW0EOp
+JffVSSXKDH8g32tlcWHGBpAcK5lzFQ==
+-----END CERTIFICATE-----


### PR DESCRIPTION
With SC62, the CABF BR now lists SKI as not recommended.

Per discussion in #762, zlint should provide two lints, one for rfc5280 behavior and one for CABF BR.

Both lint will conflict with each other, users are expected to select (or ignore) which behavior they mean to follow.

Fixes #749