### PR TITLE
Remove Windows as a release target due to compilation errors in zcrypto

### DIFF
--- a/v3/.goreleaser.yml
+++ b/v3/.goreleaser.yml
@@ -1,21 +1,24 @@
+version: 2
+
 project_name: zlint
+
 before:
   hooks:
     - go mod tidy
+
 builds:
-  -
-    main: ./cmd/zlint/main.go
+  - main: ./cmd/zlint/main.go
     binary: zlint
     env:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
     goarch:
       - amd64
+
 archives:
-  -
+  - formats: [tar.gz]
     wrap_in_directory: true
     name_template: >-
       {{- .ProjectName }}_
@@ -25,8 +28,10 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end -}}
+
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
+
 release:
   draft: true
   prerelease: auto


### PR DESCRIPTION
```
  • building binaries
    • building                                       paths=cmd/zlint/main.go binaries=zlint target=windows_amd64_v1
    • building                                       paths=cmd/zlint/main.go binaries=zlint target=linux_amd64_v1
    • building                                       paths=cmd/zlint/main.go binaries=zlint target=darwin_amd64_v1
      • took: 36s
  ⨯ release failed after 40s                        
    error=
    │ build failed: exit status 1: # github.com/zmap/zcrypto/x509
Error:     │ ../../../../go/pkg/mod/github.com/zmap/zcrypto@v0.0.0-20260426170728-e95752a6dfc1/x509/root.go:27:32: undefined: loadSystemRoots
    target=windows_amd64_v1
```