### PR TITLE
Fix goreleaser to use the --clean flag rather than --rm-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
           workdir: v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `--rm-dist` flag was apparently renamed to `--clean`.

https://github.com/goreleaser/goreleaser/blob/137855902e33dfcf6f1fa470833b0028ab5440b9/www/docs/deprecations.md?plain=1#L450

```md
### --rm-dist

> since 2023-01-17 (v1.15.0), removed 2024-05-26 (v2.0)

`--rm-dist` has been deprecated in favor of `--clean`.

=== "Before"

    ```bash
    goreleaser release --rm-dist
    ```

=== "After"

    ```bash
    goreleaser release --clean
    ```
```