### PR TITLE
Panics should not prevent other lints from running

### DIFF
--- a/v3/lint/base_test.go
+++ b/v3/lint/base_test.go
@@ -15,10 +15,11 @@ package lint
  */
 
 import (
-	"github.com/zmap/zcrypto/x509"
-	"github.com/zmap/zlint/v3/util"
 	"testing"
 	"time"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/util"
 )
 
 // This test attempts to simplify the truth table by assigning dates to the

--- a/v3/lint/base_test.go
+++ b/v3/lint/base_test.go
@@ -15,6 +15,7 @@ package lint
  */
 
 import (
+	"github.com/zmap/zlint/v3/util"
 	"testing"
 	"time"
 
@@ -311,4 +312,36 @@ func TestLint_RevocationListLint_CheckEffective(t *testing.T) {
 				d.Lint.Description, d.RevocationList.Description, got, d.Want)
 		}
 	}
+}
+
+func TestPanicLint(t *testing.T) {
+	lint := &CertificateLint{
+		LintMetadata: LintMetadata{
+			Name:          "lgtm",
+			Description:   "bad code go boom boom",
+			Citation:      "not a chance",
+			Source:        RFC5280,
+			EffectiveDate: util.RFC5280Date,
+		},
+		Lint: NewPanicLint,
+	}
+	result := lint.Execute(&x509.Certificate{NotBefore: time.Now()}, Configuration{})
+	if result.Status != Fatal {
+		t.Errorf("Lint failed, expected Fatal, got %v", result.Status)
+	}
+}
+
+type PanicLint struct {
+}
+
+func NewPanicLint() LintInterface {
+	return &PanicLint{}
+}
+
+func (l *PanicLint) CheckApplies(_ *x509.Certificate) bool {
+	return true
+}
+
+func (l *PanicLint) Execute(_ *x509.Certificate) *LintResult {
+	panic("Earth shattering kaboom")
 }

--- a/v3/lint/base_test.go
+++ b/v3/lint/base_test.go
@@ -15,11 +15,10 @@ package lint
  */
 
 import (
+	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/v3/util"
 	"testing"
 	"time"
-
-	"github.com/zmap/zcrypto/x509"
 )
 
 // This test attempts to simplify the truth table by assigning dates to the
@@ -318,7 +317,7 @@ func TestPanicLint(t *testing.T) {
 	lint := &CertificateLint{
 		LintMetadata: LintMetadata{
 			Name:          "lgtm",
-			Description:   "bad code go boom boom",
+			Description:   "bad code go boom",
 			Citation:      "not a chance",
 			Source:        RFC5280,
 			EffectiveDate: util.RFC5280Date,


### PR DESCRIPTION
Although it hasn't been an issue (that I'm aware of), it is possible for a single lint crash the entire program. I reckon that these panics should simply be converted into a `lint.Fatal` for that one lint so that life can move on and unblock the rest of the linter.