### PR TITLE
Update n_ca_digital_signature_not_set citation, notice, and doc comment

### DIFF
--- a/v3/lints/cabf_br/lint_ca_digital_signature_not_set.go
+++ b/v3/lints/cabf_br/lint_ca_digital_signature_not_set.go
@@ -23,13 +23,34 @@ import (
 type caDigSignNotSet struct{}
 
 /************************************************
-BRs: 7.1.2.1b: Root CA Certificate keyUsage
-This extension MUST be present and MUST be marked critical. Bit positions for keyCertSign and cRLSign MUST be set.
-If the Root CA Private Key is used for signing OCSP responses, then the digitalSignature bit MUST be set.
+--- Citation History of this Requirement ---
+v1 to v1.2.5: Appendix B §1(B) (roots) and §2(E) (subordinate CAs)
+v1.3.0 to v1.8.7: 7.1.2.1b (roots) and §7.1.2.2e (subordinate CAs)
+v2.0.0 to v2.1.7: 7.1.2.10.7
 
-BRs: 7.1.2.2e: Subordinate CA Certificate keyUsage
-This extension MUST be present and MUST be marked critical. Bit positions for keyCertSign and cRLSign MUST be set.
-If the Root CA Private Key is used for signing OCSP responses, then the digitalSignature bit MUST be set.
+--- Version Notes ---
+In v1.1.3, Appendix B's sections were numbered but retained their previous titles. "Root CA Certificate"
+became section 1 and "Subordinate CA Certificate" became section 2. The numerical section references are
+used here for all versions following the original document format of the Baseline Requirements.
+
+This requirement was baselined at v2.1.7 and is current.
+
+--- Requirements Language ---
+BRs: 7.1.2 "Certificate Content and Extensions"
+If the CA asserts compliance with these Baseline Requirements, all certificates that it issues MUST
+comply with one of the following certificate profiles, which incorporate, and are derived from RFC 5280.
+
+[Each of the CA profiles specifies the keyUsage extension follows section 7.1.2.10.7]
+
+BRs: 7.1.2.10.7 "CA Certificate Key Usage"
++------------------+-----------+----------+
+| Key Usage        | Permitted | Required |
++------------------+-----------+----------+
+| digitalSignature | Y         | N^15     |
++------------------+-----------+----------+
+Footnote 15:
+If a CA Certificate does not assert the digitalSignature bit, the CA Private Key MUST NOT be
+used to sign an OCSP Response. See Section 7.3 for more information.
 ************************************************/
 
 func init() {
@@ -37,7 +58,7 @@ func init() {
 		LintMetadata: lint.LintMetadata{
 			Name:          "n_ca_digital_signature_not_set",
 			Description:   "Root and Subordinate CA Certificates that wish to use their private key for signing OCSP responses will not be able to without their digital signature set",
-			Citation:      "BRs: 7.1.2.1",
+			Citation:      "BRs: 7.1.2.10.7",
 			Source:        lint.CABFBaselineRequirements,
 			EffectiveDate: util.CABEffectiveDate,
 		},
@@ -57,6 +78,9 @@ func (l *caDigSignNotSet) Execute(c *x509.Certificate) *lint.LintResult {
 	if c.KeyUsage&x509.KeyUsageDigitalSignature != 0 {
 		return &lint.LintResult{Status: lint.Pass}
 	} else {
-		return &lint.LintResult{Status: lint.Notice}
+		return &lint.LintResult{
+			Status:  lint.Notice,
+			Details: "CA certificate does not assert digitalSignature and MUST NOT be used to sign OCSP responses",
+		}
 	}
 }


### PR DESCRIPTION
### Notes
This is similar to #997, but I broke this one out both because it's not a firm requirement, and because the way the supporting language is written is different. (It's in a weird footnote.) As with the error lints, this one was years out of date and I've added essentially the same version history to it. 

### Summery
* Updated the in-program citation strings for `n_ca_digital_signature_not_set`
* Added a full history of the locations of this warning to the lint comments
* Updated the requirement language in the comments to match the current language
* Added a details string to the result when the notice is raised
  * Because this is a Notice lint warning about a requirement that it's not actually testing, I figured it would be helpful to add something to the result about what it actually means. How useful this actually is probably depends on your integration pattern.

### Doc References
* [Ballot 97](https://cabforum.org/2013/02/21/ballot-97-prevention-of-unknown-certificate-contents/) (renumbered appendix)  
* [v1.2.5 Appendix B](https://cabforum.org/uploads/BRv1.2.5.pdf#page=42&zoom=100,62,120)  
* [v1.3.0 §7.1.2](https://cabforum.org/uploads/CAB-Forum-BR-1.3.0.pdf#page=38&zoom=110,62,458)  
* [v1.8.7 §7.1.2](https://cabforum.org/uploads/CA-Browser-Forum-BR-1.8.7.pdf#page=60&zoom=100,48,458)  
* [v2.0.0 §7.1.2.10.7](https://cabforum.org/uploads/CA-Browser-Forum-BR-v2.0.0.pdf#page=93&zoom=100,48,604)  
* [v2.1.7 §7.1.2.10.7](https://cabforum.org/working-groups/server/baseline-requirements/documents/CA-Browser-Forum-TLS-BR-2.1.7.pdf#page=133&zoom=100,92,249)