### PR TITLE
Add ineffective date to DSA lints.

### DIFF
--- a/v3/lints/cabf_br/lint_dsa_correct_order_in_subgroup.go
+++ b/v3/lints/cabf_br/lint_dsa_correct_order_in_subgroup.go
@@ -29,11 +29,12 @@ type dsaSubgroup struct{}
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
-			Name:          "e_dsa_correct_order_in_subgroup",
-			Description:   "DSA: Public key value has the unique correct representation in the field, and that the key has the correct order in the subgroup",
-			Citation:      "BRs v1.7.0: 6.1.6",
-			Source:        lint.CABFBaselineRequirements,
-			EffectiveDate: util.CABEffectiveDate,
+			Name:            "e_dsa_correct_order_in_subgroup",
+			Description:     "DSA: Public key value has the unique correct representation in the field, and that the key has the correct order in the subgroup",
+			Citation:        "BRs v1.7.0: 6.1.6",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.CABFBRs_1_7_1_Date,
 		},
 		Lint: NewDsaSubgroup,
 	})

--- a/v3/lints/cabf_br/lint_dsa_shorter_than_2048_bits.go
+++ b/v3/lints/cabf_br/lint_dsa_shorter_than_2048_bits.go
@@ -31,8 +31,9 @@ func init() {
 			Description: "DSA modulus size must be at least 2048 bits",
 			Citation:    "BRs v1.7.0: 6.1.5",
 			// Refer to BRs: 6.1.5, taking the statement "Before 31 Dec 2010" literally
-			Source:        lint.CABFBaselineRequirements,
-			EffectiveDate: util.ZeroDate,
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.ZeroDate,
+			IneffectiveDate: util.CABFBRs_1_7_1_Date,
 		},
 		Lint: NewDsaTooShort,
 	})

--- a/v3/lints/cabf_br/lint_dsa_unique_correct_representation.go
+++ b/v3/lints/cabf_br/lint_dsa_unique_correct_representation.go
@@ -29,11 +29,12 @@ type dsaUniqueCorrectRepresentation struct{}
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
-			Name:          "e_dsa_unique_correct_representation",
-			Description:   "DSA: Public key value has the unique correct representation in the field, and that the key has the correct order in the subgroup",
-			Citation:      "BRs v1.7.0: 6.1.6",
-			Source:        lint.CABFBaselineRequirements,
-			EffectiveDate: util.CABEffectiveDate,
+			Name:            "e_dsa_unique_correct_representation",
+			Description:     "DSA: Public key value has the unique correct representation in the field, and that the key has the correct order in the subgroup",
+			Citation:        "BRs v1.7.0: 6.1.6",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.CABFBRs_1_7_1_Date,
 		},
 		Lint: NewDsaUniqueCorrectRepresentation,
 	})


### PR DESCRIPTION
DSA is prohibited, so we can't maintain an up-to-date reference for how a DSA key should be structured. Instead of checking prohibited DSA certs against the old requirements, rely on lint_prohibit_dsa_usage.go