### PR TITLE
RFC8813 is not recognized as a valid lint source from the CLI

### DIFF
--- a/v3/lint/source.go
+++ b/v3/lint/source.go
@@ -53,7 +53,7 @@ func (s *LintSource) UnmarshalJSON(data []byte) error {
 	}
 
 	switch LintSource(throwAway) {
-	case RFC5280, RFC5480, RFC5891, CABFBaselineRequirements, CABFEVGuidelines, CABFSMIMEBaselineRequirements, MozillaRootStorePolicy, AppleRootStorePolicy, Community, EtsiEsi, RFC6962:
+	case RFC8813, RFC5280, RFC5480, RFC5891, CABFBaselineRequirements, CABFEVGuidelines, CABFSMIMEBaselineRequirements, MozillaRootStorePolicy, AppleRootStorePolicy, Community, EtsiEsi, RFC6962:
 		*s = LintSource(throwAway)
 		return nil
 	default:
@@ -77,6 +77,8 @@ func (s *LintSource) FromString(src string) {
 		*s = RFC5480
 	case RFC5891:
 		*s = RFC5891
+	case RFC8813:
+		*s = RFC8813
 	case CABFBaselineRequirements:
 		*s = CABFBaselineRequirements
 	case CABFEVGuidelines:


### PR DESCRIPTION
This is an issue in the CLI frontend. The lint source does indeed run when `zlint` is invoked with a filter that does not explicitly refer to RFC8813. The following will run `RFC8813` successfully.

```shell
./zlint -excludeSources CABF_BR github.com
```

However, the following will simply error out at the CLI

```shell
./zlint -excludeSources RFC8813 github.com
FATA[0000] invalid -excludeSources: unknown lint source in list: "RFC8813" 
exit status 1
```

Issues such as this are found about 1-2 times per year, which is too much. I've made an issue for myself (#878) that this codebase would benefit from integration tests with the frontend.

Thank you @yukoori for submitting the issue!