### PR TITLE
mark cab_dv_conflicts_with* lints superseded

### DIFF
--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_locality.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_locality.go
@@ -14,8 +14,28 @@ package cabf_br
  * permissions and limitations under the License.
  */
 
-// If the Certificate asserts the policy identifier of 2.23.140.1.2.1, then it MUST NOT include
-// organizationName, streetAddress, localityName, stateOrProvinceName, or postalCode in the Subject field.
+/*
+--- Citation History of this Requirement ---
+§9.3.1     v1.0   to v1.2.5
+§7.1.6.1   v1.3.0 to v1.7.2
+§7.1.6.4   v1.7.3 to v1.8.7
+Superseded in v2.0.0 by a new general prohibition on extra name types not specifically allowed.
+
+--- Version Notes ---
+This practice is still prohibited, but the requirements moved from specifically prohibiting certain
+name types to blocking everything but commonName and countryName in v2.0.0. (See e_cab_dv_subject_invalid_values)
+
+This requirement was removed in v2.0.0 and is historical. The language below is from v1.8.7,
+the last relevant version.
+
+--- Requirements Language ---
+BRs: 7.1.6.4
+Certificate Policy Identifier: 2.23.140.1.2.1
+If the Certificate complies with these requirements and lacks Subject identity information that
+has been verified in accordance with Section 3.2.2.1 or Section 3.2.3.
+Such Certificates MUST NOT include organizationName, givenName, surname,
+streetAddress, localityName, stateOrProvinceName, or postalCode in the Subject field.
+*/
 
 import (
 	"github.com/zmap/zcrypto/x509"
@@ -26,11 +46,12 @@ import (
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
-			Name:          "e_cab_dv_conflicts_with_locality",
-			Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, locality name MUST NOT be included in subject",
-			Citation:      "BRs: 7.1.6.1",
-			Source:        lint.CABFBaselineRequirements,
-			EffectiveDate: util.CABEffectiveDate,
+			Name:            "e_cab_dv_conflicts_with_locality",
+			Description:     "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, locality name MUST NOT be included in subject",
+			Citation:        "BRs: 7.1.6.4",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.CABFBRs_2_0_0_Date,
 		},
 		Lint: NewCertPolicyConflictsWithLocality,
 	})

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_locality_test.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_locality_test.go
@@ -38,3 +38,21 @@ func TestCertPolicyConflictsWithLocal(t *testing.T) {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
+
+func TestCertPolicyConflictsWithLocalLastCheckedTime(t *testing.T) {
+	inputPath := "domainValWithLocalPre200.pem"
+	expected := lint.Error
+	out := test.TestLint("e_cab_dv_conflicts_with_locality", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCertPolicyConflictsWithLocalButSuperseded(t *testing.T) {
+	inputPath := "domainValWithLocalPost200.pem"
+	expected := lint.NE
+	out := test.TestLint("e_cab_dv_conflicts_with_locality", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_org.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_org.go
@@ -23,6 +23,20 @@ import (
 type certPolicyConflictsWithOrg struct{}
 
 /************************************************
+--- Citation History of this Requirement ---
+§9.3.1     v1.0   to v1.2.5
+§7.1.6.1   v1.3.0 to v1.7.2
+§7.1.6.4   v1.7.3 to v1.8.7
+Superseded in v2.0.0 by a new general prohibition on extra name types not specifically allowed.
+
+--- Version Notes ---
+This practice is still prohibited, but the requirements moved from specifically prohibiting certain
+name types to blocking everything but commonName and countryName in v2.0.0. (See e_cab_dv_subject_invalid_values)
+
+This requirement was removed in v2.0.0 and is historical. The language below is from v1.8.7,
+the last relevant version.
+
+--- Requirements Language ---
 BRs: 7.1.6.4
 Certificate Policy Identifier: 2.23.140.1.2.1
 If the Certificate complies with these requirements and lacks Subject identity information that
@@ -35,11 +49,12 @@ field.
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
-			Name:          "e_cab_dv_conflicts_with_org",
-			Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, organization name MUST NOT be included in subject",
-			Citation:      "BRs: 7.1.6.4",
-			Source:        lint.CABFBaselineRequirements,
-			EffectiveDate: util.CABEffectiveDate,
+			Name:            "e_cab_dv_conflicts_with_org",
+			Description:     "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, organization name MUST NOT be included in subject",
+			Citation:        "BRs: 7.1.6.4",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.CABFBRs_2_0_0_Date,
 		},
 		Lint: NewCertPolicyConflictsWithOrg,
 	})

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_org_test.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_org_test.go
@@ -38,3 +38,21 @@ func TestCertPolicyConflictsWithOrg(t *testing.T) {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
+
+func TestCertPolicyConflictsWithOrgLastCheckedTime(t *testing.T) {
+	inputPath := "domainValWithOrgPre200.pem"
+	expected := lint.Error
+	out := test.TestLint("e_cab_dv_conflicts_with_org", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCertPolicyConflictsWithOrgButSuperseded(t *testing.T) {
+	inputPath := "domainValWithOrgPost200.pem"
+	expected := lint.NE
+	out := test.TestLint("e_cab_dv_conflicts_with_org", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_postal.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_postal.go
@@ -23,6 +23,20 @@ import (
 type certPolicyConflictsWithPostal struct{}
 
 /************************************************
+--- Citation History of this Requirement ---
+§9.3.1     v1.0   to v1.2.5
+§7.1.6.1   v1.3.0 to v1.7.2
+§7.1.6.4   v1.7.3 to v1.8.7
+Superseded in v2.0.0 by a new general prohibition on extra name types not specifically allowed.
+
+--- Version Notes ---
+This practice is still prohibited, but the requirements moved from specifically prohibiting certain
+name types to blocking everything but commonName and countryName in v2.0.0. (See e_cab_dv_subject_invalid_values)
+
+This requirement was removed in v2.0.0 and is historical. The language below is from v1.8.7,
+the last relevant version.
+
+--- Requirements Language ---
 BRs: 7.1.6.4
 Certificate Policy Identifier: 2.23.140.1.2.1
 If the Certificate complies with these requirements and lacks Subject identity information that
@@ -35,11 +49,12 @@ field.
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
-			Name:          "e_cab_dv_conflicts_with_postal",
-			Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, postalCode MUST NOT be included in subject",
-			Citation:      "BRs: 7.1.6.4",
-			Source:        lint.CABFBaselineRequirements,
-			EffectiveDate: util.CABEffectiveDate,
+			Name:            "e_cab_dv_conflicts_with_postal",
+			Description:     "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, postalCode MUST NOT be included in subject",
+			Citation:        "BRs: 7.1.6.4",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.CABFBRs_2_0_0_Date,
 		},
 		Lint: NewCertPolicyConflictsWithPostal,
 	})

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_postal_test.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_postal_test.go
@@ -38,3 +38,21 @@ func TestCertPolicyConflictsWithPostal(t *testing.T) {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
+
+func TestCertPolicyConflictsWithPostalLastCheckedTime(t *testing.T) {
+	inputPath := "domainValWithPostalPre200.pem"
+	expected := lint.Error
+	out := test.TestLint("e_cab_dv_conflicts_with_postal", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCertPolicyConflictsWithPostalButSuperseded(t *testing.T) {
+	inputPath := "domainValWithPostalPost200.pem"
+	expected := lint.NE
+	out := test.TestLint("e_cab_dv_conflicts_with_postal", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_province.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_province.go
@@ -23,6 +23,20 @@ import (
 type certPolicyConflictsWithProvince struct{}
 
 /************************************************
+--- Citation History of this Requirement ---
+§9.3.1     v1.0   to v1.2.5
+§7.1.6.1   v1.3.0 to v1.7.2
+§7.1.6.4   v1.7.3 to v1.8.7
+Superseded in v2.0.0 by a new general prohibition on extra name types not specifically allowed.
+
+--- Version Notes ---
+This practice is still prohibited, but the requirements moved from specifically prohibiting certain
+name types to blocking everything but commonName and countryName in v2.0.0. (See e_cab_dv_subject_invalid_values)
+
+This requirement was removed in v2.0.0 and is historical. The language below is from v1.8.7,
+the last relevant version.
+
+--- Requirements Language ---
 BRs: 7.1.6.4
 Certificate Policy Identifier: 2.23.140.1.2.1
 If the Certificate complies with these requirements and lacks Subject identity information that
@@ -35,11 +49,12 @@ field.
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
-			Name:          "e_cab_dv_conflicts_with_province",
-			Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, stateOrProvinceName MUST NOT be included in subject",
-			Citation:      "BRs: 7.1.6.4",
-			Source:        lint.CABFBaselineRequirements,
-			EffectiveDate: util.CABEffectiveDate,
+			Name:            "e_cab_dv_conflicts_with_province",
+			Description:     "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, stateOrProvinceName MUST NOT be included in subject",
+			Citation:        "BRs: 7.1.6.4",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.CABFBRs_2_0_0_Date,
 		},
 		Lint: NewCertPolicyConflictsWithProvince,
 	})

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_province_test.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_province_test.go
@@ -38,3 +38,21 @@ func TestCertPolicyConflictsWithProv(t *testing.T) {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
+
+func TestCertPolicyConflictsWithProvLastCheckedTime(t *testing.T) {
+	inputPath := "domainValWithProvincePre200.pem"
+	expected := lint.Error
+	out := test.TestLint("e_cab_dv_conflicts_with_province", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCertPolicyConflictsWithProvButSuperseded(t *testing.T) {
+	inputPath := "domainValWithProvincePost200.pem"
+	expected := lint.NE
+	out := test.TestLint("e_cab_dv_conflicts_with_province", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_street.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_street.go
@@ -23,6 +23,20 @@ import (
 type certPolicyConflictsWithStreet struct{}
 
 /************************************************
+--- Citation History of this Requirement ---
+§9.3.1     v1.0   to v1.2.5
+§7.1.6.1   v1.3.0 to v1.7.2
+§7.1.6.4   v1.7.3 to v1.8.7
+Superseded in v2.0.0 by a new general prohibition on extra name types not specifically allowed.
+
+--- Version Notes ---
+This practice is still prohibited, but the requirements moved from specifically prohibiting certain
+name types to blocking everything but commonName and countryName in v2.0.0. (See e_cab_dv_subject_invalid_values)
+
+This requirement was removed in v2.0.0 and is historical. The language below is from v1.8.7,
+the last relevant version.
+
+--- Requirements Language ---
 BRs: 7.1.6.4
 Certificate Policy Identifier: 2.23.140.1.2.1
 If the Certificate complies with these requirements and lacks Subject identity information that
@@ -35,11 +49,12 @@ field.
 func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
-			Name:          "e_cab_dv_conflicts_with_street",
-			Description:   "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, streetAddress MUST NOT be included in subject",
-			Citation:      "BRs: 7.1.6.4",
-			Source:        lint.CABFBaselineRequirements,
-			EffectiveDate: util.CABEffectiveDate,
+			Name:            "e_cab_dv_conflicts_with_street",
+			Description:     "If certificate policy 2.23.140.1.2.1 (CA/B BR domain validated) is included, streetAddress MUST NOT be included in subject",
+			Citation:        "BRs: 7.1.6.4",
+			Source:          lint.CABFBaselineRequirements,
+			EffectiveDate:   util.CABEffectiveDate,
+			IneffectiveDate: util.CABFBRs_2_0_0_Date,
 		},
 		Lint: NewCertPolicyConflictsWithStreet,
 	})

--- a/v3/lints/cabf_br/lint_cab_dv_conflicts_with_street_test.go
+++ b/v3/lints/cabf_br/lint_cab_dv_conflicts_with_street_test.go
@@ -38,3 +38,21 @@ func TestCertPolicyConflictsWithStreet(t *testing.T) {
 		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
 	}
 }
+
+func TestCertPolicyConflictsWithStreetLastCheckedTime(t *testing.T) {
+	inputPath := "domainValWithStreetPre200.pem"
+	expected := lint.Error
+	out := test.TestLint("e_cab_dv_conflicts_with_street", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}
+
+func TestCertPolicyConflictsWithStreetButSuperseded(t *testing.T) {
+	inputPath := "domainValWithStreetPost200.pem"
+	expected := lint.NE
+	out := test.TestLint("e_cab_dv_conflicts_with_street", inputPath)
+	if out.Status != expected {
+		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	}
+}

--- a/v3/testdata/domainValWithLocalPost200.pem
+++ b/v3/testdata/domainValWithLocalPost200.pem
@@ -1,0 +1,92 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Validity
+            Not Before: Sep 15 00:00:00 2023 GMT
+            Not After : Dec  8 22:54:44 2023 GMT
+        Subject: C = US, L = Tallahassee, CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:bd:a8:dd:8d:ce:32:61:a7:84:ef:8a:49:04:8f:
+                    e7:16:74:fd:9d:fe:23:54:41:dc:7b:a9:68:fd:d2:
+                    04:57:bc:66:1e:18:1e:32:c5:c6:87:01:be:6a:5d:
+                    51:70:5a:f1:39:94:40:e5:e2:af:e2:2e:a1:20:c4:
+                    d8:2c:ac:04:65:93:c3:49:d3:2e:ef:1e:a0:9e:cf:
+                    f2:50:62:1b:4e:e4:35:9e:f3:de:c5:f2:9d:1c:8f:
+                    2c:2e:6f:e4:c8:25:34:3c:30:50:8b:e6:27:e8:a4:
+                    92:92:b9:8c:01:f5:47:a7:c1:90:8b:7b:2a:f5:2b:
+                    83:85:30:f9:47:65:03:7a:d8:58:19:ff:dd:2d:ce:
+                    c1:d6:35:a1:d1:bb:14:1b:e2:99:23:3e:90:3d:fa:
+                    b1:6c:3e:75:c5:98:b3:a4:3d:63:c8:a6:af:1c:90:
+                    af:22:86:c3:94:c8:eb:c6:24:a1:b6:ab:f8:29:cd:
+                    00:1d:6e:46:5f:d9:60:83:5d:97:26:82:f2:a8:ea:
+                    ab:4b:78:a3:50:58:0c:4b:6c:11:eb:bd:00:81:b7:
+                    0a:b1:b7:1b:d4:3b:38:2d:e0:86:5c:8c:27:03:d0:
+                    e5:a1:75:7d:d5:3b:0c:d6:2e:5c:d4:76:28:b0:ba:
+                    4f:78:25:6d:1f:b2:73:5a:18:d3:12:ef:ae:5c:b4:
+                    11:b1
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                01:02:03
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+            X509v3 Subject Key Identifier: 
+                04:03:02:01
+            X509v3 Subject Alternative Name: 
+                DNS:*.gov.us, DNS:gov.us
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        80:07:f7:35:16:6c:24:46:6c:df:f7:cc:17:89:35:90:2f:5a:
+        48:55:77:1d:d5:19:03:d7:a5:a4:0b:d0:6f:0b:09:b2:4d:af:
+        a9:f3:39:0d:66:92:6b:15:29:d3:76:fe:5b:16:48:f4:c3:b3:
+        fc:f6:33:ae:98:44:9c:ff:cb:6a:74:69:13:38:14:73:5f:55:
+        62:5e:d3:d5:2a:ae:f4:91:bf:14:52:dc:bb:be:bf:2f:ba:a5:
+        e0:57:f0:aa:a2:7d:3e:3c:6c:8c:9b:c2:56:79:1a:6d:18:f7:
+        77:89:aa:1e:a9:77:04:b9:3a:0f:63:f3:57:a2:88:5d:de:45:
+        12:c0:fa:6a:99:cb:24:38:91:5d:cb:8f:c1:fc:0d:df:db:e6:
+        dc:36:3c:91:60:37:32:d7:2c:95:12:a5:98:52:40:cb:99:46:
+        17:fd:36:ca:f1:6e:1a:4c:af:60:7c:68:f4:1f:5a:7c:25:ee:
+        2b:1e:7b:c5:4e:49:e1:d5:03:39:72:3f:a9:66:26:30:9d:27:
+        0d:01:1f:18:64:d4:15:5e:a6:c8:fd:20:7a:36:77:b5:98:8b:
+        7f:ae:ff:35:2d:75:94:e3:a6:91:32:4e:5b:e8:b3:36:fa:4b:
+        1b:54:5f:c6:0d:9d:64:75:43:c6:be:7a:a6:e7:df:be:63:d4:
+        c5:6e:e5:54
+-----BEGIN CERTIFICATE-----
+MIID+zCCAuOgAwIBAgIFBDFmk+0wDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDU1vdGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcx
+FjAUBgNVBAMTDU1vdGhlciBOYXR1cmUwHhcNMjMwOTE1MDAwMDAwWhcNMjMxMjA4
+MjI1NDQ0WjA0MQswCQYDVQQGEwJVUzEUMBIGA1UEBxMLVGFsbGFoYXNzZWUxDzAN
+BgNVBAMTBmdvdi51czCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL2o
+3Y3OMmGnhO+KSQSP5xZ0/Z3+I1RB3HupaP3SBFe8Zh4YHjLFxocBvmpdUXBa8TmU
+QOXir+IuoSDE2CysBGWTw0nTLu8eoJ7P8lBiG07kNZ7z3sXynRyPLC5v5MglNDww
+UIvmJ+ikkpK5jAH1R6fBkIt7KvUrg4Uw+UdlA3rYWBn/3S3OwdY1odG7FBvimSM+
+kD36sWw+dcWYs6Q9Y8imrxyQryKGw5TI68Ykobar+CnNAB1uRl/ZYINdlyaC8qjq
+q0t4o1BYDEtsEeu9AIG3CrG3G9Q7OC3ghlyMJwPQ5aF1fdU7DNYuXNR2KLC6T3gl
+bR+yc1oY0xLvrly0EbECAwEAAaOB9TCB8jAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0l
+BBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwDgYDVR0jBAcw
+BYADAQIDMGIGCCsGAQUFBwEBBFYwVDAhBggrBgEFBQcwAYYVaHR0cDovL3RoZWNh
+Lm5ldC9vY3NwMC8GCCsGAQUFBzAChiNodHRwOi8vdGhlY2EubmV0L3RvdGFsbHl0
+aGVjZXJ0LmNydDATBgNVHSAEDDAKMAgGBmeBDAECATANBgNVHQ4EBgQEBAMCATAb
+BgNVHREEFDASgggqLmdvdi51c4IGZ292LnVzMA0GCSqGSIb3DQEBCwUAA4IBAQCA
+B/c1FmwkRmzf98wXiTWQL1pIVXcd1RkD16WkC9BvCwmyTa+p8zkNZpJrFSnTdv5b
+Fkj0w7P89jOumESc/8tqdGkTOBRzX1ViXtPVKq70kb8UUty7vr8vuqXgV/Cqon0+
+PGyMm8JWeRptGPd3iaoeqXcEuToPY/NXoohd3kUSwPpqmcskOJFdy4/B/A3f2+bc
+NjyRYDcy1yyVEqWYUkDLmUYX/TbK8W4aTK9gfGj0H1p8Je4rHnvFTknh1QM5cj+p
+ZiYwnScNAR8YZNQVXqbI/SB6Nne1mIt/rv81LXWU46aRMk5b6LM2+ksbVF/GDZ1k
+dUPGvnqm59++Y9TFbuVU
+-----END CERTIFICATE-----

--- a/v3/testdata/domainValWithLocalPre200.pem
+++ b/v3/testdata/domainValWithLocalPre200.pem
@@ -1,0 +1,92 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Validity
+            Not Before: Sep 14 23:59:59 2023 GMT
+            Not After : Dec  8 22:54:44 2023 GMT
+        Subject: C = US, L = Tallahassee, CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:bd:a8:dd:8d:ce:32:61:a7:84:ef:8a:49:04:8f:
+                    e7:16:74:fd:9d:fe:23:54:41:dc:7b:a9:68:fd:d2:
+                    04:57:bc:66:1e:18:1e:32:c5:c6:87:01:be:6a:5d:
+                    51:70:5a:f1:39:94:40:e5:e2:af:e2:2e:a1:20:c4:
+                    d8:2c:ac:04:65:93:c3:49:d3:2e:ef:1e:a0:9e:cf:
+                    f2:50:62:1b:4e:e4:35:9e:f3:de:c5:f2:9d:1c:8f:
+                    2c:2e:6f:e4:c8:25:34:3c:30:50:8b:e6:27:e8:a4:
+                    92:92:b9:8c:01:f5:47:a7:c1:90:8b:7b:2a:f5:2b:
+                    83:85:30:f9:47:65:03:7a:d8:58:19:ff:dd:2d:ce:
+                    c1:d6:35:a1:d1:bb:14:1b:e2:99:23:3e:90:3d:fa:
+                    b1:6c:3e:75:c5:98:b3:a4:3d:63:c8:a6:af:1c:90:
+                    af:22:86:c3:94:c8:eb:c6:24:a1:b6:ab:f8:29:cd:
+                    00:1d:6e:46:5f:d9:60:83:5d:97:26:82:f2:a8:ea:
+                    ab:4b:78:a3:50:58:0c:4b:6c:11:eb:bd:00:81:b7:
+                    0a:b1:b7:1b:d4:3b:38:2d:e0:86:5c:8c:27:03:d0:
+                    e5:a1:75:7d:d5:3b:0c:d6:2e:5c:d4:76:28:b0:ba:
+                    4f:78:25:6d:1f:b2:73:5a:18:d3:12:ef:ae:5c:b4:
+                    11:b1
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                01:02:03
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+            X509v3 Subject Key Identifier: 
+                04:03:02:01
+            X509v3 Subject Alternative Name: 
+                DNS:*.gov.us, DNS:gov.us
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        80:07:f7:35:16:6c:24:46:6c:df:f7:cc:17:89:35:90:2f:5a:
+        48:55:77:1d:d5:19:03:d7:a5:a4:0b:d0:6f:0b:09:b2:4d:af:
+        a9:f3:39:0d:66:92:6b:15:29:d3:76:fe:5b:16:48:f4:c3:b3:
+        fc:f6:33:ae:98:44:9c:ff:cb:6a:74:69:13:38:14:73:5f:55:
+        62:5e:d3:d5:2a:ae:f4:91:bf:14:52:dc:bb:be:bf:2f:ba:a5:
+        e0:57:f0:aa:a2:7d:3e:3c:6c:8c:9b:c2:56:79:1a:6d:18:f7:
+        77:89:aa:1e:a9:77:04:b9:3a:0f:63:f3:57:a2:88:5d:de:45:
+        12:c0:fa:6a:99:cb:24:38:91:5d:cb:8f:c1:fc:0d:df:db:e6:
+        dc:36:3c:91:60:37:32:d7:2c:95:12:a5:98:52:40:cb:99:46:
+        17:fd:36:ca:f1:6e:1a:4c:af:60:7c:68:f4:1f:5a:7c:25:ee:
+        2b:1e:7b:c5:4e:49:e1:d5:03:39:72:3f:a9:66:26:30:9d:27:
+        0d:01:1f:18:64:d4:15:5e:a6:c8:fd:20:7a:36:77:b5:98:8b:
+        7f:ae:ff:35:2d:75:94:e3:a6:91:32:4e:5b:e8:b3:36:fa:4b:
+        1b:54:5f:c6:0d:9d:64:75:43:c6:be:7a:a6:e7:df:be:63:d4:
+        c5:6e:e5:54
+-----BEGIN CERTIFICATE-----
+MIID+zCCAuOgAwIBAgIFBDFmk+0wDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDU1vdGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcx
+FjAUBgNVBAMTDU1vdGhlciBOYXR1cmUwHhcNMjMwOTE0MjM1OTU5WhcNMjMxMjA4
+MjI1NDQ0WjA0MQswCQYDVQQGEwJVUzEUMBIGA1UEBxMLVGFsbGFoYXNzZWUxDzAN
+BgNVBAMTBmdvdi51czCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL2o
+3Y3OMmGnhO+KSQSP5xZ0/Z3+I1RB3HupaP3SBFe8Zh4YHjLFxocBvmpdUXBa8TmU
+QOXir+IuoSDE2CysBGWTw0nTLu8eoJ7P8lBiG07kNZ7z3sXynRyPLC5v5MglNDww
+UIvmJ+ikkpK5jAH1R6fBkIt7KvUrg4Uw+UdlA3rYWBn/3S3OwdY1odG7FBvimSM+
+kD36sWw+dcWYs6Q9Y8imrxyQryKGw5TI68Ykobar+CnNAB1uRl/ZYINdlyaC8qjq
+q0t4o1BYDEtsEeu9AIG3CrG3G9Q7OC3ghlyMJwPQ5aF1fdU7DNYuXNR2KLC6T3gl
+bR+yc1oY0xLvrly0EbECAwEAAaOB9TCB8jAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0l
+BBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwDgYDVR0jBAcw
+BYADAQIDMGIGCCsGAQUFBwEBBFYwVDAhBggrBgEFBQcwAYYVaHR0cDovL3RoZWNh
+Lm5ldC9vY3NwMC8GCCsGAQUFBzAChiNodHRwOi8vdGhlY2EubmV0L3RvdGFsbHl0
+aGVjZXJ0LmNydDATBgNVHSAEDDAKMAgGBmeBDAECATANBgNVHQ4EBgQEBAMCATAb
+BgNVHREEFDASgggqLmdvdi51c4IGZ292LnVzMA0GCSqGSIb3DQEBCwUAA4IBAQCA
+B/c1FmwkRmzf98wXiTWQL1pIVXcd1RkD16WkC9BvCwmyTa+p8zkNZpJrFSnTdv5b
+Fkj0w7P89jOumESc/8tqdGkTOBRzX1ViXtPVKq70kb8UUty7vr8vuqXgV/Cqon0+
+PGyMm8JWeRptGPd3iaoeqXcEuToPY/NXoohd3kUSwPpqmcskOJFdy4/B/A3f2+bc
+NjyRYDcy1yyVEqWYUkDLmUYX/TbK8W4aTK9gfGj0H1p8Je4rHnvFTknh1QM5cj+p
+ZiYwnScNAR8YZNQVXqbI/SB6Nne1mIt/rv81LXWU46aRMk5b6LM2+ksbVF/GDZ1k
+dUPGvnqm59++Y9TFbuVU
+-----END CERTIFICATE-----

--- a/v3/testdata/domainValWithOrgPost200.pem
+++ b/v3/testdata/domainValWithOrgPost200.pem
@@ -1,0 +1,92 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Validity
+            Not Before: Sep 15 00:00:00 2023 GMT
+            Not After : Dec  8 22:41:05 2023 GMT
+        Subject: C = US, O = Extreme Discord, CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:e7:4d:6c:ec:b2:20:0c:96:8b:87:ff:fd:77:fd:
+                    47:b5:48:b3:60:0a:9a:a9:f7:ce:06:55:4e:dd:d8:
+                    d8:26:0e:6c:29:fe:41:8f:43:64:cf:93:2c:3a:ee:
+                    e0:b4:83:02:43:26:4e:c8:4e:0b:10:cb:ba:06:1d:
+                    46:b6:44:62:8f:5f:fb:14:ec:99:37:a0:71:e2:12:
+                    b8:b9:dc:00:66:e0:3b:c0:25:59:b9:b1:85:82:0d:
+                    d7:a4:93:08:cc:fe:b0:f3:e8:7b:97:bf:73:36:24:
+                    b7:96:6a:39:93:8e:a4:05:cb:58:b2:a8:3b:cf:dd:
+                    a4:1b:ae:e9:51:b7:2c:fb:49:22:3c:0d:fd:d0:bb:
+                    f9:12:76:b8:94:cf:1e:7f:fb:c5:9c:7b:46:f5:cd:
+                    07:dc:1f:19:aa:ec:e8:a2:6f:cb:94:ab:fd:6c:30:
+                    af:fe:55:55:b0:35:48:b3:c7:52:7f:d5:65:31:08:
+                    84:3c:b3:a2:1c:00:71:70:fc:02:ee:0f:60:5a:22:
+                    f6:cb:b1:ee:0a:67:1d:93:0a:86:77:ba:63:bd:9e:
+                    1d:1a:3b:12:37:42:77:2b:d3:a9:f8:b0:8a:d4:c9:
+                    d9:9d:a3:bd:ea:3b:06:da:64:01:00:c4:c5:6b:df:
+                    e0:ec:02:44:c0:70:bf:04:bb:30:aa:f3:0f:6b:9a:
+                    d6:d5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                01:02:03
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+            X509v3 Subject Key Identifier: 
+                04:03:02:01
+            X509v3 Subject Alternative Name: 
+                DNS:*.gov.us, DNS:gov.us
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        3a:2c:fc:a7:d8:42:36:f9:aa:06:4f:13:ae:1f:43:8f:2e:31:
+        17:35:ff:58:46:4d:78:7e:d1:05:e5:1f:2e:8c:04:25:12:6d:
+        8e:0c:df:ec:4d:7f:b6:a6:ef:06:31:7e:05:74:0c:37:f4:75:
+        b5:d1:d1:78:61:f9:12:12:dd:53:fe:25:9c:94:6e:5f:49:00:
+        94:39:11:a8:41:1e:17:ca:e2:0e:02:3f:62:14:83:ba:18:23:
+        26:c0:cf:c6:52:da:1d:8b:db:4c:d7:49:9c:9f:9e:5f:10:a4:
+        79:be:bb:b9:eb:39:0e:2e:2f:fb:c9:a6:7e:4b:30:84:46:80:
+        6a:89:0f:1c:69:c3:e3:7f:cb:c4:41:39:8d:7e:92:c2:67:f8:
+        a1:9c:b8:45:fd:cb:2b:ae:ab:c2:97:55:df:bd:57:4d:88:7d:
+        b7:1d:55:45:ff:4d:cb:cd:1b:d8:83:65:5b:50:43:4e:77:f5:
+        8b:bf:3d:fb:9e:a1:2b:9d:e0:d7:a0:88:e8:1d:3d:0e:16:15:
+        ab:d6:f7:dd:11:5c:2a:2a:c1:bf:f0:f0:95:7f:9c:07:63:e0:
+        03:23:30:d2:d2:12:75:ad:b6:bd:08:11:4a:62:b3:94:3e:d9:
+        53:68:5d:d9:f8:8c:01:6e:37:d7:51:a3:f4:49:6a:45:38:8a:
+        68:53:16:61
+-----BEGIN CERTIFICATE-----
+MIID/zCCAuegAwIBAgIFBDFmk+0wDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDU1vdGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcx
+FjAUBgNVBAMTDU1vdGhlciBOYXR1cmUwHhcNMjMwOTE1MDAwMDAwWhcNMjMxMjA4
+MjI0MTA1WjA4MQswCQYDVQQGEwJVUzEYMBYGA1UEChMPRXh0cmVtZSBEaXNjb3Jk
+MQ8wDQYDVQQDEwZnb3YudXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+AQDnTWzssiAMlouH//13/Ue1SLNgCpqp984GVU7d2NgmDmwp/kGPQ2TPkyw67uC0
+gwJDJk7ITgsQy7oGHUa2RGKPX/sU7Jk3oHHiEri53ABm4DvAJVm5sYWCDdekkwjM
+/rDz6HuXv3M2JLeWajmTjqQFy1iyqDvP3aQbrulRtyz7SSI8Df3Qu/kSdriUzx5/
++8Wce0b1zQfcHxmq7Oiib8uUq/1sMK/+VVWwNUizx1J/1WUxCIQ8s6IcAHFw/ALu
+D2BaIvbLse4KZx2TCoZ3umO9nh0aOxI3Qncr06n4sIrUydmdo73qOwbaZAEAxMVr
+3+DsAkTAcL8EuzCq8w9rmtbVAgMBAAGjgfUwgfIwDgYDVR0PAQH/BAQDAgWgMB0G
+A1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAMBgNVHRMBAf8EAjAAMA4GA1Ud
+IwQHMAWAAwECAzBiBggrBgEFBQcBAQRWMFQwIQYIKwYBBQUHMAGGFWh0dHA6Ly90
+aGVjYS5uZXQvb2NzcDAvBggrBgEFBQcwAoYjaHR0cDovL3RoZWNhLm5ldC90b3Rh
+bGx5dGhlY2VydC5jcnQwEwYDVR0gBAwwCjAIBgZngQwBAgEwDQYDVR0OBAYEBAQD
+AgEwGwYDVR0RBBQwEoIIKi5nb3YudXOCBmdvdi51czANBgkqhkiG9w0BAQsFAAOC
+AQEAOiz8p9hCNvmqBk8Trh9Djy4xFzX/WEZNeH7RBeUfLowEJRJtjgzf7E1/tqbv
+BjF+BXQMN/R1tdHReGH5EhLdU/4lnJRuX0kAlDkRqEEeF8riDgI/YhSDuhgjJsDP
+xlLaHYvbTNdJnJ+eXxCkeb67ues5Di4v+8mmfkswhEaAaokPHGnD43/LxEE5jX6S
+wmf4oZy4Rf3LK66rwpdV371XTYh9tx1VRf9Ny80b2INlW1BDTnf1i789+56hK53g
+16CI6B09DhYVq9b33RFcKirBv/DwlX+cB2PgAyMw0tISda22vQgRSmKzlD7ZU2hd
+2fiMAW4311Gj9ElqRTiKaFMWYQ==
+-----END CERTIFICATE-----

--- a/v3/testdata/domainValWithOrgPre200.pem
+++ b/v3/testdata/domainValWithOrgPre200.pem
@@ -1,0 +1,92 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Validity
+            Not Before: Sep 14 23:59:59 2023 GMT
+            Not After : Dec  8 22:41:05 2023 GMT
+        Subject: C = US, O = Extreme Discord, CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:e7:4d:6c:ec:b2:20:0c:96:8b:87:ff:fd:77:fd:
+                    47:b5:48:b3:60:0a:9a:a9:f7:ce:06:55:4e:dd:d8:
+                    d8:26:0e:6c:29:fe:41:8f:43:64:cf:93:2c:3a:ee:
+                    e0:b4:83:02:43:26:4e:c8:4e:0b:10:cb:ba:06:1d:
+                    46:b6:44:62:8f:5f:fb:14:ec:99:37:a0:71:e2:12:
+                    b8:b9:dc:00:66:e0:3b:c0:25:59:b9:b1:85:82:0d:
+                    d7:a4:93:08:cc:fe:b0:f3:e8:7b:97:bf:73:36:24:
+                    b7:96:6a:39:93:8e:a4:05:cb:58:b2:a8:3b:cf:dd:
+                    a4:1b:ae:e9:51:b7:2c:fb:49:22:3c:0d:fd:d0:bb:
+                    f9:12:76:b8:94:cf:1e:7f:fb:c5:9c:7b:46:f5:cd:
+                    07:dc:1f:19:aa:ec:e8:a2:6f:cb:94:ab:fd:6c:30:
+                    af:fe:55:55:b0:35:48:b3:c7:52:7f:d5:65:31:08:
+                    84:3c:b3:a2:1c:00:71:70:fc:02:ee:0f:60:5a:22:
+                    f6:cb:b1:ee:0a:67:1d:93:0a:86:77:ba:63:bd:9e:
+                    1d:1a:3b:12:37:42:77:2b:d3:a9:f8:b0:8a:d4:c9:
+                    d9:9d:a3:bd:ea:3b:06:da:64:01:00:c4:c5:6b:df:
+                    e0:ec:02:44:c0:70:bf:04:bb:30:aa:f3:0f:6b:9a:
+                    d6:d5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                01:02:03
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+            X509v3 Subject Key Identifier: 
+                04:03:02:01
+            X509v3 Subject Alternative Name: 
+                DNS:*.gov.us, DNS:gov.us
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        3a:2c:fc:a7:d8:42:36:f9:aa:06:4f:13:ae:1f:43:8f:2e:31:
+        17:35:ff:58:46:4d:78:7e:d1:05:e5:1f:2e:8c:04:25:12:6d:
+        8e:0c:df:ec:4d:7f:b6:a6:ef:06:31:7e:05:74:0c:37:f4:75:
+        b5:d1:d1:78:61:f9:12:12:dd:53:fe:25:9c:94:6e:5f:49:00:
+        94:39:11:a8:41:1e:17:ca:e2:0e:02:3f:62:14:83:ba:18:23:
+        26:c0:cf:c6:52:da:1d:8b:db:4c:d7:49:9c:9f:9e:5f:10:a4:
+        79:be:bb:b9:eb:39:0e:2e:2f:fb:c9:a6:7e:4b:30:84:46:80:
+        6a:89:0f:1c:69:c3:e3:7f:cb:c4:41:39:8d:7e:92:c2:67:f8:
+        a1:9c:b8:45:fd:cb:2b:ae:ab:c2:97:55:df:bd:57:4d:88:7d:
+        b7:1d:55:45:ff:4d:cb:cd:1b:d8:83:65:5b:50:43:4e:77:f5:
+        8b:bf:3d:fb:9e:a1:2b:9d:e0:d7:a0:88:e8:1d:3d:0e:16:15:
+        ab:d6:f7:dd:11:5c:2a:2a:c1:bf:f0:f0:95:7f:9c:07:63:e0:
+        03:23:30:d2:d2:12:75:ad:b6:bd:08:11:4a:62:b3:94:3e:d9:
+        53:68:5d:d9:f8:8c:01:6e:37:d7:51:a3:f4:49:6a:45:38:8a:
+        68:53:16:61
+-----BEGIN CERTIFICATE-----
+MIID/zCCAuegAwIBAgIFBDFmk+0wDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDU1vdGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcx
+FjAUBgNVBAMTDU1vdGhlciBOYXR1cmUwHhcNMjMwOTE0MjM1OTU5WhcNMjMxMjA4
+MjI0MTA1WjA4MQswCQYDVQQGEwJVUzEYMBYGA1UEChMPRXh0cmVtZSBEaXNjb3Jk
+MQ8wDQYDVQQDEwZnb3YudXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+AQDnTWzssiAMlouH//13/Ue1SLNgCpqp984GVU7d2NgmDmwp/kGPQ2TPkyw67uC0
+gwJDJk7ITgsQy7oGHUa2RGKPX/sU7Jk3oHHiEri53ABm4DvAJVm5sYWCDdekkwjM
+/rDz6HuXv3M2JLeWajmTjqQFy1iyqDvP3aQbrulRtyz7SSI8Df3Qu/kSdriUzx5/
++8Wce0b1zQfcHxmq7Oiib8uUq/1sMK/+VVWwNUizx1J/1WUxCIQ8s6IcAHFw/ALu
+D2BaIvbLse4KZx2TCoZ3umO9nh0aOxI3Qncr06n4sIrUydmdo73qOwbaZAEAxMVr
+3+DsAkTAcL8EuzCq8w9rmtbVAgMBAAGjgfUwgfIwDgYDVR0PAQH/BAQDAgWgMB0G
+A1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAMBgNVHRMBAf8EAjAAMA4GA1Ud
+IwQHMAWAAwECAzBiBggrBgEFBQcBAQRWMFQwIQYIKwYBBQUHMAGGFWh0dHA6Ly90
+aGVjYS5uZXQvb2NzcDAvBggrBgEFBQcwAoYjaHR0cDovL3RoZWNhLm5ldC90b3Rh
+bGx5dGhlY2VydC5jcnQwEwYDVR0gBAwwCjAIBgZngQwBAgEwDQYDVR0OBAYEBAQD
+AgEwGwYDVR0RBBQwEoIIKi5nb3YudXOCBmdvdi51czANBgkqhkiG9w0BAQsFAAOC
+AQEAOiz8p9hCNvmqBk8Trh9Djy4xFzX/WEZNeH7RBeUfLowEJRJtjgzf7E1/tqbv
+BjF+BXQMN/R1tdHReGH5EhLdU/4lnJRuX0kAlDkRqEEeF8riDgI/YhSDuhgjJsDP
+xlLaHYvbTNdJnJ+eXxCkeb67ues5Di4v+8mmfkswhEaAaokPHGnD43/LxEE5jX6S
+wmf4oZy4Rf3LK66rwpdV371XTYh9tx1VRf9Ny80b2INlW1BDTnf1i789+56hK53g
+16CI6B09DhYVq9b33RFcKirBv/DwlX+cB2PgAyMw0tISda22vQgRSmKzlD7ZU2hd
+2fiMAW4311Gj9ElqRTiKaFMWYQ==
+-----END CERTIFICATE-----

--- a/v3/testdata/domainValWithPostalPost200.pem
+++ b/v3/testdata/domainValWithPostalPost200.pem
@@ -1,0 +1,92 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Validity
+            Not Before: Sep 15 00:00:00 2023 GMT
+            Not After : Dec  8 22:53:17 2023 GMT
+        Subject: C = US, postalCode = 30062, CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:b6:50:21:a6:87:fe:c2:b0:69:98:a0:eb:47:01:
+                    77:e2:e3:1f:33:2d:dd:61:be:63:c5:b6:90:5e:85:
+                    6c:67:a6:84:61:cc:58:0a:34:75:f6:81:c0:19:0f:
+                    1b:cc:b8:a6:25:2c:ff:41:27:65:f5:19:c5:5a:12:
+                    1e:73:55:68:61:36:8c:4f:f7:5d:a4:ba:9a:37:ea:
+                    73:9e:6d:d9:3f:44:00:23:3c:31:ae:07:f5:0c:94:
+                    fa:35:d3:f0:53:66:e5:b3:ab:3e:fa:8c:c8:32:5f:
+                    97:3e:ec:bc:06:7c:89:12:87:38:6e:ba:b1:f3:6c:
+                    97:56:98:be:05:9a:b8:0a:5b:c5:25:2d:d7:60:26:
+                    04:d0:ce:21:2a:7b:25:6c:5c:9d:e2:a6:46:44:8e:
+                    9e:4c:7b:2e:62:3b:f0:83:ad:df:82:fe:82:79:46:
+                    f4:49:1f:d5:c2:cb:ef:18:88:2d:0e:99:1b:20:05:
+                    41:eb:0b:b3:e7:3b:7e:6d:3b:90:07:40:0f:6c:55:
+                    75:e1:19:e0:09:85:f8:ae:be:f2:b6:0f:c3:e1:9b:
+                    8e:9b:97:88:7c:cf:46:a0:4d:ad:71:a4:40:df:0c:
+                    34:6a:dd:37:cf:7e:0a:44:64:35:9d:3b:af:fa:00:
+                    44:ce:11:4c:7f:c3:65:7f:f3:53:02:20:d1:a6:47:
+                    ce:b5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                01:02:03
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+            X509v3 Subject Key Identifier: 
+                04:03:02:01
+            X509v3 Subject Alternative Name: 
+                DNS:*.gov.us, DNS:gov.us
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        1b:67:cb:aa:ba:47:9e:f8:0c:e0:05:73:ff:9b:bf:02:61:08:
+        24:31:dd:6f:69:b7:25:96:9b:c6:82:7e:1d:38:86:57:4d:68:
+        39:b0:9b:e1:02:17:a7:69:ca:97:93:1c:d3:4b:9f:f1:2d:c1:
+        83:0e:41:ce:02:28:f6:24:cd:8e:40:95:30:e1:c6:88:20:79:
+        8e:99:ea:3b:4a:50:c2:a1:df:85:ec:d8:1b:9c:49:1b:01:66:
+        e5:c2:a1:a7:01:1f:18:e8:17:7f:d7:83:70:b7:0d:6c:48:36:
+        d2:8c:ed:cd:9e:3a:b3:76:a6:75:ea:a3:95:d7:11:c2:6a:3b:
+        be:b6:9c:74:a9:96:f1:f5:79:58:9f:56:32:0e:28:92:c7:0f:
+        37:a3:46:07:b5:bf:4e:75:02:9d:cc:da:4c:c7:da:49:49:55:
+        87:47:59:33:7c:d5:2d:70:2e:3b:2c:df:63:8d:58:fc:c8:67:
+        f5:3a:d2:e4:09:53:03:1c:17:3f:1f:27:af:d8:e3:ab:41:e1:
+        5a:ef:31:7b:c9:05:4f:ce:cc:ba:c3:c4:89:2a:a2:4e:9a:22:
+        d7:b3:22:d3:12:56:8c:75:d6:40:fd:02:bf:94:59:f7:c6:e7:
+        fd:e3:3b:7d:72:f8:0c:d2:d5:ab:6c:dd:ca:8c:41:a3:e4:80:
+        d8:59:6e:9c
+-----BEGIN CERTIFICATE-----
+MIID9TCCAt2gAwIBAgIFBDFmk+0wDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDU1vdGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcx
+FjAUBgNVBAMTDU1vdGhlciBOYXR1cmUwHhcNMjMwOTE1MDAwMDAwWhcNMjMxMjA4
+MjI1MzE3WjAuMQswCQYDVQQGEwJVUzEOMAwGA1UEERMFMzAwNjIxDzANBgNVBAMT
+Bmdvdi51czCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALZQIaaH/sKw
+aZig60cBd+LjHzMt3WG+Y8W2kF6FbGemhGHMWAo0dfaBwBkPG8y4piUs/0EnZfUZ
+xVoSHnNVaGE2jE/3XaS6mjfqc55t2T9EACM8Ma4H9QyU+jXT8FNm5bOrPvqMyDJf
+lz7svAZ8iRKHOG66sfNsl1aYvgWauApbxSUt12AmBNDOISp7JWxcneKmRkSOnkx7
+LmI78IOt34L+gnlG9Ekf1cLL7xiILQ6ZGyAFQesLs+c7fm07kAdAD2xVdeEZ4AmF
++K6+8rYPw+GbjpuXiHzPRqBNrXGkQN8MNGrdN89+CkRkNZ07r/oARM4RTH/DZX/z
+UwIg0aZHzrUCAwEAAaOB9TCB8jAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYI
+KwYBBQUHAwIGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwDgYDVR0jBAcwBYADAQID
+MGIGCCsGAQUFBwEBBFYwVDAhBggrBgEFBQcwAYYVaHR0cDovL3RoZWNhLm5ldC9v
+Y3NwMC8GCCsGAQUFBzAChiNodHRwOi8vdGhlY2EubmV0L3RvdGFsbHl0aGVjZXJ0
+LmNydDATBgNVHSAEDDAKMAgGBmeBDAECATANBgNVHQ4EBgQEBAMCATAbBgNVHREE
+FDASgggqLmdvdi51c4IGZ292LnVzMA0GCSqGSIb3DQEBCwUAA4IBAQAbZ8uqukee
++AzgBXP/m78CYQgkMd1vabcllpvGgn4dOIZXTWg5sJvhAhenacqXkxzTS5/xLcGD
+DkHOAij2JM2OQJUw4caIIHmOmeo7SlDCod+F7NgbnEkbAWblwqGnAR8Y6Bd/14Nw
+tw1sSDbSjO3NnjqzdqZ16qOV1xHCaju+tpx0qZbx9XlYn1YyDiiSxw83o0YHtb9O
+dQKdzNpMx9pJSVWHR1kzfNUtcC47LN9jjVj8yGf1OtLkCVMDHBc/Hyev2OOrQeFa
+7zF7yQVPzsy6w8SJKqJOmiLXsyLTElaMddZA/QK/lFn3xuf94zt9cvgM0tWrbN3K
+jEGj5IDYWW6c
+-----END CERTIFICATE-----

--- a/v3/testdata/domainValWithPostalPre200.pem
+++ b/v3/testdata/domainValWithPostalPre200.pem
@@ -1,0 +1,92 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Validity
+            Not Before: Sep 14 23:59:59 2023 GMT
+            Not After : Dec  8 22:53:17 2023 GMT
+        Subject: C = US, postalCode = 30062, CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:b6:50:21:a6:87:fe:c2:b0:69:98:a0:eb:47:01:
+                    77:e2:e3:1f:33:2d:dd:61:be:63:c5:b6:90:5e:85:
+                    6c:67:a6:84:61:cc:58:0a:34:75:f6:81:c0:19:0f:
+                    1b:cc:b8:a6:25:2c:ff:41:27:65:f5:19:c5:5a:12:
+                    1e:73:55:68:61:36:8c:4f:f7:5d:a4:ba:9a:37:ea:
+                    73:9e:6d:d9:3f:44:00:23:3c:31:ae:07:f5:0c:94:
+                    fa:35:d3:f0:53:66:e5:b3:ab:3e:fa:8c:c8:32:5f:
+                    97:3e:ec:bc:06:7c:89:12:87:38:6e:ba:b1:f3:6c:
+                    97:56:98:be:05:9a:b8:0a:5b:c5:25:2d:d7:60:26:
+                    04:d0:ce:21:2a:7b:25:6c:5c:9d:e2:a6:46:44:8e:
+                    9e:4c:7b:2e:62:3b:f0:83:ad:df:82:fe:82:79:46:
+                    f4:49:1f:d5:c2:cb:ef:18:88:2d:0e:99:1b:20:05:
+                    41:eb:0b:b3:e7:3b:7e:6d:3b:90:07:40:0f:6c:55:
+                    75:e1:19:e0:09:85:f8:ae:be:f2:b6:0f:c3:e1:9b:
+                    8e:9b:97:88:7c:cf:46:a0:4d:ad:71:a4:40:df:0c:
+                    34:6a:dd:37:cf:7e:0a:44:64:35:9d:3b:af:fa:00:
+                    44:ce:11:4c:7f:c3:65:7f:f3:53:02:20:d1:a6:47:
+                    ce:b5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                01:02:03
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+            X509v3 Subject Key Identifier: 
+                04:03:02:01
+            X509v3 Subject Alternative Name: 
+                DNS:*.gov.us, DNS:gov.us
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        1b:67:cb:aa:ba:47:9e:f8:0c:e0:05:73:ff:9b:bf:02:61:08:
+        24:31:dd:6f:69:b7:25:96:9b:c6:82:7e:1d:38:86:57:4d:68:
+        39:b0:9b:e1:02:17:a7:69:ca:97:93:1c:d3:4b:9f:f1:2d:c1:
+        83:0e:41:ce:02:28:f6:24:cd:8e:40:95:30:e1:c6:88:20:79:
+        8e:99:ea:3b:4a:50:c2:a1:df:85:ec:d8:1b:9c:49:1b:01:66:
+        e5:c2:a1:a7:01:1f:18:e8:17:7f:d7:83:70:b7:0d:6c:48:36:
+        d2:8c:ed:cd:9e:3a:b3:76:a6:75:ea:a3:95:d7:11:c2:6a:3b:
+        be:b6:9c:74:a9:96:f1:f5:79:58:9f:56:32:0e:28:92:c7:0f:
+        37:a3:46:07:b5:bf:4e:75:02:9d:cc:da:4c:c7:da:49:49:55:
+        87:47:59:33:7c:d5:2d:70:2e:3b:2c:df:63:8d:58:fc:c8:67:
+        f5:3a:d2:e4:09:53:03:1c:17:3f:1f:27:af:d8:e3:ab:41:e1:
+        5a:ef:31:7b:c9:05:4f:ce:cc:ba:c3:c4:89:2a:a2:4e:9a:22:
+        d7:b3:22:d3:12:56:8c:75:d6:40:fd:02:bf:94:59:f7:c6:e7:
+        fd:e3:3b:7d:72:f8:0c:d2:d5:ab:6c:dd:ca:8c:41:a3:e4:80:
+        d8:59:6e:9c
+-----BEGIN CERTIFICATE-----
+MIID9TCCAt2gAwIBAgIFBDFmk+0wDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDU1vdGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcx
+FjAUBgNVBAMTDU1vdGhlciBOYXR1cmUwHhcNMjMwOTE0MjM1OTU5WhcNMjMxMjA4
+MjI1MzE3WjAuMQswCQYDVQQGEwJVUzEOMAwGA1UEERMFMzAwNjIxDzANBgNVBAMT
+Bmdvdi51czCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALZQIaaH/sKw
+aZig60cBd+LjHzMt3WG+Y8W2kF6FbGemhGHMWAo0dfaBwBkPG8y4piUs/0EnZfUZ
+xVoSHnNVaGE2jE/3XaS6mjfqc55t2T9EACM8Ma4H9QyU+jXT8FNm5bOrPvqMyDJf
+lz7svAZ8iRKHOG66sfNsl1aYvgWauApbxSUt12AmBNDOISp7JWxcneKmRkSOnkx7
+LmI78IOt34L+gnlG9Ekf1cLL7xiILQ6ZGyAFQesLs+c7fm07kAdAD2xVdeEZ4AmF
++K6+8rYPw+GbjpuXiHzPRqBNrXGkQN8MNGrdN89+CkRkNZ07r/oARM4RTH/DZX/z
+UwIg0aZHzrUCAwEAAaOB9TCB8jAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYI
+KwYBBQUHAwIGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwDgYDVR0jBAcwBYADAQID
+MGIGCCsGAQUFBwEBBFYwVDAhBggrBgEFBQcwAYYVaHR0cDovL3RoZWNhLm5ldC9v
+Y3NwMC8GCCsGAQUFBzAChiNodHRwOi8vdGhlY2EubmV0L3RvdGFsbHl0aGVjZXJ0
+LmNydDATBgNVHSAEDDAKMAgGBmeBDAECATANBgNVHQ4EBgQEBAMCATAbBgNVHREE
+FDASgggqLmdvdi51c4IGZ292LnVzMA0GCSqGSIb3DQEBCwUAA4IBAQAbZ8uqukee
++AzgBXP/m78CYQgkMd1vabcllpvGgn4dOIZXTWg5sJvhAhenacqXkxzTS5/xLcGD
+DkHOAij2JM2OQJUw4caIIHmOmeo7SlDCod+F7NgbnEkbAWblwqGnAR8Y6Bd/14Nw
+tw1sSDbSjO3NnjqzdqZ16qOV1xHCaju+tpx0qZbx9XlYn1YyDiiSxw83o0YHtb9O
+dQKdzNpMx9pJSVWHR1kzfNUtcC47LN9jjVj8yGf1OtLkCVMDHBc/Hyev2OOrQeFa
+7zF7yQVPzsy6w8SJKqJOmiLXsyLTElaMddZA/QK/lFn3xuf94zt9cvgM0tWrbN3K
+jEGj5IDYWW6c
+-----END CERTIFICATE-----

--- a/v3/testdata/domainValWithProvincePost200.pem
+++ b/v3/testdata/domainValWithProvincePost200.pem
@@ -1,0 +1,92 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Validity
+            Not Before: Sep 15 00:00:00 2023 GMT
+            Not After : Dec  9 23:01:43 2023 GMT
+        Subject: C = US, ST = FL, CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:d8:53:ff:cd:27:04:b7:85:ea:b9:c8:9f:30:5c:
+                    00:4b:ac:e7:40:22:de:03:b4:0a:bd:ee:b0:46:be:
+                    22:2f:30:fe:b2:54:7a:b1:06:3b:6e:d3:c5:5d:16:
+                    5f:4a:e8:dc:1c:f6:65:85:f7:31:13:6e:2a:69:6e:
+                    2d:0d:b7:11:ff:83:6b:bc:ae:2e:90:d0:4c:ae:61:
+                    4c:9a:42:6a:6f:8a:f3:e0:e4:f2:37:1c:5f:24:7d:
+                    77:5d:18:35:84:53:5d:23:8e:41:ed:ee:c8:b0:a1:
+                    39:0a:cd:94:a7:75:1b:1f:21:36:58:00:e7:6e:00:
+                    6c:a0:7b:fe:2d:b5:86:16:f4:54:7c:a4:1f:10:37:
+                    0a:64:53:0c:9a:8e:99:2a:5a:98:7c:f8:9d:ee:01:
+                    28:31:a3:98:8e:8d:19:08:e4:e2:c2:32:94:66:19:
+                    5e:4d:52:e4:e1:85:84:3a:73:18:4b:e7:8b:e7:aa:
+                    1e:cf:40:88:7c:c7:97:d3:82:fc:68:c9:86:ba:19:
+                    75:ad:09:d8:d9:ee:99:26:2c:1e:5a:45:b2:e4:51:
+                    fe:02:77:3e:9e:b0:54:1e:da:94:04:94:0a:28:d3:
+                    63:d8:61:ec:73:f0:8d:4c:16:d8:bf:10:ff:04:85:
+                    f7:5e:84:c4:35:8b:15:c0:c3:50:07:d0:76:cb:c7:
+                    de:5b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                01:02:03
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+            X509v3 Subject Key Identifier: 
+                04:03:02:01
+            X509v3 Subject Alternative Name: 
+                DNS:*.gov.us, DNS:gov.us
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        c2:b0:34:27:f9:ac:db:1d:b3:28:a8:78:4e:33:6e:af:a7:a7:
+        c4:ea:8c:a8:fe:bb:99:51:a0:d8:49:8b:fa:05:45:ce:3c:96:
+        5e:42:ad:3c:05:fe:27:82:68:95:ad:36:80:97:6e:5a:3c:82:
+        5a:1c:87:1c:cf:a1:85:42:d7:3c:ea:01:2a:16:98:6f:08:49:
+        44:68:3e:f5:93:32:98:e5:fe:58:54:88:45:2e:05:76:3a:32:
+        81:73:2b:0c:e0:72:95:61:96:a1:ef:93:11:d3:71:60:1e:ce:
+        ba:ee:e9:f0:17:7c:e1:a9:da:fc:13:95:98:d0:f1:50:f5:82:
+        49:74:14:89:cd:ec:77:a6:8a:b2:50:bb:42:b4:83:b5:9c:e6:
+        b4:d9:19:76:02:1d:bb:de:2b:17:26:8c:89:2c:d3:14:76:b0:
+        53:80:91:0e:14:53:f4:1f:2f:4c:54:99:90:13:9a:36:60:3c:
+        1a:ef:a7:a0:a2:0d:ac:28:29:69:ad:09:86:49:ae:62:5c:e9:
+        50:9b:c8:fc:ff:f7:eb:17:a2:71:f8:f9:cf:7e:4a:2b:3e:3d:
+        d7:46:f7:e7:ea:a2:21:54:b0:c7:cb:55:8c:cc:b8:07:e0:28:
+        e8:26:46:2b:f5:46:83:0f:6e:a9:68:fe:de:6b:55:04:6a:e7:
+        70:cd:b9:ba
+-----BEGIN CERTIFICATE-----
+MIID8jCCAtqgAwIBAgIFBDFmk+0wDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDU1vdGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcx
+FjAUBgNVBAMTDU1vdGhlciBOYXR1cmUwHhcNMjMwOTE1MDAwMDAwWhcNMjMxMjA5
+MjMwMTQzWjArMQswCQYDVQQGEwJVUzELMAkGA1UECBMCRkwxDzANBgNVBAMTBmdv
+di51czCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANhT/80nBLeF6rnI
+nzBcAEus50Ai3gO0Cr3usEa+Ii8w/rJUerEGO27TxV0WX0ro3Bz2ZYX3MRNuKmlu
+LQ23Ef+Da7yuLpDQTK5hTJpCam+K8+Dk8jccXyR9d10YNYRTXSOOQe3uyLChOQrN
+lKd1Gx8hNlgA524AbKB7/i21hhb0VHykHxA3CmRTDJqOmSpamHz4ne4BKDGjmI6N
+GQjk4sIylGYZXk1S5OGFhDpzGEvni+eqHs9AiHzHl9OC/GjJhroZda0J2NnumSYs
+HlpFsuRR/gJ3Pp6wVB7alASUCijTY9hh7HPwjUwW2L8Q/wSF916ExDWLFcDDUAfQ
+dsvH3lsCAwEAAaOB9TCB8jAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYB
+BQUHAwIGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwDgYDVR0jBAcwBYADAQIDMGIG
+CCsGAQUFBwEBBFYwVDAhBggrBgEFBQcwAYYVaHR0cDovL3RoZWNhLm5ldC9vY3Nw
+MC8GCCsGAQUFBzAChiNodHRwOi8vdGhlY2EubmV0L3RvdGFsbHl0aGVjZXJ0LmNy
+dDATBgNVHSAEDDAKMAgGBmeBDAECATANBgNVHQ4EBgQEBAMCATAbBgNVHREEFDAS
+gggqLmdvdi51c4IGZ292LnVzMA0GCSqGSIb3DQEBCwUAA4IBAQDCsDQn+azbHbMo
+qHhOM26vp6fE6oyo/ruZUaDYSYv6BUXOPJZeQq08Bf4ngmiVrTaAl25aPIJaHIcc
+z6GFQtc86gEqFphvCElEaD71kzKY5f5YVIhFLgV2OjKBcysM4HKVYZah75MR03Fg
+Hs667unwF3zhqdr8E5WY0PFQ9YJJdBSJzex3poqyULtCtIO1nOa02Rl2Ah273isX
+JoyJLNMUdrBTgJEOFFP0Hy9MVJmQE5o2YDwa76egog2sKClprQmGSa5iXOlQm8j8
+//frF6Jx+PnPfkorPj3XRvfn6qIhVLDHy1WMzLgH4CjoJkYr9UaDD26paP7ea1UE
+audwzbm6
+-----END CERTIFICATE-----

--- a/v3/testdata/domainValWithProvincePre200.pem
+++ b/v3/testdata/domainValWithProvincePre200.pem
@@ -1,0 +1,92 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Validity
+            Not Before: Sep 14 23:59:59 2023 GMT
+            Not After : Dec  9 23:01:43 2023 GMT
+        Subject: C = US, ST = FL, CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:d8:53:ff:cd:27:04:b7:85:ea:b9:c8:9f:30:5c:
+                    00:4b:ac:e7:40:22:de:03:b4:0a:bd:ee:b0:46:be:
+                    22:2f:30:fe:b2:54:7a:b1:06:3b:6e:d3:c5:5d:16:
+                    5f:4a:e8:dc:1c:f6:65:85:f7:31:13:6e:2a:69:6e:
+                    2d:0d:b7:11:ff:83:6b:bc:ae:2e:90:d0:4c:ae:61:
+                    4c:9a:42:6a:6f:8a:f3:e0:e4:f2:37:1c:5f:24:7d:
+                    77:5d:18:35:84:53:5d:23:8e:41:ed:ee:c8:b0:a1:
+                    39:0a:cd:94:a7:75:1b:1f:21:36:58:00:e7:6e:00:
+                    6c:a0:7b:fe:2d:b5:86:16:f4:54:7c:a4:1f:10:37:
+                    0a:64:53:0c:9a:8e:99:2a:5a:98:7c:f8:9d:ee:01:
+                    28:31:a3:98:8e:8d:19:08:e4:e2:c2:32:94:66:19:
+                    5e:4d:52:e4:e1:85:84:3a:73:18:4b:e7:8b:e7:aa:
+                    1e:cf:40:88:7c:c7:97:d3:82:fc:68:c9:86:ba:19:
+                    75:ad:09:d8:d9:ee:99:26:2c:1e:5a:45:b2:e4:51:
+                    fe:02:77:3e:9e:b0:54:1e:da:94:04:94:0a:28:d3:
+                    63:d8:61:ec:73:f0:8d:4c:16:d8:bf:10:ff:04:85:
+                    f7:5e:84:c4:35:8b:15:c0:c3:50:07:d0:76:cb:c7:
+                    de:5b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                01:02:03
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+            X509v3 Subject Key Identifier: 
+                04:03:02:01
+            X509v3 Subject Alternative Name: 
+                DNS:*.gov.us, DNS:gov.us
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        c2:b0:34:27:f9:ac:db:1d:b3:28:a8:78:4e:33:6e:af:a7:a7:
+        c4:ea:8c:a8:fe:bb:99:51:a0:d8:49:8b:fa:05:45:ce:3c:96:
+        5e:42:ad:3c:05:fe:27:82:68:95:ad:36:80:97:6e:5a:3c:82:
+        5a:1c:87:1c:cf:a1:85:42:d7:3c:ea:01:2a:16:98:6f:08:49:
+        44:68:3e:f5:93:32:98:e5:fe:58:54:88:45:2e:05:76:3a:32:
+        81:73:2b:0c:e0:72:95:61:96:a1:ef:93:11:d3:71:60:1e:ce:
+        ba:ee:e9:f0:17:7c:e1:a9:da:fc:13:95:98:d0:f1:50:f5:82:
+        49:74:14:89:cd:ec:77:a6:8a:b2:50:bb:42:b4:83:b5:9c:e6:
+        b4:d9:19:76:02:1d:bb:de:2b:17:26:8c:89:2c:d3:14:76:b0:
+        53:80:91:0e:14:53:f4:1f:2f:4c:54:99:90:13:9a:36:60:3c:
+        1a:ef:a7:a0:a2:0d:ac:28:29:69:ad:09:86:49:ae:62:5c:e9:
+        50:9b:c8:fc:ff:f7:eb:17:a2:71:f8:f9:cf:7e:4a:2b:3e:3d:
+        d7:46:f7:e7:ea:a2:21:54:b0:c7:cb:55:8c:cc:b8:07:e0:28:
+        e8:26:46:2b:f5:46:83:0f:6e:a9:68:fe:de:6b:55:04:6a:e7:
+        70:cd:b9:ba
+-----BEGIN CERTIFICATE-----
+MIID8jCCAtqgAwIBAgIFBDFmk+0wDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDU1vdGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcx
+FjAUBgNVBAMTDU1vdGhlciBOYXR1cmUwHhcNMjMwOTE0MjM1OTU5WhcNMjMxMjA5
+MjMwMTQzWjArMQswCQYDVQQGEwJVUzELMAkGA1UECBMCRkwxDzANBgNVBAMTBmdv
+di51czCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANhT/80nBLeF6rnI
+nzBcAEus50Ai3gO0Cr3usEa+Ii8w/rJUerEGO27TxV0WX0ro3Bz2ZYX3MRNuKmlu
+LQ23Ef+Da7yuLpDQTK5hTJpCam+K8+Dk8jccXyR9d10YNYRTXSOOQe3uyLChOQrN
+lKd1Gx8hNlgA524AbKB7/i21hhb0VHykHxA3CmRTDJqOmSpamHz4ne4BKDGjmI6N
+GQjk4sIylGYZXk1S5OGFhDpzGEvni+eqHs9AiHzHl9OC/GjJhroZda0J2NnumSYs
+HlpFsuRR/gJ3Pp6wVB7alASUCijTY9hh7HPwjUwW2L8Q/wSF916ExDWLFcDDUAfQ
+dsvH3lsCAwEAAaOB9TCB8jAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYB
+BQUHAwIGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwDgYDVR0jBAcwBYADAQIDMGIG
+CCsGAQUFBwEBBFYwVDAhBggrBgEFBQcwAYYVaHR0cDovL3RoZWNhLm5ldC9vY3Nw
+MC8GCCsGAQUFBzAChiNodHRwOi8vdGhlY2EubmV0L3RvdGFsbHl0aGVjZXJ0LmNy
+dDATBgNVHSAEDDAKMAgGBmeBDAECATANBgNVHQ4EBgQEBAMCATAbBgNVHREEFDAS
+gggqLmdvdi51c4IGZ292LnVzMA0GCSqGSIb3DQEBCwUAA4IBAQDCsDQn+azbHbMo
+qHhOM26vp6fE6oyo/ruZUaDYSYv6BUXOPJZeQq08Bf4ngmiVrTaAl25aPIJaHIcc
+z6GFQtc86gEqFphvCElEaD71kzKY5f5YVIhFLgV2OjKBcysM4HKVYZah75MR03Fg
+Hs667unwF3zhqdr8E5WY0PFQ9YJJdBSJzex3poqyULtCtIO1nOa02Rl2Ah273isX
+JoyJLNMUdrBTgJEOFFP0Hy9MVJmQE5o2YDwa76egog2sKClprQmGSa5iXOlQm8j8
+//frF6Jx+PnPfkorPj3XRvfn6qIhVLDHy1WMzLgH4CjoJkYr9UaDD26paP7ea1UE
+audwzbm6
+-----END CERTIFICATE-----

--- a/v3/testdata/domainValWithStreetPost200.pem
+++ b/v3/testdata/domainValWithStreetPost200.pem
@@ -1,0 +1,92 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Validity
+            Not Before: Sep 15 00:00:00 2023 GMT
+            Not After : Dec  8 22:50:53 2023 GMT
+        Subject: C = US, street = 3210 Holly Mill Run, CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:e0:00:f6:d8:4e:ae:62:f8:d1:d4:31:91:ed:1d:
+                    2c:54:80:e4:85:7e:dc:40:46:bf:18:44:78:11:1b:
+                    61:85:c3:87:dd:2d:66:f0:6c:b3:8c:6e:1e:ef:be:
+                    bb:af:28:9b:b6:bb:7d:65:55:35:99:7c:4e:ac:f4:
+                    11:e1:59:4b:c2:00:f1:5a:f5:e8:42:1c:95:3a:59:
+                    9e:c9:49:2d:d5:d1:49:f7:ae:f1:ea:f8:46:bf:da:
+                    14:14:19:31:06:00:1c:d6:d0:17:60:cd:fc:e8:9b:
+                    0a:ac:f1:ed:6c:4d:13:51:07:02:9f:68:47:d2:3a:
+                    ce:1a:9a:92:d7:17:9b:b4:fd:21:2b:14:c5:e0:87:
+                    39:a0:f3:7f:ee:64:9c:af:e2:5b:b1:a4:c3:01:a1:
+                    8a:8b:1b:79:d9:a2:78:72:e2:df:06:bc:dc:28:7e:
+                    d9:ab:a7:76:66:57:b1:ae:db:5b:9b:cf:8e:cd:7a:
+                    39:01:6b:e2:c6:98:5e:f2:95:d4:07:52:03:ac:99:
+                    6e:c5:d7:d2:22:01:f4:77:c7:55:1f:55:80:2d:d0:
+                    35:38:41:71:88:83:f8:19:c9:f1:1c:96:64:0c:eb:
+                    d4:45:f1:6d:ae:63:51:7e:02:09:92:16:7a:f3:8c:
+                    f1:e4:e3:d3:06:36:dc:dc:19:54:40:dc:17:c7:8f:
+                    f4:a7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                01:02:03
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+            X509v3 Subject Key Identifier: 
+                04:03:02:01
+            X509v3 Subject Alternative Name: 
+                DNS:*.gov.us, DNS:gov.us
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        a4:e6:dd:96:60:e9:2d:61:b6:a2:9c:d1:07:e9:68:52:db:d2:
+        96:88:f0:0c:54:82:45:c7:1a:c9:7d:41:bf:53:b8:75:d1:b8:
+        49:e2:9b:7c:48:3d:52:6b:60:7f:2e:6c:96:4d:87:26:1b:bb:
+        90:60:c0:64:22:ac:9b:37:b2:ac:0b:21:27:cc:86:02:ca:e5:
+        cb:2d:b3:f7:b7:82:e6:28:a6:9b:bb:00:4d:29:ff:a5:e0:57:
+        be:29:42:88:ff:69:32:b8:19:d8:ca:90:27:4f:44:20:5f:ed:
+        53:1f:39:7a:73:6d:04:74:e9:17:57:12:bd:29:c0:66:c7:a0:
+        20:16:37:07:84:9c:57:79:87:e0:a2:af:a0:b4:78:6a:51:28:
+        a3:c0:e6:63:fa:e7:06:f5:60:de:38:75:7d:7e:d8:39:9f:57:
+        c5:4d:1d:db:57:aa:fc:6c:a7:67:c7:2e:81:1d:50:9f:f8:57:
+        74:ed:40:17:1d:45:54:73:e1:7e:13:06:30:fb:62:87:b6:ca:
+        1b:21:08:5f:f7:9a:06:92:c0:f5:97:ce:68:75:37:7b:72:6e:
+        b6:dc:33:d3:78:ce:28:15:51:59:f9:88:8d:24:5b:ef:54:52:
+        68:70:4b:6f:31:60:07:83:7e:78:e0:b0:61:a5:a0:14:60:71:
+        cf:6e:5d:e7
+-----BEGIN CERTIFICATE-----
+MIIEAzCCAuugAwIBAgIFBDFmk+0wDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDU1vdGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcx
+FjAUBgNVBAMTDU1vdGhlciBOYXR1cmUwHhcNMjMwOTE1MDAwMDAwWhcNMjMxMjA4
+MjI1MDUzWjA8MQswCQYDVQQGEwJVUzEcMBoGA1UECRMTMzIxMCBIb2xseSBNaWxs
+IFJ1bjEPMA0GA1UEAxMGZ292LnVzMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEA4AD22E6uYvjR1DGR7R0sVIDkhX7cQEa/GER4ERthhcOH3S1m8GyzjG4e
+7767ryibtrt9ZVU1mXxOrPQR4VlLwgDxWvXoQhyVOlmeyUkt1dFJ967x6vhGv9oU
+FBkxBgAc1tAXYM386JsKrPHtbE0TUQcCn2hH0jrOGpqS1xebtP0hKxTF4Ic5oPN/
+7mScr+JbsaTDAaGKixt52aJ4cuLfBrzcKH7Zq6d2Zlexrttbm8+OzXo5AWvixphe
+8pXUB1IDrJluxdfSIgH0d8dVH1WALdA1OEFxiIP4GcnxHJZkDOvURfFtrmNRfgIJ
+khZ684zx5OPTBjbc3BlUQNwXx4/0pwIDAQABo4H1MIHyMA4GA1UdDwEB/wQEAwIF
+oDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADAO
+BgNVHSMEBzAFgAMBAgMwYgYIKwYBBQUHAQEEVjBUMCEGCCsGAQUFBzABhhVodHRw
+Oi8vdGhlY2EubmV0L29jc3AwLwYIKwYBBQUHMAKGI2h0dHA6Ly90aGVjYS5uZXQv
+dG90YWxseXRoZWNlcnQuY3J0MBMGA1UdIAQMMAowCAYGZ4EMAQIBMA0GA1UdDgQG
+BAQEAwIBMBsGA1UdEQQUMBKCCCouZ292LnVzggZnb3YudXMwDQYJKoZIhvcNAQEL
+BQADggEBAKTm3ZZg6S1htqKc0QfpaFLb0paI8AxUgkXHGsl9Qb9TuHXRuEnim3xI
+PVJrYH8ubJZNhyYbu5BgwGQirJs3sqwLISfMhgLK5csts/e3guYoppu7AE0p/6Xg
+V74pQoj/aTK4GdjKkCdPRCBf7VMfOXpzbQR06RdXEr0pwGbHoCAWNweEnFd5h+Ci
+r6C0eGpRKKPA5mP65wb1YN44dX1+2DmfV8VNHdtXqvxsp2fHLoEdUJ/4V3TtQBcd
+RVRz4X4TBjD7Yoe2yhshCF/3mgaSwPWXzmh1N3tybrbcM9N4zigVUVn5iI0kW+9U
+UmhwS28xYAeDfnjgsGGloBRgcc9uXec=
+-----END CERTIFICATE-----

--- a/v3/testdata/domainValWithStreetPre200.pem
+++ b/v3/testdata/domainValWithStreetPre200.pem
@@ -1,0 +1,92 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 18008675309 (0x4316693ed)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, O = Mother Nature, OU = Everything, CN = Mother Nature
+        Validity
+            Not Before: Sep 14 23:59:59 2023 GMT
+            Not After : Dec  8 22:50:53 2023 GMT
+        Subject: C = US, street = 3210 Holly Mill Run, CN = gov.us
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:e0:00:f6:d8:4e:ae:62:f8:d1:d4:31:91:ed:1d:
+                    2c:54:80:e4:85:7e:dc:40:46:bf:18:44:78:11:1b:
+                    61:85:c3:87:dd:2d:66:f0:6c:b3:8c:6e:1e:ef:be:
+                    bb:af:28:9b:b6:bb:7d:65:55:35:99:7c:4e:ac:f4:
+                    11:e1:59:4b:c2:00:f1:5a:f5:e8:42:1c:95:3a:59:
+                    9e:c9:49:2d:d5:d1:49:f7:ae:f1:ea:f8:46:bf:da:
+                    14:14:19:31:06:00:1c:d6:d0:17:60:cd:fc:e8:9b:
+                    0a:ac:f1:ed:6c:4d:13:51:07:02:9f:68:47:d2:3a:
+                    ce:1a:9a:92:d7:17:9b:b4:fd:21:2b:14:c5:e0:87:
+                    39:a0:f3:7f:ee:64:9c:af:e2:5b:b1:a4:c3:01:a1:
+                    8a:8b:1b:79:d9:a2:78:72:e2:df:06:bc:dc:28:7e:
+                    d9:ab:a7:76:66:57:b1:ae:db:5b:9b:cf:8e:cd:7a:
+                    39:01:6b:e2:c6:98:5e:f2:95:d4:07:52:03:ac:99:
+                    6e:c5:d7:d2:22:01:f4:77:c7:55:1f:55:80:2d:d0:
+                    35:38:41:71:88:83:f8:19:c9:f1:1c:96:64:0c:eb:
+                    d4:45:f1:6d:ae:63:51:7e:02:09:92:16:7a:f3:8c:
+                    f1:e4:e3:d3:06:36:dc:dc:19:54:40:dc:17:c7:8f:
+                    f4:a7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Authority Key Identifier: 
+                01:02:03
+            Authority Information Access: 
+                OCSP - URI:http://theca.net/ocsp
+                CA Issuers - URI:http://theca.net/totallythecert.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.2.1
+            X509v3 Subject Key Identifier: 
+                04:03:02:01
+            X509v3 Subject Alternative Name: 
+                DNS:*.gov.us, DNS:gov.us
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        a4:e6:dd:96:60:e9:2d:61:b6:a2:9c:d1:07:e9:68:52:db:d2:
+        96:88:f0:0c:54:82:45:c7:1a:c9:7d:41:bf:53:b8:75:d1:b8:
+        49:e2:9b:7c:48:3d:52:6b:60:7f:2e:6c:96:4d:87:26:1b:bb:
+        90:60:c0:64:22:ac:9b:37:b2:ac:0b:21:27:cc:86:02:ca:e5:
+        cb:2d:b3:f7:b7:82:e6:28:a6:9b:bb:00:4d:29:ff:a5:e0:57:
+        be:29:42:88:ff:69:32:b8:19:d8:ca:90:27:4f:44:20:5f:ed:
+        53:1f:39:7a:73:6d:04:74:e9:17:57:12:bd:29:c0:66:c7:a0:
+        20:16:37:07:84:9c:57:79:87:e0:a2:af:a0:b4:78:6a:51:28:
+        a3:c0:e6:63:fa:e7:06:f5:60:de:38:75:7d:7e:d8:39:9f:57:
+        c5:4d:1d:db:57:aa:fc:6c:a7:67:c7:2e:81:1d:50:9f:f8:57:
+        74:ed:40:17:1d:45:54:73:e1:7e:13:06:30:fb:62:87:b6:ca:
+        1b:21:08:5f:f7:9a:06:92:c0:f5:97:ce:68:75:37:7b:72:6e:
+        b6:dc:33:d3:78:ce:28:15:51:59:f9:88:8d:24:5b:ef:54:52:
+        68:70:4b:6f:31:60:07:83:7e:78:e0:b0:61:a5:a0:14:60:71:
+        cf:6e:5d:e7
+-----BEGIN CERTIFICATE-----
+MIIEAzCCAuugAwIBAgIFBDFmk+0wDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDU1vdGhlciBOYXR1cmUxEzARBgNVBAsTCkV2ZXJ5dGhpbmcx
+FjAUBgNVBAMTDU1vdGhlciBOYXR1cmUwHhcNMjMwOTE0MjM1OTU5WhcNMjMxMjA4
+MjI1MDUzWjA8MQswCQYDVQQGEwJVUzEcMBoGA1UECRMTMzIxMCBIb2xseSBNaWxs
+IFJ1bjEPMA0GA1UEAxMGZ292LnVzMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEA4AD22E6uYvjR1DGR7R0sVIDkhX7cQEa/GER4ERthhcOH3S1m8GyzjG4e
+7767ryibtrt9ZVU1mXxOrPQR4VlLwgDxWvXoQhyVOlmeyUkt1dFJ967x6vhGv9oU
+FBkxBgAc1tAXYM386JsKrPHtbE0TUQcCn2hH0jrOGpqS1xebtP0hKxTF4Ic5oPN/
+7mScr+JbsaTDAaGKixt52aJ4cuLfBrzcKH7Zq6d2Zlexrttbm8+OzXo5AWvixphe
+8pXUB1IDrJluxdfSIgH0d8dVH1WALdA1OEFxiIP4GcnxHJZkDOvURfFtrmNRfgIJ
+khZ684zx5OPTBjbc3BlUQNwXx4/0pwIDAQABo4H1MIHyMA4GA1UdDwEB/wQEAwIF
+oDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADAO
+BgNVHSMEBzAFgAMBAgMwYgYIKwYBBQUHAQEEVjBUMCEGCCsGAQUFBzABhhVodHRw
+Oi8vdGhlY2EubmV0L29jc3AwLwYIKwYBBQUHMAKGI2h0dHA6Ly90aGVjYS5uZXQv
+dG90YWxseXRoZWNlcnQuY3J0MBMGA1UdIAQMMAowCAYGZ4EMAQIBMA0GA1UdDgQG
+BAQEAwIBMBsGA1UdEQQUMBKCCCouZ292LnVzggZnb3YudXMwDQYJKoZIhvcNAQEL
+BQADggEBAKTm3ZZg6S1htqKc0QfpaFLb0paI8AxUgkXHGsl9Qb9TuHXRuEnim3xI
+PVJrYH8ubJZNhyYbu5BgwGQirJs3sqwLISfMhgLK5csts/e3guYoppu7AE0p/6Xg
+V74pQoj/aTK4GdjKkCdPRCBf7VMfOXpzbQR06RdXEr0pwGbHoCAWNweEnFd5h+Ci
+r6C0eGpRKKPA5mP65wb1YN44dX1+2DmfV8VNHdtXqvxsp2fHLoEdUJ/4V3TtQBcd
+RVRz4X4TBjD7Yoe2yhshCF/3mgaSwPWXzmh1N3tybrbcM9N4zigVUVn5iI0kW+9U
+UmhwS28xYAeDfnjgsGGloBRgcc9uXec=
+-----END CERTIFICATE-----


### PR DESCRIPTION
## Summary
Continuing on with my attempt to baseline all the TLS BR lints against the current version of the BRs, this PR:
* updates the cab_dv_conflicts_with* lints with the most-recent version of their associated language
* fixes the out of date citation string in `e_cab_dv_conflicts_with_locality`
* adds a citation history to the lints
* marks `e_cab_dv_conflicts_with_locality`, `e_cab_dv_conflicts_with_org`, `e_cab_dv_conflicts_with_province`, `e_cab_dv_conflicts_with_street`, and `e_cab_dv_conflicts_with_postal` as ***ineffective on the CABFBRs_2_0_0_Date***
* adds unit testing for the validity period changes

## Why?
All of these lints are enforcing checks that trigger only in cases where certs violate the BRs. The reason I'm recommending deprecating them is that they no longer have any real basis in the text of the BRs and have been effectively superseded by new, broader requirement.

These lints are very old, all dating from the original implementation of zlint. At the time, the BRs were still much closer to their original, minimal form, and they used language that restricted what subject elements DV certificates could include by prohibiting specific OIDs. The language looked like this:

> If the Certificate asserts the policy identifier of 2.23.140.1.2.1, then it MUST NOT include organizationName, givenName, surname, streetAddress, localityName, stateOrProvinceName, or postalCode	in the Subject field.

In that context, these lints that each check one prohibited attribute made sense and directly followed the structure of the BRs. This section was completely rewritten in major certificate profile reworks included in v2.0.0, and is now a table. The table shows that countryName and commonName are permitted, but that the use of any other subject element is prohibited. This was added to zlint as `e_cab_dv_subject_invalid_values`, which now covers all the cases that were included in these lints. It follows the structure of the new requirement by checking for the specifically allowed elements and setting an error if it finds anything else.

Because the language these lints implement has been removed removed from the BR, and because the cases that these lints cover are now all covered by `e_cab_dv_subject_invalid_values`, I think it's time to sunset them. They no longer have a real basis in the requirements document, and they are just generating duplicate errors for any cert misissued after the CABFBRs_2_0_0_Date.

## Additional Notes
Starting in v1.4.1, the BRs also prohibited givenName and surname from DV certs. Somehow, these didn't make it into zlint with the others (or at least I couldn't find them here now). I didn't add them to cover the period before v2.0.0. If someone has a use for those, they should be pretty easy to add.

## Doc References
* §9.3.1 from v1.2.5 (page break edited out of image for brevity)
<img width="658" height="158" alt="image" src="https://github.com/user-attachments/assets/f786e9c3-8f4d-405f-af8d-27164b5125c2" />

* §7.1.6.1 from v1.3.0 (the next version after v1.2.5)
<img width="699" height="261" alt="image" src="https://github.com/user-attachments/assets/d8bee863-f4ca-4d1b-834d-3c0909c0ccf3" />

* [§7.1.6.4](https://cabforum.org/uploads/CA-Browser-Forum-BR-1.8.7.pdf#page=71&zoom=100,48,770) from 1.8.7
<img width="687" height="197" alt="image" src="https://github.com/user-attachments/assets/fe1ff8db-04cb-4876-b214-a12027b0b738" />

* [§7.1.2.7.2](https://cabforum.org/uploads/CA-Browser-Forum-BR-v2.0.0.pdf#page=74&zoom=100,48,924) from v2.0.0 (next version after 1.8.7, shows replacement language, page break edited out of image for brevity)
<img width="708" height="512" alt="image" src="https://github.com/user-attachments/assets/34431603-c873-4820-8035-338c4424c5be" />
