### PR TITLE
update citation for e_ca_common_name_missing

### DIFF
--- a/v3/lints/cabf_br/lint_ca_common_name_missing.go
+++ b/v3/lints/cabf_br/lint_ca_common_name_missing.go
@@ -22,12 +22,44 @@ import (
 
 type caCommonNameMissing struct{}
 
+/*
+--- Citation History of this Requirement ---
+v1.4.8 to v1.8.7: 7.1.4.3.1a
+v2.0.0 to v2.1.6: 7.1.2.10.2
+
+--- Version Notes ---
+As of v2.0.0, this requirement no longer applies to CA certificates that conform to the
+Cross-Certified Subordinate CA Certificate Profile. This lint does not implement this exemption
+because it is impossible to identify certificates to which it applies from only the certificate.
+
+This requirement was baselined at v2.1.6 and is current.
+
+--- Requirements Language ---
+BRs: 7.1.2
+If the CA asserts compliance with these Baseline Requirements, all certificates that it issues MUST
+comply with one of the following certificate profiles
+
+[Each of the CA profiles, excepting the Cross-Certified Subordinate CA Certificate Profile,
+specifies the subject follows 7.1.2.10.2]
+
+BRs: 7.1.2.10.2
+The following table details the acceptable AttributeTypes that may appear within the type
+field of an AttributeTypeAndValue, as well as the contents permitted within the value field.
++----------------+----------+----------------------------------------------------------+----------------+
+| Attribute Name | Presence | Value                                                    | Verification   |
++----------------+----------+----------------------------------------------------------+----------------+
+| commonName     | MUST     | The contents SHOULD be an identifier for the certificate |                |
+|                |          | such that the certificate’s Name is unique across all    |                |
+|                |          | certificates issued by the issuing certificate.          |                |
++----------------+----------+----------------------------------------------------------+----------------+
+*/
+
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
 			Name:          "e_ca_common_name_missing",
 			Description:   "CA Certificates common name MUST be included.",
-			Citation:      "BRs: 7.1.4.3.1",
+			Citation:      "BRs: 7.1.2.10.2",
 			Source:        lint.CABFBaselineRequirements,
 			EffectiveDate: util.CABV148Date,
 		},


### PR DESCRIPTION
This is related to #973. This requirement comes in after most of the early reformatting of the BRs, so the citation string is only one movement out of date. I've added the old citation and the versions it was included in the comments. I've also added the requirements language this lint is (now) based on to the comment, which is similar to how some other lints have it. ([example](https://github.com/zmap/zlint/blob/master/v3/lints/cabf_br/lint_ca_country_name_invalid.go#L27))

One sticking point is that in the new version, there is a "Cross-Certified Subordinate CA Certificate Profile" intended to allow new cross-signs of existing compliant CAs even after the name rules are update with their original names. This profile allows certain CAs without commonName in the subjects of their existing certificates issued before 2017-06-08 to receive new certificates which are not subject to this requirement, provided that "the encoded subject name MUST be byte-for-byte identical to the
encoded subject name of the existing CA Certificate." (It also allows other deviations from the normal CA naming requirements.) The profile otherwise looks similar to the other CA profiles.

Unfortunately, there doesn't seem to be any definitive, distinctive element to this profile that can be used to detect it in zlint. Additionally, the factors that allow its usage like "the existing CA Certificate complied with the Baseline Requirements in force at time of issuance" aren't detectable from the certificate itself. For now, I'm proposing to leave the implementation of the lint as it is with a note about this profile in the comment. CAs attempting to use it should already be aware that they are using it to circumvent the normal naming rules. Research users will unfortunately have to live with this limitation or follow up to determine if a certificate should have been eligible for this profile. If anyone has an idea how to accurately filter these certificates out, we might want to split this lint to separate the two forms of the requirement. Failing that, maybe the configuration system can be leveraged to indicate when a certificate is using this profile?