### PR TITLE
Add test for S/MIME BR 7.1.2.3.j

### DIFF
--- a/v3/lints/cabf_smime_br/lint_subject_dir_attr.go
+++ b/v3/lints/cabf_smime_br/lint_subject_dir_attr.go
@@ -45,7 +45,7 @@ func (l *subDirAttr) CheckApplies(c *x509.Certificate) bool {
 
 func (l *subDirAttr) Execute(c *x509.Certificate) *lint.LintResult {
 	if util.IsExtInCert(c, util.SubjectDirAttrOID) {
-		return &lint.LintResult{Status: lint.Error}
+		return &lint.LintResult{Status: lint.Error, Details: "subject direcotry attribute present"}
 	} else {
 		return &lint.LintResult{Status: lint.Pass}
 	}

--- a/v3/lints/cabf_smime_br/lint_subject_dir_attr_test.go
+++ b/v3/lints/cabf_smime_br/lint_subject_dir_attr_test.go
@@ -9,23 +9,32 @@ import (
 
 func TestSMIMESubjectDirAttributes(t *testing.T) {
 	testCases := []struct {
-		Name           string
-		InputFilename  string
-		ExpectedResult lint.LintStatus
+		Name            string
+		InputFilename   string
+		ExpectedResult  lint.LintStatus
+		ExpectedDetails string
 	}{
 		{
 			Name:           "pass - no subject dir attributes extension",
 			InputFilename:  "smime/mailboxValidatedStrictWithCommonName.pem",
 			ExpectedResult: lint.Pass,
 		},
-		// A negative test case is hard to construct because neither the x509 package
-		// nor OpenSSL support writing the subject directory attributes extension.
+		{
+			Name:            "fail - subject dir attributes extension present",
+			InputFilename:   "smime/subject_dir_attributes_present.pem",
+			ExpectedResult:  lint.Error,
+			ExpectedDetails: "subject direcotry attribute present",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			result := test.TestLint("e_strict_multipurpose_smime_ext_subject_directory_attr", tc.InputFilename)
 			if result.Status != tc.ExpectedResult {
 				t.Errorf("expected result %v was %v - details: %v", tc.ExpectedResult, result.Status, result.Details)
+			}
+
+			if tc.ExpectedDetails != "" && tc.ExpectedDetails != result.Details {
+				t.Errorf("expected details: %s, was %s", tc.ExpectedDetails, result.Details)
 			}
 		})
 	}

--- a/v3/testdata/smime/subject_dir_attributes_present.pem
+++ b/v3/testdata/smime/subject_dir_attributes_present.pem
@@ -1,0 +1,43 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: Feb 27 18:48:48 2024 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: 
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:9a:4e:4a:4d:46:62:b7:eb:6b:5b:e9:bc:d4:22:
+                    55:6f:68:99:08:65:6f:96:f3:50:b9:9f:f7:17:61:
+                    ac:f1:68:2a:bc:24:ec:5b:84:20:7b:f2:17:38:dd:
+                    94:fb:21:f4:b8:a4:04:e3:84:9a:2f:c8:4e:29:70:
+                    86:ff:11:ff:7c
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Extended Key Usage: 
+                E-mail Protection
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.5.1.3
+            X509v3 Subject Directory Attributes: 
+                0.
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:20:6f:37:b8:59:66:04:52:ef:1d:32:72:74:95:85:
+        ac:d8:ac:a9:39:01:cf:0d:63:c3:04:21:8a:fa:63:4b:24:47:
+        02:21:00:f7:23:52:42:5f:c4:95:d5:83:71:e4:8d:fa:05:d8:
+        1b:9d:5f:09:3f:7b:0a:fa:d6:9a:00:42:39:e3:4c:11:21
+-----BEGIN CERTIFICATE-----
+MIIBKDCBz6ADAgECAgEDMAoGCCqGSM49BAMCMAAwIBcNMjQwMjI3MTg0ODQ4WhgP
+OTk5ODExMzAwMDAwMDBaMAAwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASaTkpN
+RmK362tb6bzUIlVvaJkIZW+W81C5n/cXYazxaCq8JOxbhCB78hc43ZT7IfS4pATj
+hJovyE4pcIb/Ef98ozgwNjATBgNVHSUEDDAKBggrBgEFBQcDBDAUBgNVHSAEDTAL
+MAkGB2eBDAEFAQMwCQYDVR0JBAIwADAKBggqhkjOPQQDAgNIADBFAiBvN7hZZgRS
+7x0ycnSVhazYrKk5Ac8NY8MEIYr6Y0skRwIhAPcjUkJfxJXVg3HkjfoF2BudXwk/
+ewr61poAQjnjTBEh
+-----END CERTIFICATE-----


### PR DESCRIPTION
Add a test for S/MIME BR 7.1.2.3.j that was missing from #798.