### PR TITLE
Add cross-sign configuration for CA name tests

### DIFF
--- a/v3/lint/configuration_test.go
+++ b/v3/lint/configuration_test.go
@@ -934,6 +934,7 @@ func TestPrintConfiguration(t *testing.T) {
 [AppleRootStorePolicyConfig]
 
 [CABFBaselineRequirementsConfig]
+CrossSignedCa = false
 
 [CABFEVGuidelinesConfig]
 

--- a/v3/lint/global_configurations.go
+++ b/v3/lint/global_configurations.go
@@ -66,9 +66,11 @@ func (r RFC5891Config) namespace() string {
 // CABFBaselineRequirementsConfig is the higher scoped configuration which services as the deserialization target for...
 //
 // [CABFBaselineRequirementsConfig]
+// CrossSignedCa = false # Used to indicate that the certificate is a Cross-Certified Subordinate CA
 // ...
-// ...
-type CABFBaselineRequirementsConfig struct{}
+type CABFBaselineRequirementsConfig struct {
+	CrossSignedCa bool
+}
 
 func (c CABFBaselineRequirementsConfig) namespace() string {
 	return "CABFBaselineRequirementsConfig"
@@ -143,7 +145,6 @@ type GlobalConfiguration interface {
 // out a TOML document that is the full default configuration for ZLint.
 var defaultGlobals = []GlobalConfiguration{
 	&Global{},
-	&CABFBaselineRequirementsConfig{},
 	&RFC5280Config{},
 	&RFC5480Config{},
 	&RFC5891Config{},

--- a/v3/lints/cabf_br/lint_ca_common_name_missing_test.go
+++ b/v3/lints/cabf_br/lint_ca_common_name_missing_test.go
@@ -38,3 +38,39 @@ func TestCaCommonNameNotMissing(t *testing.T) {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
+
+func TestCaCommonNameMissingExplicitlyNotExemptCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = false`
+	inputPath := "caCommonNameMissing.pem"
+	expected := lint.Error
+	out := test.TestLintWithConfig("e_ca_common_name_missing", inputPath, config)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCaCommonNameMissingExemptCrossSignedCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = true`
+	inputPath := "caCommonNameMissing.pem"
+	expected := lint.NA
+	out := test.TestLintWithConfig("e_ca_common_name_missing", inputPath, config)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCaCommonNamePresentExemptButComplientCrossSignedCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = true`
+	inputPath := "caCommonNameNotMissing.pem"
+	expected := lint.NA
+	out := test.TestLintWithConfig("e_ca_common_name_missing", inputPath, config)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/v3/lints/cabf_br/lint_ca_country_name_invalid.go
+++ b/v3/lints/cabf_br/lint_ca_country_name_invalid.go
@@ -20,8 +20,6 @@ import (
 	"github.com/zmap/zlint/v3/util"
 )
 
-type caCountryNameInvalid struct{}
-
 /************************************************
 --- Citation History of this Requirement ---
 v1.0 to v1.2.4:   9.1.4
@@ -31,9 +29,11 @@ v1.4.8 to v1.8.7: 7.1.4.3.1c
 v2.0.0 to v2.1.6: 7.1.2.10.2
 
 --- Version Notes ---
-As of v2.0.0, this requirement no longer applies to CA certificates that conform to the
-Cross-Certified Subordinate CA Certificate Profile. This lint does not implement this exemption
-because it is infeasible to identify certificates to which it applies from only the certificate.
+As of v2.0.0, this requirement no longer applies to CA certificates that conform to the Cross-Certified
+Subordinate CA Certificate Profile. This lint uses the global CrossSignedCa setting to determine if the
+certificate under test should be treated as an exempt cross-signed CA. It does not attempt to determine
+if the issuance date is after CABFBRs_2_0_0_Date because CAs are permitted to back-date the notBefore
+to that of the earliest existing certificate under section 7.1.2.2.1
 
 This requirement was baselined at v2.1.6 and is current.
 
@@ -56,6 +56,10 @@ field of an AttributeTypeAndValue, as well as the contents permitted within the 
 +----------------+----------+--------------------------------------------------------+-----------------+
 ************************************************/
 
+type caCountryNameInvalid struct {
+	TlsBrConfig *lint.CABFBaselineRequirementsConfig
+}
+
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
@@ -73,8 +77,12 @@ func NewCaCountryNameInvalid() lint.LintInterface {
 	return &caCountryNameInvalid{}
 }
 
+func (l *caCountryNameInvalid) Configure() interface{} {
+	return l
+}
+
 func (l *caCountryNameInvalid) CheckApplies(c *x509.Certificate) bool {
-	return c.IsCA
+	return c.IsCA && (l.TlsBrConfig == nil || !l.TlsBrConfig.CrossSignedCa)
 }
 
 func (l *caCountryNameInvalid) Execute(c *x509.Certificate) *lint.LintResult {

--- a/v3/lints/cabf_br/lint_ca_country_name_invalid_test.go
+++ b/v3/lints/cabf_br/lint_ca_country_name_invalid_test.go
@@ -30,10 +30,55 @@ func TestCaCountryNameInvalid(t *testing.T) {
 	}
 }
 
+func TestCaCountryNameInvalidlyBlank(t *testing.T) {
+	inputPath := "caBlankCountry.pem"
+	expected := lint.Error
+	out := test.TestLint("e_ca_country_name_invalid", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
 func TestCaCountryNameValid(t *testing.T) {
 	inputPath := "caValCountry.pem"
 	expected := lint.Pass
 	out := test.TestLint("e_ca_country_name_invalid", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCaCountryNameInvalidExplicitlyNotExemptCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = false`
+	inputPath := "caInvalCountryCode.pem"
+	expected := lint.Error
+	out := test.TestLintWithConfig("e_ca_country_name_invalid", inputPath, config)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCaCountryNameExemptCrossSignedCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = true`
+	inputPath := "caInvalCountryCode.pem"
+	expected := lint.NA
+	out := test.TestLintWithConfig("e_ca_country_name_invalid", inputPath, config)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCaCountryNameExemptButComplientCrossSignedCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = true`
+	inputPath := "caValCountry.pem"
+	expected := lint.NA
+	out := test.TestLintWithConfig("e_ca_country_name_invalid", inputPath, config)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}

--- a/v3/lints/cabf_br/lint_ca_country_name_missing.go
+++ b/v3/lints/cabf_br/lint_ca_country_name_missing.go
@@ -20,8 +20,6 @@ import (
 	"github.com/zmap/zlint/v3/util"
 )
 
-type caCountryNameMissing struct{}
-
 /************************************************
 --- Citation History of this Requirement ---
 v1.0 to v1.2.4:   9.1.4
@@ -31,9 +29,11 @@ v1.4.8 to v1.8.7: 7.1.4.3.1c
 v2.0.0 to v2.1.6: 7.1.2.10.2
 
 --- Version Notes ---
-As of v2.0.0, this requirement no longer applies to CA certificates that conform to the
-Cross-Certified Subordinate CA Certificate Profile. This lint does not implement this exemption
-because it is infeasible to identify certificates to which it applies from only the certificate.
+As of v2.0.0, this requirement no longer applies to CA certificates that conform to the Cross-Certified
+Subordinate CA Certificate Profile. This lint uses the global CrossSignedCa setting to determine if the
+certificate under test should be treated as an exempt cross-signed CA. It does not attempt to determine
+if the issuance date is after CABFBRs_2_0_0_Date because CAs are permitted to back-date the notBefore
+to that of the earliest existing certificate under section 7.1.2.2.1
 
 This requirement was baselined at v2.1.6 and is current.
 
@@ -56,6 +56,10 @@ field of an AttributeTypeAndValue, as well as the contents permitted within the 
 +----------------+----------+--------------------------------------------------------+-----------------+
 ************************************************/
 
+type caCountryNameMissing struct {
+	TlsBrConfig *lint.CABFBaselineRequirementsConfig
+}
+
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
@@ -73,8 +77,12 @@ func NewCaCountryNameMissing() lint.LintInterface {
 	return &caCountryNameMissing{}
 }
 
+func (l *caCountryNameMissing) Configure() interface{} {
+	return l
+}
+
 func (l *caCountryNameMissing) CheckApplies(c *x509.Certificate) bool {
-	return c.IsCA
+	return c.IsCA && (l.TlsBrConfig == nil || !l.TlsBrConfig.CrossSignedCa)
 }
 
 func (l *caCountryNameMissing) Execute(c *x509.Certificate) *lint.LintResult {

--- a/v3/lints/cabf_br/lint_ca_country_name_missing_test.go
+++ b/v3/lints/cabf_br/lint_ca_country_name_missing_test.go
@@ -30,6 +30,15 @@ in which the CA’s place	of business	is located.
 ************************************************/
 
 func TestCaCountryNameMissing(t *testing.T) {
+	inputPath := "caMissingCountry.pem"
+	expected := lint.Error
+	out := test.TestLint("e_ca_country_name_missing", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCaCountryNameBlank(t *testing.T) {
 	inputPath := "caBlankCountry.pem"
 	expected := lint.Error
 	out := test.TestLint("e_ca_country_name_missing", inputPath)
@@ -42,6 +51,42 @@ func TestCaCountryNamePresent(t *testing.T) {
 	inputPath := "caValCountry.pem"
 	expected := lint.Pass
 	out := test.TestLint("e_ca_country_name_missing", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCaCountryNameMissingExplicitlyNotExemptCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = false`
+	inputPath := "caMissingCountry.pem"
+	expected := lint.Error
+	out := test.TestLintWithConfig("e_ca_country_name_missing", inputPath, config)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCaCountryNameMissingExemptCrossSignedCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = true`
+	inputPath := "caMissingCountry.pem"
+	expected := lint.NA
+	out := test.TestLintWithConfig("e_ca_country_name_missing", inputPath, config)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCaCountryNamePresentExemptButComplientCrossSignedCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = true`
+	inputPath := "caValCountry.pem"
+	expected := lint.NA
+	out := test.TestLintWithConfig("e_ca_country_name_missing", inputPath, config)
 	if out.Status != expected {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}

--- a/v3/lints/cabf_br/lint_ca_organization_name_missing.go
+++ b/v3/lints/cabf_br/lint_ca_organization_name_missing.go
@@ -20,8 +20,6 @@ import (
 	"github.com/zmap/zlint/v3/util"
 )
 
-type caOrganizationNameMissing struct{}
-
 /************************************************
 --- Citation History of this Requirement ---
 v1.0 to v1.2.4:   9.1.3
@@ -31,9 +29,11 @@ v1.4.8 to v1.8.7: 7.1.4.3.1b
 v2.0.0 to v2.1.6: 7.1.2.10.2
 
 --- Version Notes ---
-As of v2.0.0, this requirement no longer applies to CA certificates that conform to the
-Cross-Certified Subordinate CA Certificate Profile. This lint does not implement this exemption
-because it is infeasible to identify certificates to which it applies from only the certificate.
+As of v2.0.0, this requirement no longer applies to CA certificates that conform to the Cross-Certified
+Subordinate CA Certificate Profile. This lint uses the global CrossSignedCa setting to determine if the
+certificate under test should be treated as an exempt cross-signed CA. It does not attempt to determine
+if the issuance date is after CABFBRs_2_0_0_Date because CAs are permitted to back-date the notBefore
+to that of the earliest existing certificate under section 7.1.2.2.1
 
 This requirement was baselined at v2.1.6 and is current.
 
@@ -62,6 +62,10 @@ field of an AttributeTypeAndValue, as well as the contents permitted within the 
 +------------------+----------+--------------------------------------------------------+-----------------+
 ************************************************/
 
+type caOrganizationNameMissing struct {
+	TlsBrConfig *lint.CABFBaselineRequirementsConfig
+}
+
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
@@ -79,8 +83,12 @@ func NewCaOrganizationNameMissing() lint.LintInterface {
 	return &caOrganizationNameMissing{}
 }
 
+func (l *caOrganizationNameMissing) Configure() interface{} {
+	return l
+}
+
 func (l *caOrganizationNameMissing) CheckApplies(c *x509.Certificate) bool {
-	return c.IsCA
+	return c.IsCA && (l.TlsBrConfig == nil || !l.TlsBrConfig.CrossSignedCa)
 }
 
 func (l *caOrganizationNameMissing) Execute(c *x509.Certificate) *lint.LintResult {

--- a/v3/lints/cabf_br/lint_ca_organization_name_missing_test.go
+++ b/v3/lints/cabf_br/lint_ca_organization_name_missing_test.go
@@ -47,3 +47,39 @@ func TestCAOrgNameValid(t *testing.T) {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
+
+func TestCaOrgNameMissingExplicitlyNotExemptCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = false`
+	inputPath := "caOrgNameMissing.pem"
+	expected := lint.Error
+	out := test.TestLintWithConfig("e_ca_organization_name_missing", inputPath, config)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCaOrgNameMissingExemptCrossSignedCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = true`
+	inputPath := "caOrgNameMissing.pem"
+	expected := lint.NA
+	out := test.TestLintWithConfig("e_ca_organization_name_missing", inputPath, config)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCaOrgNamePresentExemptButComplientCrossSignedCa(t *testing.T) {
+	config := `
+	[CABFBaselineRequirementsConfig]
+	CrossSignedCa = true`
+	inputPath := "caValOrgName.pem"
+	expected := lint.NA
+	out := test.TestLintWithConfig("e_ca_organization_name_missing", inputPath, config)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/v3/testdata/caMissingCountry.pem
+++ b/v3/testdata/caMissingCountry.pem
@@ -1,0 +1,92 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Validity
+            Not Before: Jun 29 16:38:17 2016 GMT
+            Not After : Sep 10 16:38:17 2016 GMT
+        Subject: ST = FL, L = Tallahassee, street = 3210 Holly Mill Run, postalCode = 30062, O = Extreme Discord, OU = Chaos, CN = CA in FL but not somehow not US
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:d0:90:03:5b:8a:30:9b:27:f1:03:ef:1c:30:bf:
+                    59:80:9f:c9:87:2a:66:62:ec:8f:15:75:d4:4d:7b:
+                    2a:1c:ad:14:fe:18:12:7e:4a:93:82:2e:ca:d6:75:
+                    ac:77:2d:c2:da:4e:aa:40:41:52:ac:67:71:09:c0:
+                    af:81:d6:62:a7:d6:a1:cc:e9:10:2a:af:92:53:3a:
+                    6c:d7:02:38:7f:52:0e:81:ed:c9:5d:fd:22:61:da:
+                    5a:56:80:4a:42:a6:d1:c2:66:62:d5:03:94:67:16:
+                    ba:3f:91:0a:71:51:b4:a1:0f:ae:2c:c2:e3:e7:64:
+                    a6:ca:65:26:a6:e7:ab:0b:23:be:b6:8c:32:ff:d7:
+                    82:e7:73:87:6f:3e:54:04:42:af:9e:d5:d8:da:fa:
+                    cb:e1:7c:87:df:c9:21:d9:1a:79:cf:73:9d:7d:af:
+                    1d:98:01:15:e4:21:7c:0b:d6:3d:b1:75:0f:44:86:
+                    17:ec:42:fe:59:2c:7d:20:e4:5a:53:d2:e5:1d:dc:
+                    ef:57:a2:c9:e5:e2:18:7d:52:3e:01:f7:90:e7:fe:
+                    0e:6d:de:61:21:3d:38:cf:3b:84:c8:4f:b7:60:f6:
+                    ca:5a:33:5f:8b:f9:3e:98:54:06:23:12:c1:1e:b3:
+                    aa:91:67:62:66:e6:52:2b:4d:14:3b:47:c6:e6:c3:
+                    49:7f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Authority Key Identifier: 
+                01:02:03
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.2
+            X509v3 Subject Key Identifier: 
+                04:03:02:01
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        4c:6c:ae:0f:8b:c7:75:8e:21:34:1b:31:59:c3:6a:4d:83:42:
+        45:8f:de:98:f7:18:49:fc:c5:b2:86:f7:d6:69:03:4a:4f:2d:
+        7f:f3:66:09:4b:dd:a3:84:db:0b:d5:50:ca:03:7e:90:61:63:
+        23:fc:5e:0d:6a:1c:47:ba:94:89:81:03:0a:4c:b6:c5:28:64:
+        70:db:94:38:70:6e:47:05:ba:5a:25:38:ad:32:54:a4:41:04:
+        c0:04:0b:63:83:9f:4b:b8:39:19:db:f5:e3:c8:df:bf:eb:e0:
+        34:fa:87:49:c9:4b:25:e8:00:bb:dd:d0:5a:95:1a:70:2a:ed:
+        ac:db:0e:40:74:81:13:dd:63:aa:37:1f:e5:b5:ee:be:d0:7f:
+        6c:b5:20:bc:cf:36:7f:38:35:81:a0:ef:0b:46:b6:65:1a:f9:
+        f3:ca:00:aa:2e:17:3b:13:24:38:e6:86:3a:4d:8d:cd:e5:b7:
+        98:d0:4c:72:73:0b:25:e9:d0:5a:72:90:e7:b8:a8:5b:67:cc:
+        e5:b2:c0:e7:8d:f8:a4:e7:e7:7c:5c:a1:42:2d:ac:12:71:4a:
+        2f:28:ba:eb:65:d5:cf:76:3d:43:9e:6a:8d:1d:04:f0:90:a3:
+        5e:31:1a:16:0a:cd:bc:12:67:95:c4:3d:df:a9:38:4c:92:06:
+        31:c7:ec:08
+-----BEGIN CERTIFICATE-----
+MIIEUzCCAzugAwIBAgIFBDFmk+0wDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDU1vdGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcx
+FjAUBgNVBAMTDU1vdGhlciBOYXR1cmUwHhcNMTYwNjI5MTYzODE3WhcNMTYwOTEw
+MTYzODE3WjCBpTELMAkGA1UECBMCRkwxFDASBgNVBAcTC1RhbGxhaGFzc2VlMRww
+GgYDVQQJExMzMjEwIEhvbGx5IE1pbGwgUnVuMQ4wDAYDVQQREwUzMDA2MjEYMBYG
+A1UEChMPRXh0cmVtZSBEaXNjb3JkMQ4wDAYDVQQLEwVDaGFvczEoMCYGA1UEAxMf
+Q0EgaW4gRkwgYnV0IG5vdCBzb21laG93IG5vdCBVUzCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBANCQA1uKMJsn8QPvHDC/WYCfyYcqZmLsjxV11E17Khyt
+FP4YEn5Kk4IuytZ1rHctwtpOqkBBUqxncQnAr4HWYqfWoczpECqvklM6bNcCOH9S
+DoHtyV39ImHaWlaASkKm0cJmYtUDlGcWuj+RCnFRtKEPrizC4+dkpsplJqbnqwsj
+vraMMv/Xgudzh28+VARCr57V2Nr6y+F8h9/JIdkaec9znX2vHZgBFeQhfAvWPbF1
+D0SGF+xC/lksfSDkWlPS5R3c71eiyeXiGH1SPgH3kOf+Dm3eYSE9OM87hMhPt2D2
+ylozX4v5PphUBiMSwR6zqpFnYmbmUitNFDtHxubDSX8CAwEAAaOB2zCB2DAOBgNV
+HQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMA8GA1Ud
+EwEB/wQFMAMBAf8wDgYDVR0jBAcwBYADAQIDMGIGCCsGAQUFBwEBBFYwVDAhBggr
+BgEFBQcwAYYVaHR0cDovL3RoZWNhLm5ldC9vY3NwMC8GCCsGAQUFBzAChiNodHRw
+Oi8vdGhlY2EubmV0L3RvdGFsbHl0aGVjZXJ0LmNydDATBgNVHSAEDDAKMAgGBmeB
+DAECAjANBgNVHQ4EBgQEBAMCATANBgkqhkiG9w0BAQsFAAOCAQEATGyuD4vHdY4h
+NBsxWcNqTYNCRY/emPcYSfzFsob31mkDSk8tf/NmCUvdo4TbC9VQygN+kGFjI/xe
+DWocR7qUiYEDCky2xShkcNuUOHBuRwW6WiU4rTJUpEEEwAQLY4OfS7g5Gdv148jf
+v+vgNPqHSclLJegAu93QWpUacCrtrNsOQHSBE91jqjcf5bXuvtB/bLUgvM82fzg1
+gaDvC0a2ZRr588oAqi4XOxMkOOaGOk2NzeW3mNBMcnMLJenQWnKQ57ioW2fM5bLA
+5434pOfnfFyhQi2sEnFKLyi662XVz3Y9Q55qjR0E8JCjXjEaFgrNvBJnlcQ936k4
+TJIGMcfsCA==
+-----END CERTIFICATE-----


### PR DESCRIPTION
## Notes
This adds a new source level configuration to allow the user to specify that the input is a "Cross-Certified Subordinate CA Certificate" under the profile in § 7.1.2.2 to support proper evaluation of the subjects of those certificates. Unlike all the other CA profiles, these certificates are exempt from the CA naming rules in § 7.1.2.10.2 and instead have their own naming rules in § 7.1.2.2.2 that require only that they be byte-for-byte identical to the subject of the previous CA certificate. The only restriction is that the previous certificate must have been "issued in compliance with the then-current version of the Baseline Requirements." There's no way for zlint to check this or what naming requirements existed at the time, so instead it treats the CA naming rules as not applicable.

The reason this configuration is required is that there is no way to detect a cross-signed CA from the certificate itself. The only way to determine this would be a global search for matching CA certificates, which is clearly outside the scope of a static analysis tool like zlint. Instead, this allows the user (which might be the CA organization which issued it) to specify which rule set should apply based on outside context.

* Added a new source level configuration for the (TLS) Baseline Requirements to allow the user to specify that the input is a "Cross-Certified Subordinate CA Certificate" under the profile in § 7.1.2.2
  * This is not a global config: I've limited the scope to only the TLS BRs where this concept comes from. 
  * I made this a boolean because TOML and the zlint configuration system don't really support enumerated types or another similar way to specific which profile applied. Each lint independently evaluates the configuration based on which parts it wants to consider, so enforcing consistency in a string specifying the profile would be difficult.
  * This is the first source-level config to be added to zlint, but this applies to at least these 4 lints and probably at least two more which have this configuration at the individual level and could probably use to be set in a single place. This profile also ignores the normal rules for the certificatePolicies and extendedKeyUsage extensions and the encoding rules for name types, so it's likely it will be used in more places in the future.
* Removed a redundant entry for `CABFBaselineRequirementsConfig` from the global config list.
  * This looks like a bug that was included in the original configuration system commits that was being covered by the deduplication logic of the global configs and the fact that nothing was actually using this feature yet.
* Added new logic to `e_ca_common_name_missing`, `e_ca_country_name_invalid`, `e_ca_country_name_missing`, and `e_ca_organization_name_missing` to exempt CA certificates where the user indicates that they are cross-signed CAs
  * I think it makes more sense to mark these as `NA` than `PASS` because they don't actually pass the checks,  the section those checks are based on just doesn't apply to them, similar to how it doesn't apply to subscriber certificates.
* Updated the comments in that affected lints to indicate that cross-signed CA cert are now supported via a config setting and making note of the limitation on checking whether the certificates we issued during the period where such certs were/are allowed.
  * As noted in the comment, there's no way to tell when the certs were actually signed because CAs are permitted to back-date the notBefore field.
  * I decided against trying to add any way to specify when a certificate was actually issued because it would either require a massive change across zlint in how it processes issuance time, or else would be misleading/confusing in what it actually applies to. The limited value gained here doesn't seem to justify a change of that scale.
  * This is a two-way door that shouldn't constrain future development either way.
* Added some extra testing to the countryName lints, including a test where countryName is actually missing from the subject
  * For some reason, the name missing lint was being tested on a certificate that had a countryName in its subject sequence but where the name was an empty string. This seems more like an invalid name than a missing name to me so I've added a new test case that tests a certificate that actually has no countryName in its subject. I've also added the blank name cert as a test case to the `e_ca_country_name_invalid` test cases as an empty string is clearly an invalid name.
  * These tests aren't related to the rest of the change, but I wanted a more clearly appropriate certificate for the new tests I was adding for `e_ca_country_name_missing` anyway, so I included them here.


## Testing
* Updated the unit tests for the global config printer
* Updated tests for each of the affected lints with three test cases:
  * The config is present but set to false when the CA cert fails the test
  * The config is present and set to true which makes the test not applicable when it would otherwise fail
  * The config is present and set to true which makes the test not applicable when it would otherwise pass
  * The cases where the config is not present are retained from before this change.
* Added a new test certificate which is actually missing a RelativeDistinguishedName with a countryName AttributeTypeAndValue in the subject sequence because this is closer to what `e_ca_country_name_missing` is intended to test for
  * (It was modified from the existing test certificate, so the values are from that.)

## Document References
(Direct section fragment links work in Chrome, YMMV.)
* I developed these updates based on the then-current version 2.1.6, but 2.1.7 (released yesterday) doesn't make any changes to the certificate profiles and should not affect the correctness of these changes.
* See "Cross-Certified Subordinate CA Certificate Profile" in [§ 7.1.2.2](https://cabforum.org/working-groups/server/baseline-requirements/documents/CA-Browser-Forum-TLS-BR-2.1.7.pdf#page=93&zoom=100,92,509)
* See also, "Cross-Certified Subordinate CA Naming" in [§ 7.1.2.2.2](https://cabforum.org/working-groups/server/baseline-requirements/documents/CA-Browser-Forum-TLS-BR-2.1.7.pdf#page=94&zoom=100,92,465)
* The normal CA naming rules are in [§ 7.1.2.10.2](https://cabforum.org/working-groups/server/baseline-requirements/documents/CA-Browser-Forum-TLS-BR-2.1.7.pdf#page=129&zoom=100,92,96)

## Related Items
* This fixes #982 