### PR TITLE
Improve util.IsEmailProtectionCert function

### DIFF
--- a/v3/lint/base.go
+++ b/v3/lint/base.go
@@ -221,7 +221,7 @@ func (l *CertificateLint) Execute(cert *x509.Certificate, config Configuration) 
 	if l.Source == CABFBaselineRequirements && !util.IsServerAuthCert(cert) {
 		return &LintResult{Status: NA}
 	}
-	if l.Source == CABFSMIMEBaselineRequirements && !((util.IsEmailProtectionCert(cert) && util.HasEmailSAN(cert)) || util.IsSMIMEBRCertificate(cert)) {
+	if l.Source == CABFSMIMEBaselineRequirements && !util.IsEmailProtectionCert(cert) {
 		return &LintResult{Status: NA}
 	}
 	lint := l.Lint()

--- a/v3/util/ca.go
+++ b/v3/util/ca.go
@@ -70,17 +70,20 @@ func IsServerAuthCert(cert *x509.Certificate) bool {
 }
 
 // IsEmailProtectionCert returns true if the certificate presented is for use protecting emails.
-// A certificate is for use protecting emails if it contains the Any Purpose or emailProtection
-// EKUs or if the certificate contains no EKUs.  This last point is a way of being overly cautious
-// and choosing to prefer false positives over false negatives.
+// The S/MIME BRs say the certificate can be identified by an EKU for id-kp-emailProtection
+// and the inclusion of a rfc822Name SAN or an otherName of type id-on-SmtpUTF8Mailbox.
+// As a way of being overly cautious and choosing to prefer false positives over false negatives,
+// also include certificates that have no EKUs, the any purpose EKU, or one of the policy OIDs.
 func IsEmailProtectionCert(cert *x509.Certificate) bool {
-	if len(cert.ExtKeyUsage) == 0 {
-		return true
-	}
-	for _, eku := range cert.ExtKeyUsage {
-		if eku == x509.ExtKeyUsageAny || eku == x509.ExtKeyUsageEmailProtection {
+	if HasEmailSAN(cert) {
+		if len(cert.ExtKeyUsage) == 0 && len(cert.UnknownExtKeyUsage) == 0 {
 			return true
 		}
+		for _, eku := range cert.ExtKeyUsage {
+			if eku == x509.ExtKeyUsageAny || eku == x509.ExtKeyUsageEmailProtection {
+				return true
+			}
+		}
 	}
-	return false
+	return IsSMIMEBRCertificate(cert)
 }


### PR DESCRIPTION
This applies the same improvement from #856 to the S/MIME lints.