### PR TITLE
Add isSubscriber check to ecc key usage lint

### DIFF
--- a/v3/lints/cabf_br/lint_ecc_allowed_key_usages.go
+++ b/v3/lints/cabf_br/lint_ecc_allowed_key_usages.go
@@ -61,9 +61,12 @@ func NewEccAllowedKU() lint.LintInterface {
 	return &eccAllowedKU{}
 }
 
-// CheckApplies returns true when the certificate has an ECC public key and a key usage extension.
+// CheckApplies returns true on subscriber certificates when the certificate
+// has an ECC public key and a key usage extension.
 func (l *eccAllowedKU) CheckApplies(c *x509.Certificate) bool {
-	return c.PublicKeyAlgorithm == x509.ECDSA && util.HasKeyUsageOID(c)
+	return c.PublicKeyAlgorithm == x509.ECDSA &&
+		util.HasKeyUsageOID(c) &&
+		util.IsSubscriberCert(c)
 }
 
 func (l *eccAllowedKU) Execute(c *x509.Certificate) *lint.LintResult {

--- a/v3/lints/cabf_br/lint_ecc_allowed_key_usages_test.go
+++ b/v3/lints/cabf_br/lint_ecc_allowed_key_usages_test.go
@@ -19,6 +19,7 @@ func TestCabfEccAllowedKeyUsages(t *testing.T) {
 		{desc: "error - dv certificate with ecc key and no digitalSignature", file: "ecc_key_dv_with_no_digital_signature.pem", result: lint.Error},
 		{desc: "error - dv certificate with ecc key and prohibited keyUsage", file: "ecc_key_dv_with_prohibited_key_usage.pem", result: lint.Error},
 		{desc: "warning - dv certificate with ecc key and keyAgreement and digitalSignature", file: "ecc_key_dv_with_key_agreement.pem", result: lint.Warn},
+		{desc: "na - ca certificate with ecc key", file: "ecc_key_ca_cert.pem", result: lint.NA},
 	}
 
 	for _, tc := range tests {

--- a/v3/testdata/ecc_key_ca_cert.pem
+++ b/v3/testdata/ecc_key_ca_cert.pem
@@ -1,0 +1,59 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: CN=Test CA 2, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: May 26 15:01:14 2026 GMT
+            Not After : May 26 15:01:14 2027 GMT
+        Subject: CN=Test CA 2, OU=CA, O=Example Co, C=US
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:ec:e1:5e:7f:fa:9c:7b:42:f1:bf:1e:e0:bd:82:
+                    f5:d5:8b:30:6c:3b:f1:12:dc:b0:1a:a0:df:bc:df:
+                    a2:c9:1c:3d:f9:45:34:b4:3b:91:7e:43:98:d6:93:
+                    a4:9c:e7:42:39:87:97:34:a0:f2:6e:15:31:45:41:
+                    ff:4e:2d:a0:b3
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Authority Key Identifier: 
+                01:02:03:04:06
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.dcone.cluster.local
+            X509v3 Certificate Policies: 
+                Policy: X509v3 Any Policy
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl.dcone.cluster.local
+
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:46:02:21:00:ac:e2:78:62:92:98:69:db:95:ee:a0:9c:4d:
+        05:23:72:42:30:60:dd:52:bc:71:ab:fc:71:a6:b3:f7:91:12:
+        76:02:21:00:f3:a0:ac:aa:99:ab:c3:e2:fc:a2:4b:30:79:3b:
+        05:93:23:55:89:5e:ae:20:25:4b:b9:fc:b2:ff:e0:dd:c0:a6
+-----BEGIN CERTIFICATE-----
+MIICTTCCAfKgAwIBAgIBATAKBggqhkjOPQQDAjBDMRIwEAYDVQQDEwlUZXN0IENB
+IDIxCzAJBgNVBAsTAkNBMRMwEQYDVQQKEwpFeGFtcGxlIENvMQswCQYDVQQGEwJV
+UzAeFw0yNjA1MjYxNTAxMTRaFw0yNzA1MjYxNTAxMTRaMEMxEjAQBgNVBAMTCVRl
+c3QgQ0EgMjELMAkGA1UECxMCQ0ExEzARBgNVBAoTCkV4YW1wbGUgQ28xCzAJBgNV
+BAYTAlVTMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7OFef/qce0Lxvx7gvYL1
+1YswbDvxEtywGqDfvN+iyRw9+UU0tDuRfkOY1pOknOdCOYeXNKDybhUxRUH/Ti2g
+s6OB1jCB0zAOBgNVHQ8BAf8EBAMCAYYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsG
+AQUFBwMCMA8GA1UdEwEB/wQFMAMBAf8wEAYDVR0jBAkwB4AFAQIDBAYwOwYIKwYB
+BQUHAQEELzAtMCsGCCsGAQUFBzABhh9odHRwOi8vb2NzcC5kY29uZS5jbHVzdGVy
+LmxvY2FsMBEGA1UdIAQKMAgwBgYEVR0gADAvBgNVHR8EKDAmMCSgIqAghh5odHRw
+Oi8vY3JsLmRjb25lLmNsdXN0ZXIubG9jYWwwCgYIKoZIzj0EAwIDSQAwRgIhAKzi
+eGKSmGnble6gnE0FI3JCMGDdUrxxq/xxprP3kRJ2AiEA86Csqpmrw+L8oksweTsF
+kyNViV6uICVLufyy/+DdwKY=
+-----END CERTIFICATE-----


### PR DESCRIPTION
Fixed the e_cabf_ecc_allowed_key_usages lint to only run on subscriber certificates to address [this issue](https://github.com/zmap/zlint/issues/1050)
> 7.1.2.7.11 Subscriber Certificate Key Usage
> The acceptable Key Usage values vary based on whether the Certificate’s
> subjectPublicKeyInfo identifies an RSA public key or an ECC public key. CAs MUST ensure
> the Key Usage is appropriate for the Certificate Public Key.
> 	+-------------------+-----------+------------------+
> 	| Key Usage         | Permitted | Required         |
> 	+-------------------+-----------+------------------+
> 	| digitalSignature  | Y         | MUST             |
> 	| nonRepudiation    | N         | –                |
> 	| keyEncipherment   | N         | –                |
> 	| dataEncipherment  | N         | –                |
> 	| keyAgreement      | Y         | NOT RECOMMENDED  |
> 	| keyCertSign       | N         | –                |
> 	| cRLSign           | N         | –                |
> 	| encipherOnly      | N         | –                |
> 	| decipherOnly      | N         | –                |
> 	+-------------------+-----------+------------------+