### PR TITLE
Handle BMPString properly in e_subject_dn_not_printable_characters 

### DIFF
--- a/v3/lints/rfc/lint_subject_dn_not_printable_characters.go
+++ b/v3/lints/rfc/lint_subject_dn_not_printable_characters.go
@@ -57,7 +57,7 @@ func (l *subjectDNNotPrintableCharacters) Execute(c *x509.Certificate) *lint.Lin
 	for _, attrTypeAndValueSet := range rdnSequence {
 		for _, attrTypeAndValue := range attrTypeAndValueSet {
 			bytes := attrTypeAndValue.Value.Bytes
-			runes := []rune{}
+			var runes []rune
 			if attrTypeAndValue.Value.Tag == tagBMPString {
 				runestr, _ := util.ParseBMPString(bytes)
 				runes = []rune(runestr)


### PR DESCRIPTION
Looking at #818 , other string types should be allowable as printable in subject fields to conform to RFC 5280.