### PR TITLE
Remove FreeBSD as a release target due to compilation errors in zcrypto

### DIFF
--- a/v3/.goreleaser.yml
+++ b/v3/.goreleaser.yml
@@ -10,7 +10,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - freebsd
       - windows
       - darwin
     goarch:


### PR DESCRIPTION
We cannot release due to a failed build again `freebsd_amd64_v1`.

```
  • building binaries
    • building                                       paths=cmd/zlint/main.go binaries=zlint target=darwin_amd64_v1
    • building                                       paths=cmd/zlint/main.go binaries=zlint target=freebsd_amd64_v1
    • building                                       paths=cmd/zlint/main.go binaries=zlint target=windows_amd64_v1
    • building                                       paths=cmd/zlint/main.go binaries=zlint target=linux_amd64_v1
      • took: 47s
  ⨯ release failed after 50s                        
    error=
    │ build failed: exit status 1: # github.com/zmap/zcrypto/x509
Error:     │ ../../../../go/pkg/mod/github.com/zmap/zcrypto@v0.0.0-20260426170728-e95752a6dfc1/x509/root_unix.go:36:11: undefined: certFiles
Error:     │ ../../../../go/pkg/mod/github.com/zmap/zcrypto@v0.0.0-20260426170728-e95752a6dfc1/x509/root_unix.go:53:10: undefined: certDirectories
    target=freebsd_amd64_v1
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.15.4/x64/goreleaser' failed with exit code 1

```