### PR TITLE
OU (2.5.4.11) is incorrectly omitted from the allow list in e_ev_extra_subject_attribs

### DIFF
--- a/v3/integration/config.json
+++ b/v3/integration/config.json
@@ -978,7 +978,7 @@
         "ErrCount": 1303
     },
     "e_ev_extra_subject_attribs": {
-        "ErrCount": 12279
+        "ErrCount": 63
     },
     "e_subj_contains_html_entities": {
         "ErrCount": 14

--- a/v3/lints/cabf_ev/lint_extra_subject_attribs.go
+++ b/v3/lints/cabf_ev/lint_extra_subject_attribs.go
@@ -51,15 +51,6 @@ func (l *extraSubjectAttribs) CheckApplies(c *x509.Certificate) bool {
 	return util.IsEV(c.PolicyIdentifiers) && util.IsSubscriberCert(c)
 }
 
-/*
- * We also include the OU attribute here, even though it is now banned, because this lint
- * deals with a more general requirement that came into force long before the OU ban,
- * and there is already another lint that deals with the OU attribute specifically.
- *
- * The organizationIdentifier attribute is only permitted starting from 21-may-2019 (EVGL 1.7.0),
- * which is slightly after SC16 came into force, however any certificates that contain this
- * attribute and were issued before that date have long since expired, so it makes no difference.
- */
 var allowedAttribs = map[string]bool{
 	"1.3.6.1.4.1.311.60.2.1.1": true, // joiLocalityName
 	"1.3.6.1.4.1.311.60.2.1.2": true, // joiStateOrProvinceName
@@ -71,9 +62,20 @@ var allowedAttribs = map[string]bool{
 	"2.5.4.8":                  true, // stateOrProvinceName
 	"2.5.4.9":                  true, // streetAddress
 	"2.5.4.10":                 true, // organizationName
-	"2.5.4.15":                 true, // businessCategory
-	"2.5.4.17":                 true, // postalCode
-	"2.5.4.97":                 true, // organizationIdentifier
+	/*
+	 * We also include the OU attribute here, even though it is now banned, because this lint
+	 * deals with a more general requirement that came into force long before the OU ban,
+	 * and there is already another lint that deals with the OU attribute specifically.
+	 */
+	"2.5.4.11": true, // organizationUnitName
+	"2.5.4.15": true, // businessCategory
+	"2.5.4.17": true, // postalCode
+	/*
+	 * The organizationIdentifier attribute is only permitted starting from 21-may-2019 (EVGL 1.7.0),
+	 * which is slightly after SC16 came into force, however any certificates that contain this
+	 * attribute and were issued before that date have long since expired, so it makes no difference.
+	 */
+	"2.5.4.97": true, // organizationIdentifier
 }
 
 func (l *extraSubjectAttribs) Execute(c *x509.Certificate) *lint.LintResult {

--- a/v3/lints/cabf_ev/lint_extra_subject_attribs_test.go
+++ b/v3/lints/cabf_ev/lint_extra_subject_attribs_test.go
@@ -53,6 +53,10 @@ func TestExtraSubjectAttribs(t *testing.T) {
 			want:  lint.Pass,
 		},
 		{
+			input: "extra_subj_attrs_with_ou_ok2.pem",
+			want:  lint.Pass,
+		},
+		{
 			input: "extra_subj_attrs_ne1.pem",
 			want:  lint.NE,
 		},

--- a/v3/testdata/extra_subj_attrs_with_ou_ok2.pem
+++ b/v3/testdata/extra_subj_attrs_with_ou_ok2.pem
@@ -1,0 +1,64 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer:
+        Validity
+            Not Before: Feb  8 16:15:44 2025 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.org, OU = Example Security Division, O = "Example Corp, Inc.", street = 123 Example Street, L = San Francisco, ST = California, C = US, serialNumber = 1234567890
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:15:00:78:6a:d2:96:d0:4f:d6:60:10:5d:61:7f:
+                    46:6d:44:a0:26:89:55:10:1f:9e:72:85:86:fa:fe:
+                    2a:92:a4:fa:9c:83:05:dc:cf:cc:ab:7c:bc:aa:7d:
+                    db:8e:dd:26:75:ed:04:2b:81:4f:fb:ae:1e:34:e9:
+                    1e:23:51:b9:e0
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Subject Key Identifier:
+                81:2F:1F:10:DF:33:E6:9B:E4:2C:0F:AE:E6:F4:8D:51:BC:63:E1:BA
+            X509v3 Authority Key Identifier:
+                E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+            Authority Information Access:
+                OCSP - URI:http://ca.someca-inc.com/ocsp
+                CA Issuers - URI:http://ca.someca-inc.com/root
+            X509v3 Subject Alternative Name:
+                DNS:example.org
+            X509v3 Certificate Policies:
+                Policy: 2.23.140.1.1
+            X509v3 CRL Distribution Points:
+                Full Name:
+                  URI:http://ca.someca-inc.com/crl
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:21:00:be:3d:65:20:74:8a:e7:d8:9e:fc:ce:ff:f3:
+        9b:f5:50:34:8c:e2:2a:88:c4:56:e5:a8:7d:8c:bc:a6:3d:0e:
+        f4:02:20:52:c6:89:c7:24:a9:46:5e:8f:f8:7c:4b:21:dc:2f:
+        d1:90:93:11:3e:4c:e8:90:79:92:5d:11:18:0a:61:b3:1f
+-----BEGIN CERTIFICATE-----
+MIIC6zCCApGgAwIBAgIBAzAKBggqhkjOPQQDAjAAMCAXDTI1MDIwODE2MTU0NFoY
+Dzk5OTgxMTMwMDAwMDAwWjCBwzEUMBIGA1UEAxMLZXhhbXBsZS5vcmcxIjAgBgNV
+BAsTGUV4YW1wbGUgU2VjdXJpdHkgRGl2aXNpb24xGzAZBgNVBAoTEkV4YW1wbGUg
+Q29ycCwgSW5jLjEbMBkGA1UECRMSMTIzIEV4YW1wbGUgU3RyZWV0MRYwFAYDVQQH
+Ew1TYW4gRnJhbmNpc2NvMRMwEQYDVQQIEwpDYWxpZm9ybmlhMQswCQYDVQQGEwJV
+UzETMBEGA1UEBRMKMTIzNDU2Nzg5MDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IA
+BBUAeGrSltBP1mAQXWF/Rm1EoCaJVRAfnnKFhvr+KpKk+pyDBdzPzKt8vKp9247d
+JnXtBCuBT/uuHjTpHiNRueCjggE0MIIBMDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0l
+BBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMB0GA1UdDgQWBBSBLx8Q3zPmm+QsD67m
+9I1RvGPhujAfBgNVHSMEGDAWgBTotvZ2S9A75Ual+VTUfgez3g1gPjBkBggrBgEF
+BQcBAQRYMFYwKQYIKwYBBQUHMAGGHWh0dHA6Ly9jYS5zb21lY2EtaW5jLmNvbS9v
+Y3NwMCkGCCsGAQUFBzAChh1odHRwOi8vY2Euc29tZWNhLWluYy5jb20vcm9vdDAW
+BgNVHREEDzANggtleGFtcGxlLm9yZzASBgNVHSAECzAJMAcGBWeBDAEBMC0GA1Ud
+HwQmMCQwIqAgoB6GHGh0dHA6Ly9jYS5zb21lY2EtaW5jLmNvbS9jcmwwCgYIKoZI
+zj0EAwIDSAAwRQIhAL49ZSB0iufYnvzO//Ob9VA0jOIqiMRW5ah9jLymPQ70AiBS
+xonHJKlGXo/4fEsh3C/RkJMRPkzokHmSXREYCmGzHw==
+-----END CERTIFICATE-----


### PR DESCRIPTION
The [relevant date](https://cabforum.org/working-groups/server/extended-validation/guidelines/#relevant-dates) table of the EV CABF guidelines specifically references that §9.2.7 regarding the prohibition of `subject:organizationalUnitName (OID: 2.5.4.11)` takes effect on 2022-09-01 rather than inheriting the effective date of the parent revision.

| Compliance Date | Section(s) | Summary Description |
|----------------|-----------|---------------------|
| 2022-09-01    | [9.2.7]   | CAs MUST NOT include the `organizationalUnitName` field in the Subject. |


The lint's in-code documentation correctly identifies that it should not have an opinion on `subject:organizationalUnitName (OID: 2.5.4.11)` as that lint covers all other subject attributes and leaves OU to its own lint. However, we removed OU from the allow list of this lint in #903. For my part, I read the CABF guideline and agreed to the change because I had forgotten that there was wording elsewhere that overrides the parent document's effective date.

@XolphinMartijn and @defacto64 I would appreciate it if you would chime in on whether-or-not you may an argument against the above. If not then I will move forward with the change.

Thank you @mathewhodson for your PR at #911 which highlighted this issue.