### PR TITLE
Linter is broken due to a broken dependency on an old Golang version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,17 +14,10 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v2
-
-#      - name: Set up Go
-#        uses: actions/setup-go@v2
-#        with:
-#          go-version: ^1.18
       - name: Install golangci-lint
         run: |
           wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.tar.gz
           tar zxvf golangci-lint-1.62.0-linux-amd64.tar.gz
-          #wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.deb
-          #sudo apt install -y ./golangci-lint-1.62.0-linux-amd64.deb
       - name: Run golangci-lint
         run: |
           cd v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.18
+          go-version: 1.18
       - name: Install golangci-lint
         run: |
           wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.deb

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,15 +15,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.18
+#      - name: Set up Go
+#        uses: actions/setup-go@v2
+#        with:
+#          go-version: ^1.18
       - name: Install golangci-lint
         run: |
-          wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.deb
-          sudo apt install -y ./golangci-lint-1.62.0-linux-amd64.deb
+          wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.tar.gz
+          tar zxvf golangci-lint-1.62.0-linux-amd64.tar.gz
+          #wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.deb
+          #sudo apt install -y ./golangci-lint-1.62.0-linux-amd64.deb
       - name: Run golangci-lint
         run: |
           cd v3
-          golangci-lint run
+          ../golangci-lint run

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,4 +27,5 @@ jobs:
           #sudo apt install -y ./golangci-lint-1.62.0-linux-amd64.deb
       - name: Run golangci-lint
         run: |
+          cd v3
           ../golangci-lint-1.62.0-linux-amd64/golangci-lint run

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,13 +23,8 @@ jobs:
         run: |
           wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.tar.gz
           tar zxvf golangci-lint-1.62.0-linux-amd64.tar.gz
-          pwd
-          ls
           #wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.deb
           #sudo apt install -y ./golangci-lint-1.62.0-linux-amd64.deb
       - name: Run golangci-lint
         run: |
-          pwd
-          ls
-          cd v3
-          ../golangci-lint run
+          ../golangci-lint-1.62.0-linux-amd64/golangci-lint run

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.20
+          go-version: ^1.18
       - name: Install golangci-lint
         run: |
           wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.deb

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,9 +23,13 @@ jobs:
         run: |
           wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.tar.gz
           tar zxvf golangci-lint-1.62.0-linux-amd64.tar.gz
+          pwd
+          ls
           #wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.deb
           #sudo apt install -y ./golangci-lint-1.62.0-linux-amd64.deb
       - name: Run golangci-lint
         run: |
+          pwd
+          ls
           cd v3
           ../golangci-lint run

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,16 +9,18 @@ on:
 jobs:
   golangci:
     name: Lint Sourcecode
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install golangci-lint
         run: |
-          wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.tar.gz
-          tar zxvf golangci-lint-1.62.0-linux-amd64.tar.gz
+          VERSION=1.62.0
+          wget https://github.com/golangci/golangci-lint/releases/download/v${VERSION}/golangci-lint-${VERSION}-linux-amd64.tar.gz
+          tar zxvf golangci-lint-${VERSION}-linux-amd64.tar.gz
+          mv golangci-lint-${VERSION}-linux-amd64/golangci-lint . 
       - name: Run golangci-lint
         run: |
           cd v3
-          ../golangci-lint-1.62.0-linux-amd64/golangci-lint run
+          ../golangci-lint run

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,8 +21,8 @@ jobs:
           go-version: ^1.20
       - name: Install golangci-lint
         run: |
-          wget https://github.com/golangci/golangci-lint/releases/download/v1.61.0/golangci-lint-1.61.0-linux-amd64.deb
-          sudo apt install -y ./golangci-lint-1.61.0-linux-amd64.deb
+          wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.deb
+          sudo apt install -y ./golangci-lint-1.62.0-linux-amd64.deb
       - name: Run golangci-lint
         run: |
           cd v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   golangci:
     name: Lint Sourcecode
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Check out code
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: ^1.18
       - name: Install golangci-lint
         run: |
           wget https://github.com/golangci/golangci-lint/releases/download/v1.62.0/golangci-lint-1.62.0-linux-amd64.deb

--- a/v3/lint/registration.go
+++ b/v3/lint/registration.go
@@ -35,6 +35,8 @@ import (
 //
 // Only one of NameFilter or IncludeNames/ExcludeNames can be provided at
 // a time.
+//
+//nolint:recvcheck
 type FilterOptions struct {
 	// NameFilter is a regexp used to filter lints by their name. It is mutually
 	// exclusive with IncludeNames and ExcludeNames.

--- a/v3/lint/result.go
+++ b/v3/lint/result.go
@@ -23,6 +23,7 @@ import (
 // LintStatus is an enum returned by lints inside of a LintResult.
 //
 //nolint:revive
+//nolint:recvcheck
 type LintStatus int
 
 // Known LintStatus values

--- a/v3/lint/result.go
+++ b/v3/lint/result.go
@@ -22,8 +22,7 @@ import (
 
 // LintStatus is an enum returned by lints inside of a LintResult.
 //
-//nolint:revive
-//nolint:recvcheck
+//nolint:revive,recvcheck
 type LintStatus int
 
 // Known LintStatus values

--- a/v3/lint/source.go
+++ b/v3/lint/source.go
@@ -23,7 +23,7 @@ import (
 // LintSource is a type representing a known lint source that lints cite
 // requirements from.
 //
-//nolint:revive,recvcheck
+//nolint:revive
 type LintSource string
 
 const (
@@ -99,6 +99,8 @@ func (s *LintSource) FromString(src string) {
 }
 
 // SourceList is a slice of LintSources that can be sorted.
+//
+//nolint:recvcheck
 type SourceList []LintSource
 
 // Len returns the length of the list.

--- a/v3/lint/source.go
+++ b/v3/lint/source.go
@@ -23,8 +23,7 @@ import (
 // LintSource is a type representing a known lint source that lints cite
 // requirements from.
 //
-//nolint:revive
-//nolint:recvcheck
+//nolint:revive,recvcheck
 type LintSource string
 
 const (

--- a/v3/lint/source.go
+++ b/v3/lint/source.go
@@ -24,6 +24,7 @@ import (
 // requirements from.
 //
 //nolint:revive
+//nolint:recvcheck
 type LintSource string
 
 const (


### PR DESCRIPTION
I couldn't tell you why, but the `.deb` package that golangci-lint produces declares a dependency on the compiler (1.18) and that old version appears to be yanked from the repos.

So may as well just download the precompiled binary and bypass their broken packaging.