### PR TITLE
update ca_is_ca citations, language, expand test coverage

### DIFF
--- a/v3/lints/cabf_br/lint_ca_is_ca.go
+++ b/v3/lints/cabf_br/lint_ca_is_ca.go
@@ -21,6 +21,39 @@ import (
 	"github.com/zmap/zlint/v3/util"
 )
 
+/*
+--- Citation History of this Requirement ---
+v1.0 to v1.2.5: Appendix B §1(A) (roots) and §2(D) (subordinate CAs)
+v1.3.0 to v1.8.7: §7.1.2.1(a) (roots) and §7.1.2.2(d) (subordinate CAs)
+v2.0.0 to v2.1.7: §7.1.2.1.4 (roots) and §7.1.2.10.4 (all other CA profiles)
+
+--- Version Notes ---
+In v1.1.3, Appendix B's sections were numbered but retained their previous titles. "Root CA Certificate"
+became section 1 and "Subordinate CA Certificate" became section 2. The numerical section references are
+used here for all versions following the original document format of the Baseline Requirements.
+
+This requirement was baselined at v2.2.6 and is current.
+
+--- Requirements Language ---
+BRs: 7.1.2.1.4 Root CA Basic Constraints
++-------------------+------------------+
+| Field             | Description      |
++-------------------+------------------+
+| cA                | MUST be set TRUE |
++-------------------+------------------+
+| pathLenConstraint | NOT RECOMMENDED  |
++-------------------+------------------+
+
+BRs: 7.1.2.10.4 CA Certificate Basic Constraints
++-------------------+------------------+
+| Field             | Description      |
++-------------------+------------------+
+| cA                | MUST be set TRUE |
++-------------------+------------------+
+| pathLenConstraint | MAY be present   |
++-------------------+------------------+
+*/
+
 type caIsCA struct{}
 
 func init() {
@@ -28,7 +61,7 @@ func init() {
 		LintMetadata: lint.LintMetadata{
 			Name:          "e_ca_is_ca",
 			Description:   "Root and Sub CA Certificate: The CA field MUST be set to true.",
-			Citation:      "BRs: 7.1.2.1, BRs: 7.1.2.2",
+			Citation:      "BRs: 7.1.2.1.4, 7.1.2.10.4",
 			Source:        lint.CABFBaselineRequirements,
 			EffectiveDate: util.CABEffectiveDate,
 		},

--- a/v3/lints/cabf_br/lint_ca_is_ca_test.go
+++ b/v3/lints/cabf_br/lint_ca_is_ca_test.go
@@ -21,20 +21,27 @@ import (
 	"github.com/zmap/zlint/v3/test"
 )
 
-func TestKeyCertSignNotCA(t *testing.T) {
-	inputPath := "keyCertSignNotCA.pem"
-	expected := lint.Error
-	out := test.TestLint("e_ca_is_ca", inputPath)
-	if out.Status != expected {
-		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+func TestCaIsCa(t *testing.T) {
+	tests := []struct {
+		id        string
+		inputFile string
+		expected  lint.LintStatus
+	}{
+		{"TestKeyCertSignNotCA", "keyCertSignNotCA.pem", lint.Error},
+		{"TestKeyCertSignNotCAExplicitFalse", "keyCertSignNotCAExplicitly.pem", lint.Error},
+		{"TestKeyCertSignCA", "keyCertSignCA.pem", lint.Pass},
+		{"TestCaNoKeyUsageNotApplicable", "subCaNokeyUsage.pem", lint.NA},
+		{"TestCaNoCertSignNotApplicable", "subCaNoCertSign.pem", lint.NA},
+		{"TestKeyCertSignNoBasicConstraints", "subCertNoBcWithCertSign.pem", lint.NA},
+		{"TestKeyCertSignNotCAButRequirementNotEffective", "subCaNotCaButOld.pem", lint.NE},
 	}
-}
 
-func TestKeyCertSignCA(t *testing.T) {
-	inputPath := "keyCertSignCA.pem"
-	expected := lint.Pass
-	out := test.TestLint("e_ca_is_ca", inputPath)
-	if out.Status != expected {
-		t.Errorf("%s: expected %s, got %s", inputPath, expected, out.Status)
+	for _, testCase := range tests {
+		t.Run(testCase.id, func(t *testing.T) {
+			var out *lint.LintResult = test.TestLint("e_ca_is_ca", testCase.inputFile)
+			if out.Status != testCase.expected {
+				t.Errorf("%s: expected %s, got %s", testCase.inputFile, testCase.expected, out.Status)
+			}
+		})
 	}
 }

--- a/v3/testdata/keyCertSignNotCAExplicitly.pem
+++ b/v3/testdata/keyCertSignNotCAExplicitly.pem
@@ -1,0 +1,62 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            06:7f:94:57:58:fe:55:b9:ee:3f:75:83:1d:47:f0:7d:22:6c:8a
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: C = US, O = Example Corp, CN = Test Root CA 3
+        Validity
+            Not Before: Oct 22 00:00:00 2015 GMT
+            Not After : Oct 19 00:00:00 2025 GMT
+        Subject: C = US, O = Example Corp, CN = Sneaky Subscriber CA
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:d8:71:8b:0a:99:87:51:d0:68:fc:5f:3e:39:13:
+                    f9:5f:71:34:e7:5e:18:36:12:d0:08:60:12:07:c9:
+                    7b:ff:65:0c:b2:c8:26:ac:d5:aa:6d:5f:f2:39:4f:
+                    57:28:4f:a5:ca:d7:cd:60:9c:1f:21:00:3b:8a:7d:
+                    69:4d:a0:86:11
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 Subject Key Identifier: 
+                04:DC:E0:95:E5:E8:B9:6B:94:A1:EF:8C:5B:31:1E:13:7E:55:97:DA
+            X509v3 Authority Key Identifier: 
+                AB:B6:DB:D7:06:9F:37:AC:20:86:07:92:70:C7:9C:B4:19:B1:78:C0
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.rootca3.example.test
+                CA Issuers - URI:http://crt.rootca3.example.test/rootca3.cer
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl.rootca3.example.test/rootca3.crl
+            X509v3 Certificate Policies: 
+                Policy: X509v3 Any Policy
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:20:3a:5f:ef:bb:1d:2a:7f:13:66:d3:95:b7:7a:87:
+        da:f6:52:b0:cf:aa:0a:bd:db:ba:83:a4:9c:d1:49:70:81:17:
+        02:21:00:92:59:24:3a:17:a2:47:2e:87:8e:58:bc:85:14:5e:
+        b9:f1:e3:4a:10:a6:e4:10:63:07:cf:7e:20:2d:7f:cd:de
+-----BEGIN CERTIFICATE-----
+MIICsDCCAlagAwIBAgITBn+UV1j+VbnuP3WDHUfwfSJsijAKBggqhkjOPQQDAjA9
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRXhhbXBsZSBDb3JwMRcwFQYDVQQDEw5U
+ZXN0IFJvb3QgQ0EgMzAeFw0xNTEwMjIwMDAwMDBaFw0yNTEwMTkwMDAwMDBaMEMx
+CzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxFeGFtcGxlIENvcnAxHTAbBgNVBAMTFFNu
+ZWFreSBTdWJzY3JpYmVyIENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2HGL
+CpmHUdBo/F8+ORP5X3E0514YNhLQCGASB8l7/2UMssgmrNWqbV/yOU9XKE+lytfN
+YJwfIQA7in1pTaCGEaOCAS0wggEpMA8GA1UdEwEB/wQFMAMBAQAwDgYDVR0PAQH/
+BAQDAgGGMB0GA1UdDgQWBBQE3OCV5ei5a5Sh74xbMR4TflWX2jAfBgNVHSMEGDAW
+gBSrttvXBp83rCCGB5Jwx5y0GbF4wDB1BggrBgEFBQcBAQRpMGcwLAYIKwYBBQUH
+MAGGIGh0dHA6Ly9vY3NwLnJvb3RjYTMuZXhhbXBsZS50ZXN0MDcGCCsGAQUFBzAC
+hitodHRwOi8vY3J0LnJvb3RjYTMuZXhhbXBsZS50ZXN0L3Jvb3RjYTMuY2VyMDwG
+A1UdHwQ1MDMwMaAvoC2GK2h0dHA6Ly9jcmwucm9vdGNhMy5leGFtcGxlLnRlc3Qv
+cm9vdGNhMy5jcmwwEQYDVR0gBAowCDAGBgRVHSAAMAoGCCqGSM49BAMCA0gAMEUC
+IDpf77sdKn8TZtOVt3qH2vZSsM+qCr3buoOknNFJcIEXAiEAklkkOheiRy6Hjli8
+hRReufHjShCm5BBjB89+IC1/zd4=
+-----END CERTIFICATE-----

--- a/v3/testdata/subCaNoCertSign.pem
+++ b/v3/testdata/subCaNoCertSign.pem
@@ -1,0 +1,62 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            06:7f:94:57:58:fe:55:b9:ee:3f:75:83:1d:47:f0:7d:22:6c:8a
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: C = US, O = Example Corp, CN = Test Root CA 3
+        Validity
+            Not Before: Oct 22 00:00:00 2015 GMT
+            Not After : Oct 19 00:00:00 2025 GMT
+        Subject: C = US, O = Example Corp, CN = Server Test CA
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:d8:71:8b:0a:99:87:51:d0:68:fc:5f:3e:39:13:
+                    f9:5f:71:34:e7:5e:18:36:12:d0:08:60:12:07:c9:
+                    7b:ff:65:0c:b2:c8:26:ac:d5:aa:6d:5f:f2:39:4f:
+                    57:28:4f:a5:ca:d7:cd:60:9c:1f:21:00:3b:8a:7d:
+                    69:4d:a0:86:11
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Digital Signature, CRL Sign
+            X509v3 Subject Key Identifier: 
+                04:DC:E0:95:E5:E8:B9:6B:94:A1:EF:8C:5B:31:1E:13:7E:55:97:DA
+            X509v3 Authority Key Identifier: 
+                AB:B6:DB:D7:06:9F:37:AC:20:86:07:92:70:C7:9C:B4:19:B1:78:C0
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.rootca3.example.test
+                CA Issuers - URI:http://crt.rootca3.example.test/rootca3.cer
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl.rootca3.example.test/rootca3.crl
+            X509v3 Certificate Policies: 
+                Policy: X509v3 Any Policy
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:20:3a:5f:ef:bb:1d:2a:7f:13:66:d3:95:b7:7a:87:
+        da:f6:52:b0:cf:aa:0a:bd:db:ba:83:a4:9c:d1:49:70:81:17:
+        02:21:00:92:59:24:3a:17:a2:47:2e:87:8e:58:bc:85:14:5e:
+        b9:f1:e3:4a:10:a6:e4:10:63:07:cf:7e:20:2d:7f:cd:de
+-----BEGIN CERTIFICATE-----
+MIICrTCCAlOgAwIBAgITBn+UV1j+VbnuP3WDHUfwfSJsijAKBggqhkjOPQQDAjA9
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRXhhbXBsZSBDb3JwMRcwFQYDVQQDEw5U
+ZXN0IFJvb3QgQ0EgMzAeFw0xNTEwMjIwMDAwMDBaFw0yNTEwMTkwMDAwMDBaMD0x
+CzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxFeGFtcGxlIENvcnAxFzAVBgNVBAMTDlNl
+cnZlciBUZXN0IENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2HGLCpmHUdBo
+/F8+ORP5X3E0514YNhLQCGASB8l7/2UMssgmrNWqbV/yOU9XKE+lytfNYJwfIQA7
+in1pTaCGEaOCATAwggEsMBIGA1UdEwEB/wQIMAYBAf8CAQAwDgYDVR0PAQH/BAQD
+AgGCMB0GA1UdDgQWBBQE3OCV5ei5a5Sh74xbMR4TflWX2jAfBgNVHSMEGDAWgBSr
+ttvXBp83rCCGB5Jwx5y0GbF4wDB1BggrBgEFBQcBAQRpMGcwLAYIKwYBBQUHMAGG
+IGh0dHA6Ly9vY3NwLnJvb3RjYTMuZXhhbXBsZS50ZXN0MDcGCCsGAQUFBzAChito
+dHRwOi8vY3J0LnJvb3RjYTMuZXhhbXBsZS50ZXN0L3Jvb3RjYTMuY2VyMDwGA1Ud
+HwQ1MDMwMaAvoC2GK2h0dHA6Ly9jcmwucm9vdGNhMy5leGFtcGxlLnRlc3Qvcm9v
+dGNhMy5jcmwwEQYDVR0gBAowCDAGBgRVHSAAMAoGCCqGSM49BAMCA0gAMEUCIDpf
+77sdKn8TZtOVt3qH2vZSsM+qCr3buoOknNFJcIEXAiEAklkkOheiRy6Hjli8hRRe
+ufHjShCm5BBjB89+IC1/zd4=
+-----END CERTIFICATE-----

--- a/v3/testdata/subCaNotCaButOld.pem
+++ b/v3/testdata/subCaNotCaButOld.pem
@@ -1,0 +1,62 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            06:7f:94:57:58:fe:55:b9:ee:3f:75:83:1d:47:f0:7d:22:6c:8a
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: C = US, O = Example Corp, CN = Test Root CA 3
+        Validity
+            Not Before: Oct 22 00:00:00 2011 GMT
+            Not After : Oct 19 00:00:00 2015 GMT
+        Subject: C = US, O = Example Corp, CN = Server Test CA
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:d8:71:8b:0a:99:87:51:d0:68:fc:5f:3e:39:13:
+                    f9:5f:71:34:e7:5e:18:36:12:d0:08:60:12:07:c9:
+                    7b:ff:65:0c:b2:c8:26:ac:d5:aa:6d:5f:f2:39:4f:
+                    57:28:4f:a5:ca:d7:cd:60:9c:1f:21:00:3b:8a:7d:
+                    69:4d:a0:86:11
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 Subject Key Identifier: 
+                04:DC:E0:95:E5:E8:B9:6B:94:A1:EF:8C:5B:31:1E:13:7E:55:97:DA
+            X509v3 Authority Key Identifier: 
+                AB:B6:DB:D7:06:9F:37:AC:20:86:07:92:70:C7:9C:B4:19:B1:78:C0
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.rootca3.example.test
+                CA Issuers - URI:http://crt.rootca3.example.test/rootca3.cer
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl.rootca3.example.test/rootca3.crl
+            X509v3 Certificate Policies: 
+                Policy: X509v3 Any Policy
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:20:3a:5f:ef:bb:1d:2a:7f:13:66:d3:95:b7:7a:87:
+        da:f6:52:b0:cf:aa:0a:bd:db:ba:83:a4:9c:d1:49:70:81:17:
+        02:21:00:92:59:24:3a:17:a2:47:2e:87:8e:58:bc:85:14:5e:
+        b9:f1:e3:4a:10:a6:e4:10:63:07:cf:7e:20:2d:7f:cd:de
+-----BEGIN CERTIFICATE-----
+MIICpzCCAk2gAwIBAgITBn+UV1j+VbnuP3WDHUfwfSJsijAKBggqhkjOPQQDAjA9
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRXhhbXBsZSBDb3JwMRcwFQYDVQQDEw5U
+ZXN0IFJvb3QgQ0EgMzAeFw0xMTEwMjIwMDAwMDBaFw0xNTEwMTkwMDAwMDBaMD0x
+CzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxFeGFtcGxlIENvcnAxFzAVBgNVBAMTDlNl
+cnZlciBUZXN0IENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2HGLCpmHUdBo
+/F8+ORP5X3E0514YNhLQCGASB8l7/2UMssgmrNWqbV/yOU9XKE+lytfNYJwfIQA7
+in1pTaCGEaOCASowggEmMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgGGMB0G
+A1UdDgQWBBQE3OCV5ei5a5Sh74xbMR4TflWX2jAfBgNVHSMEGDAWgBSrttvXBp83
+rCCGB5Jwx5y0GbF4wDB1BggrBgEFBQcBAQRpMGcwLAYIKwYBBQUHMAGGIGh0dHA6
+Ly9vY3NwLnJvb3RjYTMuZXhhbXBsZS50ZXN0MDcGCCsGAQUFBzAChitodHRwOi8v
+Y3J0LnJvb3RjYTMuZXhhbXBsZS50ZXN0L3Jvb3RjYTMuY2VyMDwGA1UdHwQ1MDMw
+MaAvoC2GK2h0dHA6Ly9jcmwucm9vdGNhMy5leGFtcGxlLnRlc3Qvcm9vdGNhMy5j
+cmwwEQYDVR0gBAowCDAGBgRVHSAAMAoGCCqGSM49BAMCA0gAMEUCIDpf77sdKn8T
+ZtOVt3qH2vZSsM+qCr3buoOknNFJcIEXAiEAklkkOheiRy6Hjli8hRReufHjShCm
+5BBjB89+IC1/zd4=
+-----END CERTIFICATE-----

--- a/v3/testdata/subCertNoBcWithCertSign.pem
+++ b/v3/testdata/subCertNoBcWithCertSign.pem
@@ -1,0 +1,60 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            06:7f:94:57:58:fe:55:b9:ee:3f:75:83:1d:47:f0:7d:22:6c:8a
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: C = US, O = Example Corp, CN = Test Root CA 3
+        Validity
+            Not Before: Oct 22 00:00:00 2015 GMT
+            Not After : Oct 19 00:00:00 2025 GMT
+        Subject: C = US, O = Example Corp, CN = Sneaky Subscriber CA
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:d8:71:8b:0a:99:87:51:d0:68:fc:5f:3e:39:13:
+                    f9:5f:71:34:e7:5e:18:36:12:d0:08:60:12:07:c9:
+                    7b:ff:65:0c:b2:c8:26:ac:d5:aa:6d:5f:f2:39:4f:
+                    57:28:4f:a5:ca:d7:cd:60:9c:1f:21:00:3b:8a:7d:
+                    69:4d:a0:86:11
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 Subject Key Identifier: 
+                04:DC:E0:95:E5:E8:B9:6B:94:A1:EF:8C:5B:31:1E:13:7E:55:97:DA
+            X509v3 Authority Key Identifier: 
+                AB:B6:DB:D7:06:9F:37:AC:20:86:07:92:70:C7:9C:B4:19:B1:78:C0
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.rootca3.example.test
+                CA Issuers - URI:http://crt.rootca3.example.test/rootca3.cer
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl.rootca3.example.test/rootca3.crl
+            X509v3 Certificate Policies: 
+                Policy: X509v3 Any Policy
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:20:3a:5f:ef:bb:1d:2a:7f:13:66:d3:95:b7:7a:87:
+        da:f6:52:b0:cf:aa:0a:bd:db:ba:83:a4:9c:d1:49:70:81:17:
+        02:21:00:92:59:24:3a:17:a2:47:2e:87:8e:58:bc:85:14:5e:
+        b9:f1:e3:4a:10:a6:e4:10:63:07:cf:7e:20:2d:7f:cd:de
+-----BEGIN CERTIFICATE-----
+MIICnzCCAkWgAwIBAgITBn+UV1j+VbnuP3WDHUfwfSJsijAKBggqhkjOPQQDAjA9
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRXhhbXBsZSBDb3JwMRcwFQYDVQQDEw5U
+ZXN0IFJvb3QgQ0EgMzAeFw0xNTEwMjIwMDAwMDBaFw0yNTEwMTkwMDAwMDBaMEMx
+CzAJBgNVBAYTAlVTMRUwEwYDVQQKEwxFeGFtcGxlIENvcnAxHTAbBgNVBAMTFFNu
+ZWFreSBTdWJzY3JpYmVyIENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2HGL
+CpmHUdBo/F8+ORP5X3E0514YNhLQCGASB8l7/2UMssgmrNWqbV/yOU9XKE+lytfN
+YJwfIQA7in1pTaCGEaOCARwwggEYMA4GA1UdDwEB/wQEAwIBhjAdBgNVHQ4EFgQU
+BNzgleXouWuUoe+MWzEeE35Vl9owHwYDVR0jBBgwFoAUq7bb1wafN6wghgeScMec
+tBmxeMAwdQYIKwYBBQUHAQEEaTBnMCwGCCsGAQUFBzABhiBodHRwOi8vb2NzcC5y
+b290Y2EzLmV4YW1wbGUudGVzdDA3BggrBgEFBQcwAoYraHR0cDovL2NydC5yb290
+Y2EzLmV4YW1wbGUudGVzdC9yb290Y2EzLmNlcjA8BgNVHR8ENTAzMDGgL6Athito
+dHRwOi8vY3JsLnJvb3RjYTMuZXhhbXBsZS50ZXN0L3Jvb3RjYTMuY3JsMBEGA1Ud
+IAQKMAgwBgYEVR0gADAKBggqhkjOPQQDAgNIADBFAiA6X++7HSp/E2bTlbd6h9r2
+UrDPqgq927qDpJzRSXCBFwIhAJJZJDoXokcuh45YvIUUXrnx40oQpuQQYwfPfiAt
+f83e
+-----END CERTIFICATE-----


### PR DESCRIPTION
## Overview
* Updated the citation strings for lint_ca_is_ca
* Added a comment with the current version of the requirement language and historical references for every previous version of the Baseline Requirements
* Added some new test cases to cover the `checkApplies()` and an (incorrectly encoded) explicit false for isCa in the basic constraints
  * That `checkApplies()` probably looks odd at first glance, but it's more sane than it appears. If there's no basic constraints extension included at all, zlint will interpret the cert as a server certificate and flag it for `e_sub_cert_key_usage_cert_sign_bit_set` instead. That's defensible enough, since it _is_ a server cert with certSign set, and it means there's no detection gap here.
  * Fundamentally, this lint is a bit of an oddball trying to detect improperly encoded intention from only the resulting certificate which is always going to be somewhat of a guessing game, so I decided not to pitch any changes to its detection logic.
* Refactored tests into a table-driven test based on previous feedback

## Documentation References
(Fragment links should go directly to the sections.)
* [v1.0 Appendix B](https://cabforum.org/uploads/Baseline_Requirements_V1.pdf#page=33&zoom=100,48,50)
* [v1.2.5 Appendix B](https://cabforum.org/uploads/BRv1.2.5.pdf#page=42&zoom=100,48,200)
* [v1.3.0 §7.1.2.1](https://cabforum.org/uploads/CAB-Forum-BR-1.3.0.pdf#page=38&zoom=100,48,600)
* [v1.3.0 §7.1.2.2](https://cabforum.org/uploads/CAB-Forum-BR-1.3.0.pdf#page=39&zoom=100,48,280)
* [v1.8.7 §7.1.2.1 & §7.1.2.2](https://cabforum.org/uploads/CA-Browser-Forum-BR-1.8.7.pdf#page=60&zoom=100,48,440)
* [v2.0.0 §7.1.2.1.4](https://cabforum.org/uploads/CA-Browser-Forum-BR-v2.0.0.pdf#page=62&zoom=100,48,1045)
* [v2.0.0 §7.1.2.10.4](https://cabforum.org/uploads/CA-Browser-Forum-BR-v2.0.0.pdf#page=91&zoom=100,48,753)
* [v2.2.6 §7.1.2.1.4](https://cabforum.org/working-groups/server/baseline-requirements/documents/CA-Browser-Forum-TLS-BR-2.2.6.pdf#page=72&zoom=100,48,800)
* [v2.0.0 §7.1.2.10.4](https://cabforum.org/working-groups/server/baseline-requirements/documents/CA-Browser-Forum-TLS-BR-2.2.6.pdf#page=101&zoom=100,48,950)