### PR TITLE
Fix a bug in the check for 7.1.4.2.h - single email address in subject:emailAddress

### DIFF
--- a/v3/lints/cabf_smime_br/lint_single_email_if_present_test.go
+++ b/v3/lints/cabf_smime_br/lint_single_email_if_present_test.go
@@ -24,8 +24,13 @@ func TestSingleEmailIfPresent(t *testing.T) {
 			ExpectedResult: lint.NA,
 		},
 		{
-			Name:           "Error - cert with multiple email addresses",
+			Name:           "Pass - cert with multiple email addresses",
 			InputFilename:  "smime/multiple_email_present.pem",
+			ExpectedResult: lint.Pass,
+		},
+		{
+			Name:           "Error - email address present with mutliple values",
+			InputFilename:  "smime/email_with_multiple_values.pem",
 			ExpectedResult: lint.Error,
 		},
 	}

--- a/v3/lints/cabf_smime_br/lint_single_email_if_present_test.go
+++ b/v3/lints/cabf_smime_br/lint_single_email_if_present_test.go
@@ -29,7 +29,7 @@ func TestSingleEmailIfPresent(t *testing.T) {
 			ExpectedResult: lint.Pass,
 		},
 		{
-			Name:           "Error - email address present with mutliple values",
+			Name:           "Error - email address present with multiple values",
 			InputFilename:  "smime/email_with_multiple_values.pem",
 			ExpectedResult: lint.Error,
 		},

--- a/v3/testdata/smime/email_with_multiple_values.pem
+++ b/v3/testdata/smime/email_with_multiple_values.pem
@@ -1,0 +1,44 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Sep 30 00:00:00 2023 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:b1:40:22:c1:13:22:0c:f6:64:60:55:a0:3c:7d:
+                    3f:e5:81:49:00:bd:36:9f:ef:d6:29:c6:eb:28:e5:
+                    d7:25:98:9b:f5:a5:e4:b3:95:0f:f6:af:bf:f5:b1:
+                    32:39:3c:5e:6b:bc:0e:2d:cf:ea:39:55:50:25:55:
+                    74:bd:e8:5e:f5
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                E-mail Protection
+            X509v3 Subject Alternative Name: 
+                email:test+1@example.com test+2@example.com, email:test+3@example.com
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.5.1.1
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:44:02:20:0a:ad:0d:13:2f:8d:f2:ea:66:17:2d:d2:6a:63:
+        ff:4b:3f:01:0a:32:00:74:ce:cd:ea:e2:9f:0d:21:14:55:64:
+        02:20:6c:6a:fb:1b:64:88:d8:67:fe:39:a9:e7:77:29:a6:a3:
+        77:a5:34:8f:60:1a:85:e6:db:18:5b:e7:00:41:30:fb
+-----BEGIN CERTIFICATE-----
+MIIBYzCCAQqgAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTIzMDkzMDAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsUAi
+wRMiDPZkYFWgPH0/5YFJAL02n+/WKcbrKOXXJZib9aXks5UP9q+/9bEyOTxea7wO
+Lc/qOVVQJVV0vehe9aNzMHEwEwYDVR0lBAwwCgYIKwYBBQUHAwQwRAYDVR0RBD0w
+O4EldGVzdCsxQGV4YW1wbGUuY29tIHRlc3QrMkBleGFtcGxlLmNvbYESdGVzdCsz
+QGV4YW1wbGUuY29tMBQGA1UdIAQNMAswCQYHZ4EMAQUBATAKBggqhkjOPQQDAgNH
+ADBEAiAKrQ0TL43y6mYXLdJqY/9LPwEKMgB0zs3q4p8NIRRVZAIgbGr7G2SI2Gf+
+Oanndymmo3elNI9gGoXm2xhb5wBBMPs=
+-----END CERTIFICATE-----


### PR DESCRIPTION
See comments on #753. The Check should not disallow multiple emails in the subject field on a compliant cert, but it should only allow a single value in any individual subject:emailAddress field. This PR fixes that issue.