### PR TITLE
update language and citations for e_ca_organization_name_missing

### DIFF
--- a/v3/lints/cabf_br/lint_ca_organization_name_missing.go
+++ b/v3/lints/cabf_br/lint_ca_organization_name_missing.go
@@ -23,16 +23,51 @@ import (
 type caOrganizationNameMissing struct{}
 
 /************************************************
-BRs: 7.1.2.1e
-The Certificate Subject MUST contain the following: organizationName (OID 2.5.4.10): This field MUST be present and the contents MUST contain either the Subject CA’s name or DBA as verified under Section 3.2.2.2.
+--- Citation History of this Requirement ---
+v1.0 to v1.2.4:   9.1.3
+v1.2.5:           Appendix B 1E, 2H
+v1.3.0 to v1.4.7: 7.1.2.1e, 7.1.2.2h
+v1.4.8 to v1.8.7: 7.1.4.3.1b
+v2.0.0 to v2.1.6: 7.1.2.10.2
+
+--- Version Notes ---
+As of v2.0.0, this requirement no longer applies to CA certificates that conform to the
+Cross-Certified Subordinate CA Certificate Profile. This lint does not implement this exemption
+because it is infeasible to identify certificates to which it applies from only the certificate.
+
+This requirement was baselined at v2.1.6 and is current.
+
+--- Requirements Language ---
+BRs: 7.1.2
+If the CA asserts compliance with these Baseline Requirements, all certificates that it issues MUST
+comply with one of the following certificate profiles
+
+[Each of the CA profiles, excepting the Cross-Certified Subordinate CA Certificate Profile,
+specifies the subject follows 7.1.2.10.2 in the profile table.]
+
+BRs: 7.1.2.10.2
+The following table details the acceptable AttributeTypes that may appear within the type
+field of an AttributeTypeAndValue, as well as the contents permitted within the value field.
++------------------+----------+--------------------------------------------------------+-----------------+
+| Attribute Name   | Presence | Value                                                  | Verification    |
++------------------+----------+--------------------------------------------------------+-----------------+
+| organizationName | MUST     | The CA’s name or DBA. The CA MAY include information   | Section 3.2.2.2 |
+|                  |          | in this field that differs slightly from the verified  |                 |
+|                  |          | name, such as common variations or abbreviations,      |                 |
+|                  |          | provided that the CA documents the difference and any  |                 |
+|                  |          | abbreviations used are locally accepted abbreviations; |                 |
+|                  |          | e.g. if the official record shows “Company Name        |                 |
+|                  |          | Incorporated”, the CA MAY use “Company Name Inc.” or   |                 |
+|                  |          | “Company Name”.                                        |                 |
++------------------+----------+--------------------------------------------------------+-----------------+
 ************************************************/
 
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
 			Name:          "e_ca_organization_name_missing",
-			Description:   "Root and Subordinate CA certificates MUST have a organizationName present in subject information",
-			Citation:      "BRs: 7.1.2.1",
+			Description:   "Root and Subordinate CA certificates MUST have an organizationName present in subject information",
+			Citation:      "BRs: 7.1.2.10.2",
 			Source:        lint.CABFBaselineRequirements,
 			EffectiveDate: util.CABEffectiveDate,
 		},


### PR DESCRIPTION
This is the last of the lints for the MUST include requirements for CA subjects. Like the other three, this PR only fixes the citation and the documentation in the comments. I'll open an issue to track fixing the cross-signed CA profile exemption separately.

The history of the organizationName requirement follows essentially the same history as the countryName requirements in #979, usually occurring in the same or an adjacent section. I've put it in a separate PR to highlight that most of the references are one character off so it doesn't get lost in the mix.

Summary:  
* added full requirement history for all previous versions
* replaced old governing language in the comments with the current table and language
* updated the Citation string to the current section
* fixed a typo in the Description string
* added a note about the limitations in handling cross-signed CAs with legacy subjects