### PR TITLE
Fix the linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,19 +9,15 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - interfacer
-    - nosnakecase
     - tparallel
     - nonamedreturns
     - exhaustruct
     - stylecheck
     - gosec
     - dupl
-    - maligned
     - depguard
     - lll
     - prealloc
-    - scopelint
     - gocritic
     - gochecknoinits
     - gochecknoglobals
@@ -31,12 +27,9 @@ linters:
     - whitespace
     - gocognit
     - testpackage
-    - goerr113
-    - gomnd
     - gofumpt
     - exhaustive
     - goconst
-    - golint
     - godot
     - forbidigo
     - nlreturn
@@ -44,9 +37,7 @@ linters:
     - paralleltest
     - varnamelen
     - wrapcheck
-    - ifshort
     - gci
-    - exhaustivestruct
     - cyclop
     - errorlint
     - revive
@@ -55,6 +46,8 @@ linters:
     - tagliatelle
     - nilnil
     - mnd
+    - copyloopvar
+    - intrange
 
 issues:
   exclude-rules:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,6 +48,7 @@ linters:
     - mnd
     - copyloopvar
     - intrange
+    - err113
 
 issues:
   exclude-rules:


### PR DESCRIPTION
A handful were deprecated and no longer active.

```
level=warning msg="[lintersdb] The linter \"interfacer\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle"
level=warning msg="[lintersdb] The linter \"nosnakecase\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle"
level=warning msg="[lintersdb] The linter \"maligned\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle"
level=warning msg="[lintersdb] The linter \"scopelint\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle"
level=warning msg="[lintersdb] The linter \"gomnd\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle"
level=warning msg="[lintersdb] The linter \"golint\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle"
level=warning msg="[lintersdb] The linter \"ifshort\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle"
level=warning msg="[lintersdb] The linter \"exhaustivestruct\" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle"
level=warning msg="[lintersdb] The name \"goerr113\" is deprecated. The linter has been renamed to: err113."
level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
```

`copyloopvar` points out that you no longer have to alias a loop variable before capturing it in a closure. But it's not wrong to still do so and there are too many of them in this code base.

`intrange` points out that these days you can do `for i := range 10`. There are too many c-style loops to care to go through all of them. Besides, I don't quite like how it implicitly starts at `0`. I would have preferred something like the Rust syntax `for i in 0..10`.

`err113` has an opinion on how to construct errors. Far too many of them to conform.

Not that anyone is listening, or that this is particularly actionable, but I have not been impressed Go's linters. Perhaps I am simply spoiled by Rust's [clippy](https://github.com/rust-lang/rust-clippy). One of the best features is that can automatically apply the lint's suggestion (correctly! I have never seen in generate bunk code).
