### PR TITLE
Update main.go to have CRL linting lint on provided registry

### DIFF
--- a/v3/cmd/zlint/main.go
+++ b/v3/cmd/zlint/main.go
@@ -200,7 +200,7 @@ func doLint(inputFile *os.File, inform string, registry lint.Registry) {
 		if err != nil {
 			log.Fatalf("unable to parse certificate revocation list: %s", err)
 		}
-		zlintResult = zlint.LintRevocationList(crl)
+		zlintResult = zlint.LintRevocationListEx(crl, registry)
 	} else {
 		c, err := x509.ParseCertificate(asn1Data)
 		if err != nil {


### PR DESCRIPTION
Currently, linting a CRL will run all lint sources. The proposed change makes it so that only the provided lint sources or lint names will be run when a CRL is linted.