### PR TITLE
Corrected an issue with not all lint sources being considered correcty during filtering

### DIFF
--- a/v3/lint/registration.go
+++ b/v3/lint/registration.go
@@ -253,11 +253,20 @@ func (r *registryImpl) BySource(s LintSource) []*Lint {
 // Sources returns a SourceList of registered LintSources. The list is not
 // sorted but can be sorted by the caller with sort.Sort() if required.
 func (r *registryImpl) Sources() SourceList {
+	set := map[LintSource]struct{}{}
+	for _, source := range r.certificateLints.Sources() {
+		set[source] = struct{}{}
+	}
+	for _, source := range r.revocationListLints.Sources() {
+		set[source] = struct{}{}
+	}
+	for _, source := range r.ocspResponseLints.Sources() {
+		set[source] = struct{}{}
+	}
 	var sources SourceList
-
-	sources = append(sources, r.certificateLints.Sources()...)
-	sources = append(sources, r.revocationListLints.Sources()...)
-	sources = append(sources, r.ocspResponseLints.Sources()...)
+	for source := range set {
+		sources = append(sources, source)
+	}
 	return sources
 }
 

--- a/v3/lint/source.go
+++ b/v3/lint/source.go
@@ -53,7 +53,20 @@ func (s *LintSource) UnmarshalJSON(data []byte) error {
 	}
 
 	switch LintSource(throwAway) {
-	case RFC8813, RFC5280, RFC5480, RFC5891, CABFBaselineRequirements, CABFEVGuidelines, CABFSMIMEBaselineRequirements, MozillaRootStorePolicy, AppleRootStorePolicy, Community, EtsiEsi, RFC6962:
+	case RFC3279,
+		RFC5280,
+		RFC5480,
+		RFC5891,
+		RFC6962,
+		RFC8813,
+		CABFBaselineRequirements,
+		CABFCSBaselineRequirements,
+		CABFSMIMEBaselineRequirements,
+		CABFEVGuidelines,
+		MozillaRootStorePolicy,
+		AppleRootStorePolicy,
+		Community,
+		EtsiEsi:
 		*s = LintSource(throwAway)
 		return nil
 	default:
@@ -71,28 +84,32 @@ func (s *LintSource) FromString(src string) {
 	// Trim space and try to match a known value
 	src = strings.TrimSpace(src)
 	switch LintSource(src) {
+	case RFC3279:
+		*s = RFC3279
 	case RFC5280:
 		*s = RFC5280
 	case RFC5480:
 		*s = RFC5480
 	case RFC5891:
 		*s = RFC5891
+	case RFC6962:
+		*s = RFC6962
 	case RFC8813:
 		*s = RFC8813
 	case CABFBaselineRequirements:
 		*s = CABFBaselineRequirements
-	case CABFEVGuidelines:
-		*s = CABFEVGuidelines
+	case CABFCSBaselineRequirements:
+		*s = CABFCSBaselineRequirements
 	case CABFSMIMEBaselineRequirements:
 		*s = CABFSMIMEBaselineRequirements
+	case CABFEVGuidelines:
+		*s = CABFEVGuidelines
 	case MozillaRootStorePolicy:
 		*s = MozillaRootStorePolicy
 	case AppleRootStorePolicy:
 		*s = AppleRootStorePolicy
 	case Community:
 		*s = Community
-	case RFC6962:
-		*s = RFC6962
 	case EtsiEsi:
 		*s = EtsiEsi
 	}


### PR DESCRIPTION
Addresses #925.

Additionally, the `list-sources` flag was printing duplicates because the same source is present across multiple lint types (cert, crl, and ocsp).