### PR TITLE
set IneffectiveDate for w_sub_ca_aia_does_not_contain_issuing_ca_url

### DIFF
--- a/v3/lints/cabf_br/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
+++ b/v3/lints/cabf_br/lint_sub_ca_aia_does_not_contain_issuing_ca_url.go
@@ -35,11 +35,12 @@ It SHOULD contain the HTTP URL of the Issuing CA’s certificate (accessMethod =
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
-			Name:          "w_sub_ca_aia_does_not_contain_issuing_ca_url",
-			Description:   "Subordinate CA Certificate: authorityInformationAccess SHOULD also contain the HTTP URL of the Issuing CA's certificate.",
-			Citation:      "BRs: 7.1.2.2",
-			Source:        lint.CABFBaselineRequirements,
-			EffectiveDate: util.CABEffectiveDate,
+			Name:            "w_sub_ca_aia_does_not_contain_issuing_ca_url",
+			Description:     "Subordinate CA Certificate: authorityInformationAccess SHOULD also contain the HTTP URL of the Issuing CA's certificate.",
+			Citation:        "BRs: 7.1.2.2",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.CABFBRs_2_0_0_Date,
 		},
 		Lint: NewSubCaIssuerUrl,
 	})

--- a/v3/lints/cabf_br/lint_sub_ca_aia_does_not_contain_issuing_ca_url_test.go
+++ b/v3/lints/cabf_br/lint_sub_ca_aia_does_not_contain_issuing_ca_url_test.go
@@ -38,3 +38,12 @@ func TestSubCaAiaHasIssuerUrl(t *testing.T) {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
+
+func TestSubCaAiaNoIssuerUrlAfterIneffective(t *testing.T) {
+	inputPath := "subCAAIANoIssuerIneffective.pem"
+	expected := lint.NE
+	out := test.TestLint("w_sub_ca_aia_does_not_contain_issuing_ca_url", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/v3/testdata/subCAAIANoIssuerIneffective.pem
+++ b/v3/testdata/subCAAIANoIssuerIneffective.pem
@@ -1,0 +1,111 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            0d:f2:26:10:e1:a0:32:db:4b:ee:1e:8b:d0:79:a4:13
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: C = US, O = Example, CN = Example ECDSA 256 M02
+        Validity
+            Not Before: Sep 15 00:00:01 2023 GMT
+            Not After : Apr  1 23:59:59 2026 GMT
+        Subject: C = US, O = Example, CN = revoked.rootca3.demo.example.com
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:a9:16:04:3f:4a:8e:fd:42:e3:25:2e:f9:f1:7a:
+                    a1:4f:1c:e6:a8:f2:d7:ee:59:47:6e:b2:87:e3:4c:
+                    65:9f:12:87:da:93:24:69:08:ec:34:e3:ef:91:fa:
+                    ee:30:84:b4:83:8a:60:c9:7d:c9:de:84:26:a3:d3:
+                    da:18:20:04:9a
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Authority Key Identifier: 
+                BB:78:9A:D7:68:33:32:9D:1A:BB:6C:FD:B1:34:4C:01:DE:CB:D0:75
+            X509v3 Subject Key Identifier: 
+                82:74:CB:F2:4D:AB:D7:53:CD:AF:F1:A7:8E:C2:7A:7F:28:09:06:AE
+            X509v3 Subject Alternative Name: 
+                DNS:revoked.rootca3.demo.example.com, DNS:revoked.sca3a.example.com
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl.e2m02.example.com/e2m02.crl
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.e2m02.example.com
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 0E:57:94:BC:F3:AE:A9:3E:33:1B:2C:99:07:B3:F7:90:
+                                DF:9B:C2:3D:71:32:25:DD:21:A9:25:AC:61:C5:4E:21
+                    Timestamp : Mar  2 01:03:24.786 2025 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:44:02:20:1F:B0:2E:6D:E0:69:CC:C2:57:39:14:BC:
+                                3C:EB:26:80:BC:53:96:97:8E:46:9D:53:B2:05:F6:04:
+                                B1:DB:EE:3E:02:20:45:92:23:1A:43:12:7A:7E:AE:4E:
+                                5E:11:03:A1:66:F6:E0:F6:C5:64:4C:1B:67:35:54:40:
+                                DB:56:99:2C:86:5F
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 64:11:C4:6C:A4:12:EC:A7:89:1C:A2:02:2E:00:BC:AB:
+                                4F:28:07:D4:1E:35:27:AB:EA:FE:D5:03:C9:7D:CD:F0
+                    Timestamp : Mar  2 01:03:24.852 2025 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:44:02:20:4B:95:9F:DB:EC:E4:2B:3C:AF:E6:06:E1:
+                                40:2C:9A:FF:20:3D:14:94:DA:11:FF:8C:CC:90:76:3A:
+                                9E:FF:8F:04:02:20:20:05:F8:C5:26:51:F6:CE:5A:0F:
+                                8A:E7:63:40:E0:A1:CC:AD:B8:39:27:E9:4D:5F:7D:D1:
+                                73:AA:13:6E:17:F0
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 49:9C:9B:69:DE:1D:7C:EC:FC:36:DE:CD:87:64:A6:B8:
+                                5B:AF:0A:87:80:19:D1:55:52:FB:E9:EB:29:DD:F8:C3
+                    Timestamp : Mar  2 01:03:24.867 2025 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:44:02:20:65:C8:12:36:1C:B1:A3:FF:3A:DA:C1:D2:
+                                67:48:9B:15:44:25:79:8C:16:17:E7:A5:E4:C5:59:EF:
+                                1E:17:44:0C:02:20:34:7F:E1:A1:06:58:54:72:D6:53:
+                                5A:0A:E4:ED:85:8D:CC:23:3A:77:AA:90:C4:CD:C0:FE:
+                                95:29:AA:7F:AD:8B
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:46:02:21:00:f8:94:2c:18:f6:8d:17:57:66:ba:39:06:cb:
+        43:53:db:e3:ec:4a:a0:b4:ea:6f:bf:5f:c1:29:b0:ae:3b:03:
+        84:02:21:00:de:55:40:e1:44:d5:f7:12:83:a6:1a:ce:41:bc:
+        3d:3e:68:09:8b:a6:0c:a6:ef:12:d0:70:95:39:ce:ca:17:1a
+-----BEGIN CERTIFICATE-----
+MIIEXjCCBAOgAwIBAgIQDfImEOGgMttL7h6L0HmkEzAKBggqhkjOPQQDAjA/MQsw
+CQYDVQQGEwJVUzEQMA4GA1UEChMHRXhhbXBsZTEeMBwGA1UEAxMVRXhhbXBsZSBF
+Q0RTQSAyNTYgTTAyMB4XDTIzMDkxNTAwMDAwMVoXDTI2MDQwMTIzNTk1OVowSjEL
+MAkGA1UEBhMCVVMxEDAOBgNVBAoTB0V4YW1wbGUxKTAnBgNVBAMTIHJldm9rZWQu
+cm9vdGNhMy5kZW1vLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcD
+QgAEqRYEP0qO/ULjJS758XqhTxzmqPLX7llHbrKH40xlnxKH2pMkaQjsNOPvkfru
+MIS0g4pgyX3J3oQmo9PaGCAEmqOCAtQwggLQMB8GA1UdIwQYMBaAFLt4mtdoMzKd
+Grts/bE0TAHey9B1MB0GA1UdDgQWBBSCdMvyTavXU82v8aeOwnp/KAkGrjBGBgNV
+HREEPzA9giByZXZva2VkLnJvb3RjYTMuZGVtby5leGFtcGxlLmNvbYIZcmV2b2tl
+ZC5zY2EzYS5leGFtcGxlLmNvbTATBgNVHSAEDDAKMAgGBmeBDAECATAOBgNVHQ8B
+Af8EBAMCAYYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMDcGA1UdHwQw
+MC4wLKAqoCiGJmh0dHA6Ly9jcmwuZTJtMDIuZXhhbXBsZS5jb20vZTJtMDIuY3Js
+MDkGCCsGAQUFBwEBBC0wKzApBggrBgEFBQcwAYYdaHR0cDovL29jc3AuZTJtMDIu
+ZXhhbXBsZS5jb20wDwYDVR0TAQH/BAUwAwEB/zCCAXsGCisGAQQB1nkCBAIEggFr
+BIIBZwFlAHUADleUvPOuqT4zGyyZB7P3kN+bwj1xMiXdIaklrGHFTiEAAAGVVGEa
+cgAABAMARjBEAiAfsC5t4GnMwlc5FLw86yaAvFOWl45GnVOyBfYEsdvuPgIgRZIj
+GkMSen6uTl4RA6Fm9uD2xWRMG2c1VEDbVpkshl8AdQBkEcRspBLsp4kcogIuALyr
+TygH1B41J6vq/tUDyX3N8AAAAZVUYRq0AAAEAwBGMEQCIEuVn9vs5Cs8r+YG4UAs
+mv8gPRSU2hH/jMyQdjqe/48EAiAgBfjFJlH2zloPiudjQOChzK24OSfpTV990XOq
+E24X8AB1AEmcm2neHXzs/DbezYdkprhbrwqHgBnRVVL76esp3fjDAAABlVRhGsMA
+AAQDAEYwRAIgZcgSNhyxo/862sHSZ0ibFUQleYwWF+el5MVZ7x4XRAwCIDR/4aEG
+WFRy1lNaCuTthY3MIzp3qpDEzcD+lSmqf62LMAoGCCqGSM49BAMCA0kAMEYCIQD4
+lCwY9o0XV2a6OQbLQ1Pb4+xKoLTqb79fwSmwrjsDhAIhAN5VQOFE1fcSg6YazkG8
+PT5oCYumDKbvEtBwlTnOyhca
+-----END CERTIFICATE-----


### PR DESCRIPTION
This change is intended to fix #956. It sets an `IneffectiveDate` for this lint for when this requirement was removed from the BRs to maintain backwards compatibility. I've also included a test with a certificate with a notBefore one second after the `IneffectiveDate`. That test cert is a sample cert modified to trigger this lint. I ran manual before-and-after tests with it to verify that it does trigger the warning without the patch. I'm confident has sufficient fidelity for this use, but let me know if you'd like to clean up any any component to make it a bit more like a real CA cert.

I traced back the changes, and it looks like this requirement was removed from the BRs in [v2.0.0](https://cabforum.org/uploads/CA-Browser-Forum-BR-v2.0.0.pdf) as part of the profile rework. You can see the new MAY requirement that replaced it in § 7.1.2.10.3 and the old SHOULD in the previous [v1.8.7](https://cabforum.org/uploads/CA-Browser-Forum-BR-1.8.7.pdf) §7.1.2.2(c). (That section was also rewritten from the language cited in the lint in [v1.7.1](https://cabforum.org/uploads/CA-Browser-Forum-BR-1.7.1-redlined.pdf), but that revision kept the SHOULD requirement, now phrased as `It SHOULD contain the HTTP URL of the Issuing CA’s certificate (accessMethod = 1.3.6.1.5.5.7.48.2).`) Note that 2.0.0 is the revision immediately following 1.8.7.