### PR TITLE
update CA countryName lints' citations

### DIFF
--- a/v3/lints/cabf_br/lint_ca_country_name_invalid.go
+++ b/v3/lints/cabf_br/lint_ca_country_name_invalid.go
@@ -23,11 +23,37 @@ import (
 type caCountryNameInvalid struct{}
 
 /************************************************
-BRs: 7.1.2.1e
-The	Certificate	Subject	MUST contain the following:
-‐	countryName	(OID 2.5.4.6).
-This field MUST	contain	the	two‐letter	ISO	3166‐1 country code	for	the country
-in which the CA’s place	of business	is located.
+--- Citation History of this Requirement ---
+v1.0 to v1.2.4:   9.1.4
+v1.2.5:           Appendix B 1E, 2H
+v1.3.0 to v1.4.7: 7.1.2.1e, 7.1.2.2h
+v1.4.8 to v1.8.7: 7.1.4.3.1c
+v2.0.0 to v2.1.6: 7.1.2.10.2
+
+--- Version Notes ---
+As of v2.0.0, this requirement no longer applies to CA certificates that conform to the
+Cross-Certified Subordinate CA Certificate Profile. This lint does not implement this exemption
+because it is infeasible to identify certificates to which it applies from only the certificate.
+
+This requirement was baselined at v2.1.6 and is current.
+
+--- Requirements Language ---
+BRs: 7.1.2
+If the CA asserts compliance with these Baseline Requirements, all certificates that it issues MUST
+comply with one of the following certificate profiles
+
+[Each of the CA profiles, excepting the Cross-Certified Subordinate CA Certificate Profile,
+specifies the subject follows 7.1.2.10.2 in the profile table.]
+
+BRs: 7.1.2.10.2
+The following table details the acceptable AttributeTypes that may appear within the type
+field of an AttributeTypeAndValue, as well as the contents permitted within the value field.
++----------------+----------+--------------------------------------------------------+-----------------+
+| Attribute Name | Presence | Value                                                  | Verification    |
++----------------+----------+--------------------------------------------------------+-----------------+
+| countryName    | MUST     | The two‐letter ISO 3166‐1 country code for the country | Section 3.2.2.3 |
+|                |          | in which the CA’s place of business is located.        |                 |
++----------------+----------+--------------------------------------------------------+-----------------+
 ************************************************/
 
 func init() {
@@ -35,7 +61,7 @@ func init() {
 		LintMetadata: lint.LintMetadata{
 			Name:          "e_ca_country_name_invalid",
 			Description:   "Root and Subordinate CA certificates MUST have a two-letter country code specified in ISO 3166-1",
-			Citation:      "BRs: 7.1.2.1",
+			Citation:      "BRs: 7.1.2.10.2",
 			Source:        lint.CABFBaselineRequirements,
 			EffectiveDate: util.CABEffectiveDate,
 		},

--- a/v3/lints/cabf_br/lint_ca_country_name_missing.go
+++ b/v3/lints/cabf_br/lint_ca_country_name_missing.go
@@ -23,11 +23,37 @@ import (
 type caCountryNameMissing struct{}
 
 /************************************************
-BRs: 7.1.2.1e
-The	Certificate	Subject	MUST contain the following:
-‐	countryName	(OID 2.5.4.6).
-This field MUST	contain	the	two‐letter	ISO	3166‐1 country code	for	the country
-in which the CA’s place	of business	is located.
+--- Citation History of this Requirement ---
+v1.0 to v1.2.4:   9.1.4
+v1.2.5:           Appendix B 1E, 2H
+v1.3.0 to v1.4.7: 7.1.2.1e, 7.1.2.2h
+v1.4.8 to v1.8.7: 7.1.4.3.1c
+v2.0.0 to v2.1.6: 7.1.2.10.2
+
+--- Version Notes ---
+As of v2.0.0, this requirement no longer applies to CA certificates that conform to the
+Cross-Certified Subordinate CA Certificate Profile. This lint does not implement this exemption
+because it is infeasible to identify certificates to which it applies from only the certificate.
+
+This requirement was baselined at v2.1.6 and is current.
+
+--- Requirements Language ---
+BRs: 7.1.2
+If the CA asserts compliance with these Baseline Requirements, all certificates that it issues MUST
+comply with one of the following certificate profiles
+
+[Each of the CA profiles, excepting the Cross-Certified Subordinate CA Certificate Profile,
+specifies the subject follows 7.1.2.10.2 in the profile table.]
+
+BRs: 7.1.2.10.2
+The following table details the acceptable AttributeTypes that may appear within the type
+field of an AttributeTypeAndValue, as well as the contents permitted within the value field.
++----------------+----------+--------------------------------------------------------+-----------------+
+| Attribute Name | Presence | Value                                                  | Verification    |
++----------------+----------+--------------------------------------------------------+-----------------+
+| countryName    | MUST     | The two‐letter ISO 3166‐1 country code for the country | Section 3.2.2.3 |
+|                |          | in which the CA’s place of business is located.        |                 |
++----------------+----------+--------------------------------------------------------+-----------------+
 ************************************************/
 
 func init() {
@@ -35,7 +61,7 @@ func init() {
 		LintMetadata: lint.LintMetadata{
 			Name:          "e_ca_country_name_missing",
 			Description:   "Root and Subordinate CA certificates MUST have a countryName present in subject information",
-			Citation:      "BRs: 7.1.2.1",
+			Citation:      "BRs: 7.1.2.10.2",
 			Source:        lint.CABFBaselineRequirements,
 			EffectiveDate: util.CABEffectiveDate,
 		},


### PR DESCRIPTION
This history on these two lints goes back quite a bit further than the last one, but I went ahead and included the full history. The early BR versions inexplicably express this requirement as being on the issuer field, at least until I guess someone remembered that the issuer field should match the subject of the CA certificate. Given that the fix in v1.4.8 just rephrases the existing wording against the CA's subject, I think that language was always intended to be interpreted as CA subject restriction and I've left that in the history.

I know the project favors many smaller CRs over large ones, but I've combined these two together because they have always been derived from the same language in the BRs and their history is identical.

These two lints, and also `e_ca_organization_name_missing` are both affected by the issue with the cross-signed CA profile I mentioned in #976 and this change does not address that. I'll open a new issue to track that problem as separate from the rest of the requirements language change.