### PR TITLE
Add lint to check for sdn org presence in both EV and non-EV code signing certificates

### DIFF
--- a/v3/lints/cabf_cs_br/lint_cs_subject_org_required.go
+++ b/v3/lints/cabf_cs_br/lint_cs_subject_org_required.go
@@ -1,0 +1,88 @@
+package cabf_cs_br
+
+/*
+ * ZLint Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+type csSubjectOrgRequired struct{}
+
+/************************************************
+CSBRs: 7.1.4.2.3, 7.1.4.2.4
+Certificate Field: subject:organizationName (OID 2.5.4.10)
+Required/Optional: Required
+
+7.1.4.2.3 (Non-EV Code Signing Certificates):
+The subject:organizationName field MUST contain either the Subject's name or DBA as verified
+under BR Section 3.2. The CA MAY include information in this field that differs slightly from
+the verified name, such as common variations or abbreviations, provided that the CA documents
+the difference and any abbreviations used are locally accepted abbreviations; e.g., if the
+official record shows "Company Name Incorporated", the CA MAY use "Company Name Inc." or
+"Company Name". Because subject name attributes for individuals (e.g. subject:givenName
+(2.5.4.42) and subject:surname (2.5.4.4)) are not broadly supported by application software,
+the CA MAY use the subject:organizationName field to convey a natural person Subject's name or
+DBA. The CA MUST have a documented process for verifying that the information included in the
+subject:organizationName field is not misleading to a Relying Party.
+
+7.1.4.2.4 (EV Code Signing Certificates):
+This field MUST contain the Subject's full legal organization name as listed in the official
+records of the Incorporating or Registration Agency in the Subject's Jurisdiction of
+Incorporation or Registration or as otherwise verified by the CA as provided herein. A CA MAY
+abbreviate the organization prefixes or suffixes in the organization name, e.g., if the
+official record shows "Company Name Incorporated" the CA MAY include "Company Name, Inc."
+When abbreviating a Subject's full legal name as allowed by this subsection, the CA MUST use
+abbreviations that are not misleading in the Jurisdiction of Incorporation or Registration.
+In addition, an assumed name or DBA name used by the Subject MAY be included at the beginning
+of this field, provided that it is followed by the full legal organization name in parenthesis.
+If the combination of names or the organization name by itself exceeds 64 characters, the CA
+MAY abbreviate parts of the organization name, and/or omit non-material words in the
+organization name in such a way that the text in this field does not exceed the 64-character
+limit; provided that the CA checks this field in accordance with the High Risk Certificate
+Request requirements of Section 4.2.1 and a Relying Party will not be misled into thinking
+that they are dealing with a different organization. In cases where this is not possible, the
+CA MUST NOT issue the EV Code Signing Certificate.
+************************************************/
+
+func init() {
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cs_requires_org",
+			Description:   "Code Signing certificates MUST include organizationName in the subject field",
+			Citation:      "CSBRs: 7.1.4.2.3, 7.1.4.2.4", // Applies to both EV and non-EV CS certs
+			Source:        lint.CABFCSBaselineRequirements,
+			EffectiveDate: util.CABF_CS_BRs_1_2_Date,
+		},
+		Lint: NewCsSubjectOrgRequired,
+	})
+}
+
+func NewCsSubjectOrgRequired() lint.LintInterface {
+	return &csSubjectOrgRequired{}
+}
+
+func (l *csSubjectOrgRequired) CheckApplies(cert *x509.Certificate) bool {
+	return util.IsSubscriberCert(cert)
+}
+
+func (l *csSubjectOrgRequired) Execute(cert *x509.Certificate) *lint.LintResult {
+	if len(cert.Subject.Organization) > 0 {
+		return &lint.LintResult{Status: lint.Pass}
+	}
+
+	return &lint.LintResult{Status: lint.Error, Details: "Code Signing certificate is missing required organizationName in subject."}
+}

--- a/v3/lints/cabf_cs_br/lint_cs_subject_org_required_test.go
+++ b/v3/lints/cabf_cs_br/lint_cs_subject_org_required_test.go
@@ -1,0 +1,45 @@
+package cabf_cs_br
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestCsSubjectOrgRequired(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		InputFilename  string
+		ExpectedResult lint.LintStatus
+	}{
+		{
+			Name:           "pass - Non-EV CS certificate with organizationName in subject",
+			InputFilename:  "code_signing/cs_ov_subject_org_present.pem",
+			ExpectedResult: lint.Pass,
+		},
+		{
+			Name:           "pass - EV CS certificate with organizationName in subject",
+			InputFilename:  "code_signing/cs_ev_subject_org_present.pem",
+			ExpectedResult: lint.Pass,
+		},
+		{
+			Name:           "error - Non-EV CS certificate missing organizationName in subject",
+			InputFilename:  "code_signing/cs_ov_subject_org_missing.pem",
+			ExpectedResult: lint.Error,
+		},
+		{
+			Name:           "error - EV CS certificate missing organizationName in subject",
+			InputFilename:  "code_signing/cs_ev_subject_org_missing.pem",
+			ExpectedResult: lint.Error,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := test.TestLint("e_cs_requires_org", tc.InputFilename)
+			if result.Status != tc.ExpectedResult {
+				t.Errorf("expected result %v was %v - details: %v", tc.ExpectedResult, result.Status, result.Details)
+			}
+		})
+	}
+}

--- a/v3/testdata/code_signing/cs_ev_subject_org_missing.pem
+++ b/v3/testdata/code_signing/cs_ev_subject_org_missing.pem
@@ -1,0 +1,125 @@
+
+
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            99:aa:a1:bb:8e:2c:7d:6e:c6:81:e3:86:a1:ea:53:e4
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=EV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 14 18:00:26 2026 GMT
+            Not After : Jun 14 18:00:26 2027 GMT
+        Subject: CN=Example Co, L=Mountain View, ST=California, C=US, jurisdictionL=Mountain View, jurisdictionST=California, jurisdictionC=US, serialNumber=12345678, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:b6:f5:b2:62:47:38:6e:11:ea:19:07:a0:80:1a:
+                    fb:ca:a6:09:27:8f:a0:89:88:28:4e:48:b6:b2:4b:
+                    16:ff:81:85:55:16:37:27:e3:0e:2b:9c:0d:b1:34:
+                    5d:c6:55:80:9f:18:d3:ff:f7:f8:ca:6e:66:26:d2:
+                    4a:37:08:80:16:d9:70:49:c8:ae:e2:b7:5d:16:9c:
+                    2e:4a:46:5f:f8:ee:23:63:32:4b:2f:41:36:29:d6:
+                    76:19:f0:b5:37:76:61:01:1e:0e:f2:4d:40:6c:b0:
+                    76:82:98:82:32:82:f3:80:9e:c2:2a:1b:86:9c:96:
+                    be:50:f2:d4:54:33:a0:01:5b:5d:6b:48:61:bb:0d:
+                    6e:ab:54:9a:9a:7c:45:1a:39:2c:f1:57:de:a7:f7:
+                    c7:46:dc:76:17:7e:28:74:a7:3e:20:3e:0d:f8:77:
+                    75:19:db:10:dc:f1:65:a4:81:c5:98:f8:63:dc:10:
+                    dd:af:19:c1:66:c4:2d:dd:43:f5:94:1a:36:99:d5:
+                    58:5d:22:da:f3:c6:7b:cd:99:d3:ca:9f:a1:b2:70:
+                    03:d6:d0:99:bb:de:f2:1a:8e:41:e3:e5:ee:1f:ac:
+                    38:00:31:2e:5d:c4:1b:49:89:16:6f:74:d9:5f:a8:
+                    8d:57:dc:8c:f5:8c:ad:06:8b:f0:15:aa:fb:aa:f7:
+                    92:97:6d:dd:6d:39:49:1a:f7:52:71:7d:ea:cd:aa:
+                    41:24:38:b9:f5:7a:b2:fb:a8:a3:82:f5:f1:dc:ba:
+                    cf:13:af:6f:e6:d1:6e:d4:d9:7d:31:37:2b:4b:4a:
+                    e8:e4:82:05:07:84:5d:a6:22:81:b4:bc:d1:0a:14:
+                    0c:61:93:2b:9c:34:c5:e8:bc:cb:af:d6:61:29:09:
+                    05:38:fb:52:da:30:1a:a3:2b:60:99:86:b3:80:63:
+                    8c:48:7d:2f:77:ac:e4:97:b8:97:25:94:d7:0c:88:
+                    9e:57:76:6b:8c:66:74:5b:56:1b:32:db:d7:7e:78:
+                    c5:a8:76:d7:d1:1f:50:a5:ae:df
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                37:34:35:F1:6B:EE:7C:C7:98:57:01:A8:9A:0E:C1:36:28:44:46:A9
+            X509v3 Authority Key Identifier: 
+                7F:D8:4C:DB:5B:24:99:C7:C8:4C:2C:61:F0:F8:AD:9E:02:11:B7:80
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.3
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        9d:0f:59:14:4d:aa:c9:77:ba:9b:54:17:58:40:c0:4d:e7:fb:
+        9d:92:82:d4:f3:83:78:3c:2c:ee:f6:2f:9a:d5:39:7b:65:12:
+        01:1f:6d:65:80:4e:bd:23:9e:9b:c4:7f:3e:ff:3f:46:dc:f8:
+        2f:41:bc:b7:08:36:10:b4:77:51:26:59:ce:89:b3:09:29:02:
+        f2:ac:20:9c:67:41:08:53:29:ee:ae:03:d3:89:e9:a3:6b:12:
+        ee:4e:37:18:07:4a:25:41:d0:b6:89:43:ab:33:0b:b3:49:1f:
+        a4:15:e2:35:2c:c9:74:4e:c3:22:6f:79:61:a4:38:0c:e9:de:
+        53:69:84:5e:ff:e4:a4:91:f9:73:99:63:94:67:c0:7d:91:89:
+        0e:d2:5f:b9:b1:90:28:61:1b:b9:7a:33:28:5e:b6:e7:4c:c6:
+        a4:31:8e:5e:09:75:b4:85:3b:7d:f2:87:88:dd:03:17:b1:b2:
+        45:5b:47:5d:47:f4:5a:b9:37:de:2a:ff:31:91:90:d4:d2:d0:
+        b4:84:26:47:34:a6:11:fa:49:4f:50:50:05:02:48:57:5e:22:
+        1c:19:9f:dc:b9:54:ac:4f:b6:b5:1c:f7:bf:4a:08:8e:19:14:
+        a7:fc:6f:34:f3:f0:35:f1:22:25:b1:5d:51:a9:f5:55:05:50:
+        7e:3e:c5:a2:c2:63:74:02:e0:0e:e3:4a:2f:46:d7:84:83:82:
+        0e:78:33:ca:34:07:f2:7c:f5:ce:0d:1c:6c:82:3c:25:68:2c:
+        28:a0:5b:ea:70:0b:49:8a:cf:c7:a9:91:10:ba:5a:9b:4c:1d:
+        a3:90:c6:de:e3:41:8f:80:b7:da:dd:d4:51:7e:62:60:d2:d7:
+        28:2a:ab:a2:53:1a:71:84:08:de:80:a5:38:c8:7a:3d:9b:f7:
+        5d:4d:e5:fe:07:76:12:b6:9d:a3:62:43:c3:08:32:a7:0a:5d:
+        e2:6c:06:b6:4e:35:37:f4:e0:89:55:45:a5:c3:45:96:a3:e2:
+        7c:bf:93:3f:0e:b4
+-----BEGIN CERTIFICATE-----
+MIIF7jCCBFagAwIBAgIRAJmqobuOLH1uxoHjhqHqU+QwDQYJKoZIhvcNAQELBQAw
+TDEbMBkGA1UEAxMSRVYgQ29kZSBTaWduaW5nIENBMQswCQYDVQQLEwJDQTETMBEG
+A1UEChMKRXhhbXBsZSBDbzELMAkGA1UEBhMCVVMwHhcNMjYwNjE0MTgwMDI2WhcN
+MjcwNjE0MTgwMDI2WjCB0zETMBEGA1UEAxMKRXhhbXBsZSBDbzEWMBQGA1UEBxMN
+TW91bnRhaW4gVmlldzETMBEGA1UECBMKQ2FsaWZvcm5pYTELMAkGA1UEBhMCVVMx
+HjAcBgsrBgEEAYI3PAIBARMNTW91bnRhaW4gVmlldzEbMBkGCysGAQQBgjc8AgEC
+EwpDYWxpZm9ybmlhMRMwEQYLKwYBBAGCNzwCAQMTAlVTMREwDwYDVQQFEwgxMjM0
+NTY3ODEdMBsGA1UEDxMUUHJpdmF0ZSBPcmdhbml6YXRpb24wggGiMA0GCSqGSIb3
+DQEBAQUAA4IBjwAwggGKAoIBgQC29bJiRzhuEeoZB6CAGvvKpgknj6CJiChOSLay
+Sxb/gYVVFjcn4w4rnA2xNF3GVYCfGNP/9/jKbmYm0ko3CIAW2XBJyK7it10WnC5K
+Rl/47iNjMksvQTYp1nYZ8LU3dmEBHg7yTUBssHaCmIIygvOAnsIqG4aclr5Q8tRU
+M6ABW11rSGG7DW6rVJqafEUaOSzxV96n98dG3HYXfih0pz4gPg34d3UZ2xDc8WWk
+gcWY+GPcEN2vGcFmxC3dQ/WUGjaZ1VhdItrzxnvNmdPKn6GycAPW0Jm73vIajkHj
+5e4frDgAMS5dxBtJiRZvdNlfqI1X3Iz1jK0Gi/AVqvuq95KXbd1tOUka91JxferN
+qkEkOLn1erL7qKOC9fHcus8Tr2/m0W7U2X0xNytLSujkggUHhF2mIoG0vNEKFAxh
+kyucNMXovMuv1mEpCQU4+1LaMBqjK2CZhrOAY4xIfS93rOSXuJcllNcMiJ5XdmuM
+ZnRbVhsy29d+eMWodtfRH1Clrt8CAwEAAaOCAUEwggE9MA4GA1UdDwEB/wQEAwIH
+gDATBgNVHSUEDDAKBggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBQ3
+NDXxa+58x5hXAaiaDsE2KERGqTAfBgNVHSMEGDAWgBR/2EzbWySZx8hMLGHw+K2e
+AhG3gDBbBggrBgEFBQcBAQRPME0wIwYIKwYBBQUHMAGGF2h0dHA6Ly9vY3NwLmV4
+YW1wbGUuY29tMCYGCCsGAQUFBzAChhpodHRwOi8vZXhhbXBsZS5jb20vY2ExLmNy
+dDASBgNVHSAECzAJMAcGBWeBDAEDMFcGA1UdHwRQME4wJaAjoCGGH2h0dHA6Ly9j
+cmwxLmV4YW1wbGUuY29tL2NhMS5jcmwwJaAjoCGGH2h0dHA6Ly9jcmwyLmV4YW1w
+bGUuY29tL2NhMS5jcmwwDQYJKoZIhvcNAQELBQADggGBAJ0PWRRNqsl3uptUF1hA
+wE3n+52SgtTzg3g8LO72L5rVOXtlEgEfbWWATr0jnpvEfz7/P0bc+C9BvLcINhC0
+d1EmWc6JswkpAvKsIJxnQQhTKe6uA9OJ6aNrEu5ONxgHSiVB0LaJQ6szC7NJH6QV
+4jUsyXROwyJveWGkOAzp3lNphF7/5KSR+XOZY5RnwH2RiQ7SX7mxkChhG7l6Myhe
+tudMxqQxjl4JdbSFO33yh4jdAxexskVbR11H9Fq5N94q/zGRkNTS0LSEJkc0phH6
+SU9QUAUCSFdeIhwZn9y5VKxPtrUc979KCI4ZFKf8bzTz8DXxIiWxXVGp9VUFUH4+
+xaLCY3QC4A7jSi9G14SDgg54M8o0B/J89c4NHGyCPCVoLCigW+pwC0mKz8epkRC6
+WptMHaOQxt7jQY+At9rd1FF+YmDS1ygqq6JTGnGECN6ApTjIej2b911N5f4HdhK2
+naNiQ8MIMqcKXeJsBrZONTf04IlVRaXDRZaj4ny/kz8OtA==
+-----END CERTIFICATE-----

--- a/v3/testdata/code_signing/cs_ev_subject_org_present.pem
+++ b/v3/testdata/code_signing/cs_ev_subject_org_present.pem
@@ -1,0 +1,125 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            d5:29:2e:56:3f:6c:27:d1:f8:86:47:f2:c7:80:06:25
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=EV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 14 17:54:47 2026 GMT
+            Not After : Jun 14 17:54:47 2027 GMT
+        Subject: CN=Example Co, O=Example Co, L=Mountain View, ST=California, C=US, jurisdictionL=Mountain View, jurisdictionST=California, jurisdictionC=US, serialNumber=12345678, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:cd:ee:b1:79:ac:24:51:76:df:02:bd:4f:82:74:
+                    b3:5d:d4:da:4d:c2:2d:06:5e:d3:5c:81:5a:ad:51:
+                    71:92:1e:7a:c7:b1:9d:ac:0a:d4:90:db:6c:3a:d4:
+                    2b:56:ec:73:3d:00:3d:de:bf:c5:74:35:a6:73:9a:
+                    b6:cd:b4:01:9b:d5:2d:c9:79:bf:71:86:77:b7:d9:
+                    9d:5e:28:01:43:06:b5:6a:64:81:9f:9a:cc:2f:48:
+                    4c:35:75:57:f7:da:91:5a:1e:1a:dd:5c:c5:b5:ca:
+                    a0:ec:ef:91:71:a8:a3:2b:0c:fb:c1:05:60:09:65:
+                    39:8d:c8:db:c7:ca:54:85:06:bd:f5:1b:a1:25:95:
+                    07:bd:bb:5b:18:51:d8:89:a1:7c:5b:8b:16:b6:da:
+                    69:c2:2d:58:96:c3:4e:55:41:73:08:1b:eb:85:bd:
+                    4f:a3:1a:70:6c:ae:99:c7:16:c0:e5:d5:5f:13:72:
+                    68:d9:43:e8:69:22:24:e6:dc:a0:71:9e:ae:fa:8f:
+                    d1:a1:b7:2e:be:00:9c:07:6b:b3:8e:b0:1b:24:fa:
+                    06:6f:b2:76:ca:c3:b0:b4:6a:f8:b2:6b:af:0c:61:
+                    d3:46:62:72:13:c1:e9:87:ab:62:01:fd:c1:97:54:
+                    59:6d:fb:f9:a1:9a:92:64:b4:dd:15:6a:48:c5:b2:
+                    4f:8a:a0:4e:24:a4:03:f7:71:a7:c8:f3:52:7e:33:
+                    bc:58:04:b9:8f:e2:ee:62:8d:4a:90:64:b3:c0:87:
+                    38:74:fc:3e:f2:5e:a9:f0:18:67:26:86:ce:f6:34:
+                    eb:34:4b:80:bb:51:c4:04:e5:74:d5:7f:ac:3a:9e:
+                    3c:0b:16:f0:be:00:30:a8:4f:ff:7e:96:52:5c:ae:
+                    0a:4c:68:55:b9:b9:48:83:a3:9f:61:c3:d4:ed:5e:
+                    05:49:f6:eb:ae:29:fa:18:41:12:44:7e:57:1b:da:
+                    03:55:2e:de:87:23:c1:40:51:f1:3d:ef:7f:0d:f1:
+                    fa:5d:86:89:b5:42:4d:3f:c9:57
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                69:84:FA:C0:A3:30:19:B8:E1:0A:AF:1B:C3:4E:04:BD:26:86:89:FA
+            X509v3 Authority Key Identifier: 
+                F0:6A:F4:B5:52:86:50:0E:5B:34:24:8E:FF:30:8E:C6:DA:B4:16:9B
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.3
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        88:e1:dc:4e:d7:28:bc:03:2d:9d:6a:b2:43:0f:d3:ca:fb:c8:
+        b5:4c:6f:bc:22:2b:a8:d0:f0:ba:1c:f0:98:f7:88:29:7f:fe:
+        6c:22:97:b1:50:fb:6b:ee:6d:55:5c:7e:e3:08:32:a3:2b:5d:
+        c6:00:9b:f8:15:02:20:41:cf:4a:ba:b7:0f:cc:e3:98:5c:a8:
+        cf:13:cb:c6:88:bc:ac:6f:2e:a7:3e:22:45:5e:5f:47:f9:45:
+        07:49:da:8f:7f:6c:ac:87:2d:c4:d6:57:3c:56:d4:8d:f9:28:
+        1e:fe:89:02:e1:d8:48:b2:d0:c5:14:3b:75:18:37:47:28:55:
+        a3:ed:a9:f6:ce:ce:bb:f1:80:81:71:51:b1:97:0e:37:5b:9e:
+        09:03:fd:4d:ca:5c:d4:89:76:72:99:d8:2b:81:65:52:2c:29:
+        e8:2b:7a:c8:a3:42:35:8b:8c:2d:4b:e7:aa:26:3f:09:e1:7c:
+        67:e9:54:b4:cd:85:17:95:86:76:16:6d:2a:28:0e:95:63:d9:
+        68:38:51:e8:23:86:09:dc:2a:82:0f:7a:bf:83:53:62:40:49:
+        72:63:e4:3c:36:74:fc:ff:c0:02:6e:e5:96:5c:7e:d1:32:27:
+        f6:01:b1:ea:35:85:ca:53:16:5e:0b:a5:55:c4:af:6f:2b:69:
+        27:5d:71:1c:6e:3a:12:51:a6:ec:2e:17:b2:96:74:2c:c2:7c:
+        94:1f:b5:16:a3:09:94:c4:1e:4a:d5:3c:15:c5:25:72:41:77:
+        95:23:69:e5:07:68:12:ed:ab:37:39:46:cc:bb:52:9b:91:d6:
+        3b:8e:52:9b:63:18:52:7b:ab:c8:1b:39:52:b0:d6:b0:c8:b2:
+        ea:dc:31:16:4a:85:d0:28:e4:db:5b:42:e1:c0:bd:0a:8d:74:
+        7d:10:96:43:99:e7:f8:7b:6f:5e:bf:a4:62:cc:a7:69:9f:9f:
+        54:ba:18:d3:80:19:92:14:bb:9f:c1:66:61:14:af:07:94:fd:
+        b4:16:93:f5:16:ec
+-----BEGIN CERTIFICATE-----
+MIIGAzCCBGugAwIBAgIRANUpLlY/bCfR+IZH8seABiUwDQYJKoZIhvcNAQELBQAw
+TDEbMBkGA1UEAxMSRVYgQ29kZSBTaWduaW5nIENBMQswCQYDVQQLEwJDQTETMBEG
+A1UEChMKRXhhbXBsZSBDbzELMAkGA1UEBhMCVVMwHhcNMjYwNjE0MTc1NDQ3WhcN
+MjcwNjE0MTc1NDQ3WjCB6DETMBEGA1UEAxMKRXhhbXBsZSBDbzETMBEGA1UEChMK
+RXhhbXBsZSBDbzEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzETMBEGA1UECBMKQ2Fs
+aWZvcm5pYTELMAkGA1UEBhMCVVMxHjAcBgsrBgEEAYI3PAIBARMNTW91bnRhaW4g
+VmlldzEbMBkGCysGAQQBgjc8AgECEwpDYWxpZm9ybmlhMRMwEQYLKwYBBAGCNzwC
+AQMTAlVTMREwDwYDVQQFEwgxMjM0NTY3ODEdMBsGA1UEDxMUUHJpdmF0ZSBPcmdh
+bml6YXRpb24wggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQDN7rF5rCRR
+dt8CvU+CdLNd1NpNwi0GXtNcgVqtUXGSHnrHsZ2sCtSQ22w61CtW7HM9AD3ev8V0
+NaZzmrbNtAGb1S3Jeb9xhne32Z1eKAFDBrVqZIGfmswvSEw1dVf32pFaHhrdXMW1
+yqDs75FxqKMrDPvBBWAJZTmNyNvHylSFBr31G6EllQe9u1sYUdiJoXxbixa22mnC
+LViWw05VQXMIG+uFvU+jGnBsrpnHFsDl1V8TcmjZQ+hpIiTm3KBxnq76j9Ghty6+
+AJwHa7OOsBsk+gZvsnbKw7C0aviya68MYdNGYnITwemHq2IB/cGXVFlt+/mhmpJk
+tN0VakjFsk+KoE4kpAP3cafI81J+M7xYBLmP4u5ijUqQZLPAhzh0/D7yXqnwGGcm
+hs72NOs0S4C7UcQE5XTVf6w6njwLFvC+ADCoT/9+llJcrgpMaFW5uUiDo59hw9Tt
+XgVJ9uuuKfoYQRJEflcb2gNVLt6HI8FAUfE9738N8fpdhom1Qk0/yVcCAwEAAaOC
+AUEwggE9MA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAMBgNV
+HRMBAf8EAjAAMB0GA1UdDgQWBBRphPrAozAZuOEKrxvDTgS9JoaJ+jAfBgNVHSME
+GDAWgBTwavS1UoZQDls0JI7/MI7G2rQWmzBbBggrBgEFBQcBAQRPME0wIwYIKwYB
+BQUHMAGGF2h0dHA6Ly9vY3NwLmV4YW1wbGUuY29tMCYGCCsGAQUFBzAChhpodHRw
+Oi8vZXhhbXBsZS5jb20vY2ExLmNydDASBgNVHSAECzAJMAcGBWeBDAEDMFcGA1Ud
+HwRQME4wJaAjoCGGH2h0dHA6Ly9jcmwxLmV4YW1wbGUuY29tL2NhMS5jcmwwJaAj
+oCGGH2h0dHA6Ly9jcmwyLmV4YW1wbGUuY29tL2NhMS5jcmwwDQYJKoZIhvcNAQEL
+BQADggGBAIjh3E7XKLwDLZ1qskMP08r7yLVMb7wiK6jQ8Loc8Jj3iCl//mwil7FQ
++2vubVVcfuMIMqMrXcYAm/gVAiBBz0q6tw/M45hcqM8Ty8aIvKxvLqc+IkVeX0f5
+RQdJ2o9/bKyHLcTWVzxW1I35KB7+iQLh2Eiy0MUUO3UYN0coVaPtqfbOzrvxgIFx
+UbGXDjdbngkD/U3KXNSJdnKZ2CuBZVIsKegresijQjWLjC1L56omPwnhfGfpVLTN
+hReVhnYWbSooDpVj2Wg4UegjhgncKoIPer+DU2JASXJj5Dw2dPz/wAJu5ZZcftEy
+J/YBseo1hcpTFl4LpVXEr28raSddcRxuOhJRpuwuF7KWdCzCfJQftRajCZTEHkrV
+PBXFJXJBd5UjaeUHaBLtqzc5Rsy7UpuR1juOUptjGFJ7q8gbOVKw1rDIsurcMRZK
+hdAo5NtbQuHAvQqNdH0QlkOZ5/h7b16/pGLMp2mfn1S6GNOAGZIUu5/BZmEUrweU
+/bQWk/UW7A==
+-----END CERTIFICATE-----

--- a/v3/testdata/code_signing/cs_ov_subject_org_missing.pem
+++ b/v3/testdata/code_signing/cs_ov_subject_org_missing.pem
@@ -1,0 +1,141 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            af:94:0e:ba:e0:83:09:74:2c:34:5b:00:bc:30:54:e7
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=OV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 14 17:58:07 2026 GMT
+            Not After : Jun 14 17:58:07 2027 GMT
+        Subject: CN=Example Co, L=Mountain View, ST=California, C=US, jurisdictionC=US, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:c0:f1:4f:66:20:00:db:26:d3:a9:e2:53:f4:09:
+                    40:05:6b:b2:92:f8:6c:57:0c:70:47:68:1d:0d:cc:
+                    a5:67:b0:63:bc:c3:91:eb:07:cb:0c:de:f4:7d:64:
+                    f5:07:b0:a4:ee:d5:7b:ee:3d:b1:57:56:15:0d:d5:
+                    2c:81:db:bc:73:10:2c:b4:43:3b:3c:29:5b:fc:39:
+                    38:65:86:23:bb:db:f4:04:87:2e:b5:4d:d8:96:12:
+                    45:c8:fd:2d:69:ca:af:ae:27:54:f5:33:08:63:ab:
+                    0e:32:6c:6c:5d:7f:75:06:5a:5b:0c:0e:1b:bd:0e:
+                    54:cd:ca:eb:2f:c8:fc:7e:8c:53:99:a7:5a:d3:25:
+                    2a:fb:d3:aa:f9:1d:88:c3:76:f5:77:18:64:95:f0:
+                    ac:d8:6a:fc:a0:5a:0b:dd:04:a9:dd:1e:a1:7d:37:
+                    1e:f3:27:b8:3c:15:c0:0e:c5:ed:69:a8:58:33:18:
+                    b8:b5:a2:40:19:27:53:cb:40:74:82:bd:24:4c:60:
+                    b5:bb:17:e6:8b:ff:5b:ae:c4:b9:8c:9a:0a:5a:98:
+                    4a:d4:f8:13:44:d8:a2:e4:ed:e4:6a:46:c5:07:17:
+                    f6:20:46:89:af:a6:8a:a5:00:33:43:41:a9:4a:57:
+                    b0:fe:c0:87:ac:37:b7:33:dd:10:b3:bf:39:12:5a:
+                    16:97:56:18:17:fe:6a:b8:8b:d4:27:da:8a:73:41:
+                    f9:aa:9f:28:65:77:9f:ce:2e:36:0b:37:a5:56:cd:
+                    b5:78:7a:86:7f:87:45:68:5e:0c:2c:0c:dc:1c:1d:
+                    d2:6e:8a:2b:88:87:68:fa:a4:42:22:ad:fe:a2:19:
+                    a9:4b:4f:02:ac:01:f9:ed:d2:b9:90:c5:c3:3b:f6:
+                    16:07:8f:54:dd:82:ec:fa:4e:48:1b:b3:cb:5e:4c:
+                    da:64:34:52:9b:7a:33:af:44:99:30:ad:db:a9:66:
+                    75:61:84:31:56:7d:9f:e8:04:4d:fc:63:a7:21:78:
+                    b7:9f:6c:6e:b0:6c:fc:f0:f7:c7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                0B:C7:EA:4F:3D:5C:43:D2:CE:B2:5F:2B:45:3F:94:FC:B6:90:DA:34
+            X509v3 Authority Key Identifier: 
+                96:A9:1A:01:BF:7D:99:2C:E6:55:20:A9:D1:20:F5:62:A1:13:3C:BB
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.4.1
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : C4:69:28:BC:87:DE:23:B9:A8:BD:23:5A:A1:FE:67:CC:
+                                B1:54:2C:83:89:AD:3F:02:BF:4A:B5:CF:F5:06:E9:8F
+                    Timestamp : Jan 15 06:56:07.890 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:31
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 73:AA:A5:07:1D:9F:86:15:50:D5:14:69:CB:D8:9E:0A:
+                                6E:53:71:48:6F:D9:4C:96:75:28:1D:1C:EF:BD:51:17
+                    Timestamp : Jan 15 06:56:07.891 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:32
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        48:da:b8:72:cf:da:6d:5e:75:dd:f0:d6:69:5f:db:96:5a:99:
+        92:9b:2f:24:c9:ea:ed:99:25:4c:80:ca:4b:4a:8e:28:5c:74:
+        16:76:6f:96:ac:7a:30:13:78:4a:47:c2:49:c5:cd:f1:9a:14:
+        32:51:da:31:15:d9:d2:a3:ef:95:1d:c3:de:6a:27:42:de:39:
+        da:9f:cb:47:24:59:22:3b:d4:38:28:5d:0d:56:e2:b9:37:8c:
+        49:7e:3d:46:03:f0:fc:ac:4c:a7:3a:29:11:e0:10:a8:95:a0:
+        9b:9d:cf:bd:8c:2d:3d:e7:a6:60:60:16:fd:42:e6:b8:37:00:
+        1b:06:17:a8:96:28:5f:e9:3c:49:cc:a5:ee:4f:07:af:d4:f1:
+        00:24:85:10:9d:b4:4d:8a:5d:05:b0:97:60:be:c4:17:6f:51:
+        fd:5b:97:24:e0:0c:f3:98:68:45:e3:ed:a6:a0:86:2f:3f:46:
+        bd:dc:9e:f9:03:6f:09:c5:33:7b:92:e9:df:61:36:93:47:5f:
+        3c:25:de:f0:b1:bf:52:e7:de:b9:20:d1:a7:a5:50:ca:1f:65:
+        41:a9:1f:b1:fa:a8:d3:08:74:1c:66:17:40:1e:eb:e7:c8:32:
+        35:31:db:3f:f7:f5:08:5b:0e:61:34:e5:62:ff:b9:11:ad:33:
+        2b:30:4f:0e:56:a2:60:11:16:a7:86:d4:33:ad:de:3c:37:58:
+        ee:3b:49:fe:12:78:b8:97:85:9b:14:dc:f3:af:2a:b7:59:a8:
+        5f:96:c2:84:96:e1:90:c0:fc:e1:e6:37:83:c5:1f:1d:8c:dc:
+        f9:2d:73:0c:be:fb:7b:7e:86:73:f6:42:fb:ad:3e:15:6e:c3:
+        54:46:16:1d:6b:5c:45:47:bf:2f:b7:c9:9a:24:db:ae:11:54:
+        90:c5:d2:bb:1d:fa:a5:ef:27:53:a5:ef:40:dd:f7:e7:1f:a6:
+        b6:e1:be:0d:0d:09:b8:d4:a6:1d:f3:68:e3:ad:6d:7c:6c:0d:
+        5f:d3:20:74:cf:cf
+-----BEGIN CERTIFICATE-----
+MIIGKjCCBJKgAwIBAgIRAK+UDrrggwl0LDRbALwwVOcwDQYJKoZIhvcNAQELBQAw
+TDEbMBkGA1UEAxMST1YgQ29kZSBTaWduaW5nIENBMQswCQYDVQQLEwJDQTETMBEG
+A1UEChMKRXhhbXBsZSBDbzELMAkGA1UEBhMCVVMwHhcNMjYwNjE0MTc1ODA3WhcN
+MjcwNjE0MTc1ODA3WjCBgzETMBEGA1UEAxMKRXhhbXBsZSBDbzEWMBQGA1UEBxMN
+TW91bnRhaW4gVmlldzETMBEGA1UECBMKQ2FsaWZvcm5pYTELMAkGA1UEBhMCVVMx
+EzARBgsrBgEEAYI3PAIBAxMCVVMxHTAbBgNVBA8TFFByaXZhdGUgT3JnYW5pemF0
+aW9uMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAwPFPZiAA2ybTqeJT
+9AlABWuykvhsVwxwR2gdDcylZ7BjvMOR6wfLDN70fWT1B7Ck7tV77j2xV1YVDdUs
+gdu8cxAstEM7PClb/Dk4ZYYju9v0BIcutU3YlhJFyP0tacqvridU9TMIY6sOMmxs
+XX91BlpbDA4bvQ5UzcrrL8j8foxTmada0yUq+9Oq+R2Iw3b1dxhklfCs2Gr8oFoL
+3QSp3R6hfTce8ye4PBXADsXtaahYMxi4taJAGSdTy0B0gr0kTGC1uxfmi/9brsS5
+jJoKWphK1PgTRNii5O3kakbFBxf2IEaJr6aKpQAzQ0GpSlew/sCHrDe3M90Qs785
+EloWl1YYF/5quIvUJ9qKc0H5qp8oZXefzi42CzelVs21eHqGf4dFaF4MLAzcHB3S
+booriIdo+qRCIq3+ohmpS08CrAH57dK5kMXDO/YWB49U3YLs+k5IG7PLXkzaZDRS
+m3ozr0SZMK3bqWZ1YYQxVn2f6ARN/GOnIXi3n2xusGz88PfHAgMBAAGjggHNMIIB
+yTAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwMwDAYDVR0TAQH/
+BAIwADAdBgNVHQ4EFgQUC8fqTz1cQ9LOsl8rRT+U/LaQ2jQwHwYDVR0jBBgwFoAU
+lqkaAb99mSzmVSCp0SD1YqETPLswWwYIKwYBBQUHAQEETzBNMCMGCCsGAQUFBzAB
+hhdodHRwOi8vb2NzcC5leGFtcGxlLmNvbTAmBggrBgEFBQcwAoYaaHR0cDovL2V4
+YW1wbGUuY29tL2NhMS5jcnQwEwYDVR0gBAwwCjAIBgZngQwBBAEwVwYDVR0fBFAw
+TjAloCOgIYYfaHR0cDovL2NybDEuZXhhbXBsZS5jb20vY2ExLmNybDAloCOgIYYf
+aHR0cDovL2NybDIuZXhhbXBsZS5jb20vY2ExLmNybDCBiAYKKwYBBAHWeQIEAgR6
+BHgAdgA5AMRpKLyH3iO5qL0jWqH+Z8yxVCyDia0/Ar9Ktc/1BumPAAAAAEmWAtIA
+AAQDAApzaWduYXR1cmUxADkAc6qlBx2fhhVQ1RRpy9ieCm5TcUhv2UyWdSgdHO+9
+URcAAAAASZYC0wAABAMACnNpZ25hdHVyZTIwDQYJKoZIhvcNAQELBQADggGBAEja
+uHLP2m1edd3w1mlf25ZamZKbLyTJ6u2ZJUyAyktKjihcdBZ2b5asejATeEpHwknF
+zfGaFDJR2jEV2dKj75Udw95qJ0LeOdqfy0ckWSI71DgoXQ1W4rk3jEl+PUYD8Pys
+TKc6KRHgEKiVoJudz72MLT3npmBgFv1C5rg3ABsGF6iWKF/pPEnMpe5PB6/U8QAk
+hRCdtE2KXQWwl2C+xBdvUf1blyTgDPOYaEXj7aaghi8/Rr3cnvkDbwnFM3uS6d9h
+NpNHXzwl3vCxv1Ln3rkg0aelUMofZUGpH7H6qNMIdBxmF0Ae6+fIMjUx2z/39Qhb
+DmE05WL/uRGtMyswTw5WomARFqeG1DOt3jw3WO47Sf4SeLiXhZsU3POvKrdZqF+W
+woSW4ZDA/OHmN4PFHx2M3Pktcwy++3t+hnP2QvutPhVuw1RGFh1rXEVHvy+3yZok
+264RVJDF0rsd+qXvJ1Ol70Dd9+cfprbhvg0NCbjUph3zaOOtbXxsDV/TIHTPzw==
+-----END CERTIFICATE-----

--- a/v3/testdata/code_signing/cs_ov_subject_org_present.pem
+++ b/v3/testdata/code_signing/cs_ov_subject_org_present.pem
@@ -1,0 +1,142 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            38:4b:1b:dd:aa:ab:59:6f:27:4b:08:f0:f0:f5:fd:93
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=OV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 14 17:50:42 2026 GMT
+            Not After : Jun 14 17:50:42 2027 GMT
+        Subject: CN=Example Co, O=Example Co, L=Mountain View, ST=California, C=US, jurisdictionC=US, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:e5:f4:42:d5:2a:15:aa:e2:61:6e:f8:75:dd:3a:
+                    a6:a1:9a:5e:89:96:78:43:a4:ee:8f:63:d7:a2:60:
+                    93:a2:fb:43:78:93:72:15:a5:89:84:52:fb:fe:c0:
+                    75:f0:d4:76:47:e0:f4:f4:0d:48:0f:a9:30:8b:38:
+                    9b:ff:7c:95:f5:40:b4:78:62:6e:d4:92:e7:a8:4d:
+                    03:53:39:20:ec:e8:50:8f:53:f6:89:6e:b4:7a:f9:
+                    56:7e:e9:d8:a7:9d:4f:53:60:ce:14:ef:60:3a:34:
+                    9f:c1:97:f5:11:1f:99:2c:35:96:14:42:6f:93:51:
+                    7b:a8:d4:e0:99:2c:82:1d:f7:76:76:fb:4f:3c:35:
+                    df:4f:f1:18:b8:bd:ad:45:7b:7e:fb:91:92:a4:66:
+                    77:50:db:0c:cf:49:b0:9c:d9:5d:86:0d:68:b6:5c:
+                    a2:11:56:7b:90:e2:ee:5c:37:bc:a3:3e:da:27:65:
+                    49:f4:c8:34:cc:69:a7:ec:57:cd:c1:fe:21:6a:6c:
+                    80:eb:06:ea:a6:d0:e9:47:8e:21:e3:bd:8f:89:c6:
+                    e0:51:8a:bb:e8:74:33:60:fc:c4:3a:0f:87:e1:be:
+                    c2:7a:18:63:15:6a:ad:db:ad:1f:55:99:fe:73:fc:
+                    dc:aa:ee:9f:33:ca:a8:d2:6a:26:fc:cb:7f:eb:5b:
+                    3a:c1:56:f3:d6:51:55:1f:7c:a4:0a:c0:26:64:fe:
+                    28:95:59:74:f4:b1:c3:ba:59:76:ca:e9:b2:f5:a5:
+                    2a:db:48:00:d2:68:04:0e:a1:3f:b1:09:2d:4d:df:
+                    1d:01:64:81:af:de:86:6a:11:79:c8:8e:aa:e4:91:
+                    e4:75:8b:a2:76:bb:98:ae:ce:f6:c9:50:06:b1:79:
+                    96:bd:07:8d:b4:61:69:5b:31:d0:18:d1:4e:13:4c:
+                    f1:1b:89:e8:cc:72:a5:1e:b4:f3:89:12:3f:1e:38:
+                    6a:31:3c:3b:d1:5e:08:14:b6:2a:df:84:5e:72:d9:
+                    35:d8:64:d9:35:a5:3c:82:47:cd
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                1D:4C:A6:9C:02:9D:3C:D2:76:AC:41:A2:CA:86:79:A3:CE:D5:56:38
+            X509v3 Authority Key Identifier: 
+                5C:05:86:4B:DC:2B:D1:8D:37:D4:CC:F2:01:CA:ED:E7:62:01:8A:DE
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.4.1
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : C4:69:28:BC:87:DE:23:B9:A8:BD:23:5A:A1:FE:67:CC:
+                                B1:54:2C:83:89:AD:3F:02:BF:4A:B5:CF:F5:06:E9:8F
+                    Timestamp : Jan 15 06:56:07.890 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:31
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 73:AA:A5:07:1D:9F:86:15:50:D5:14:69:CB:D8:9E:0A:
+                                6E:53:71:48:6F:D9:4C:96:75:28:1D:1C:EF:BD:51:17
+                    Timestamp : Jan 15 06:56:07.891 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:32
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        70:1a:ab:2a:46:b8:90:a6:c2:58:00:d6:e8:80:2f:a9:36:2b:
+        2d:ce:6f:6a:fa:05:d0:ef:c8:97:44:e2:0e:63:ef:a2:e6:72:
+        5f:18:68:b2:ee:fe:50:e4:04:6d:ef:82:db:1e:f0:2f:1d:30:
+        de:32:06:f5:b1:af:36:3c:51:e6:97:47:9f:9e:9e:ac:22:59:
+        3e:eb:27:1d:86:2b:a9:dc:27:eb:21:7a:0a:27:75:b5:3a:9f:
+        2b:36:eb:37:0c:e9:82:75:99:db:1f:d8:2e:29:71:90:17:bc:
+        65:38:e1:22:35:a4:df:4a:0a:ff:8c:a5:a7:0e:7b:89:0f:06:
+        a3:77:10:ef:e5:ff:f5:4e:19:96:6f:68:57:42:21:cb:6f:30:
+        8c:8f:26:c1:c2:ec:03:31:80:90:af:ff:24:00:c0:1c:b4:97:
+        ea:1c:40:f1:11:8d:5a:bf:75:ed:64:a5:ff:90:97:df:df:76:
+        8d:11:2b:38:08:ce:ba:1d:09:42:ec:4a:01:ba:a1:0b:a7:db:
+        31:94:b9:48:28:9a:fc:81:3e:c0:ed:7b:37:26:1c:46:91:66:
+        3c:18:8f:1e:0a:a8:34:6c:bd:71:cc:ff:a3:ac:5e:93:48:8c:
+        2c:fe:57:53:b5:41:1b:cd:07:05:ec:8b:fc:2c:b2:ab:5a:c6:
+        f6:ea:b6:09:6a:9a:4c:6c:8a:43:7f:da:6b:bb:c2:9a:dc:f0:
+        3e:38:3d:5c:16:bc:a3:ab:31:a6:8e:8d:39:2c:05:35:44:49:
+        cb:c4:a3:04:d4:d5:f6:7e:8d:5f:89:f3:93:8c:9d:7f:c9:c7:
+        8d:72:b9:e3:1c:23:13:d9:44:49:4a:6f:fd:ad:68:48:80:ea:
+        90:de:af:c7:fa:f2:18:48:36:f2:f2:e9:f0:1c:f9:64:11:5f:
+        9e:0a:a6:22:2a:8b:dc:c1:db:6f:f0:d2:9e:00:a0:ce:e7:03:
+        dd:3b:40:41:84:d0:a9:81:57:35:7c:71:aa:36:75:d0:14:59:
+        b3:32:c3:0c:4f:aa
+-----BEGIN CERTIFICATE-----
+MIIGPjCCBKagAwIBAgIQOEsb3aqrWW8nSwjw8PX9kzANBgkqhkiG9w0BAQsFADBM
+MRswGQYDVQQDExJPViBDb2RlIFNpZ25pbmcgQ0ExCzAJBgNVBAsTAkNBMRMwEQYD
+VQQKEwpFeGFtcGxlIENvMQswCQYDVQQGEwJVUzAeFw0yNjA2MTQxNzUwNDJaFw0y
+NzA2MTQxNzUwNDJaMIGYMRMwEQYDVQQDEwpFeGFtcGxlIENvMRMwEQYDVQQKEwpF
+eGFtcGxlIENvMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRMwEQYDVQQIEwpDYWxp
+Zm9ybmlhMQswCQYDVQQGEwJVUzETMBEGCysGAQQBgjc8AgEDEwJVUzEdMBsGA1UE
+DxMUUHJpdmF0ZSBPcmdhbml6YXRpb24wggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAw
+ggGKAoIBgQDl9ELVKhWq4mFu+HXdOqahml6JlnhDpO6PY9eiYJOi+0N4k3IVpYmE
+Uvv+wHXw1HZH4PT0DUgPqTCLOJv/fJX1QLR4Ym7UkueoTQNTOSDs6FCPU/aJbrR6
++VZ+6dinnU9TYM4U72A6NJ/Bl/URH5ksNZYUQm+TUXuo1OCZLIId93Z2+088Nd9P
+8Ri4va1Fe377kZKkZndQ2wzPSbCc2V2GDWi2XKIRVnuQ4u5cN7yjPtonZUn0yDTM
+aafsV83B/iFqbIDrBuqm0OlHjiHjvY+JxuBRirvodDNg/MQ6D4fhvsJ6GGMVaq3b
+rR9Vmf5z/Nyq7p8zyqjSaib8y3/rWzrBVvPWUVUffKQKwCZk/iiVWXT0scO6WXbK
+6bL1pSrbSADSaAQOoT+xCS1N3x0BZIGv3oZqEXnIjqrkkeR1i6J2u5iuzvbJUAax
+eZa9B420YWlbMdAY0U4TTPEbiejMcqUetPOJEj8eOGoxPDvRXggUtirfhF5y2TXY
+ZNk1pTyCR80CAwEAAaOCAc0wggHJMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAK
+BggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBQdTKacAp080nasQaLK
+hnmjztVWODAfBgNVHSMEGDAWgBRcBYZL3CvRjTfUzPIByu3nYgGK3jBbBggrBgEF
+BQcBAQRPME0wIwYIKwYBBQUHMAGGF2h0dHA6Ly9vY3NwLmV4YW1wbGUuY29tMCYG
+CCsGAQUFBzAChhpodHRwOi8vZXhhbXBsZS5jb20vY2ExLmNydDATBgNVHSAEDDAK
+MAgGBmeBDAEEATBXBgNVHR8EUDBOMCWgI6Ahhh9odHRwOi8vY3JsMS5leGFtcGxl
+LmNvbS9jYTEuY3JsMCWgI6Ahhh9odHRwOi8vY3JsMi5leGFtcGxlLmNvbS9jYTEu
+Y3JsMIGIBgorBgEEAdZ5AgQCBHoEeAB2ADkAxGkovIfeI7movSNaof5nzLFULIOJ
+rT8Cv0q1z/UG6Y8AAAAASZYC0gAABAMACnNpZ25hdHVyZTEAOQBzqqUHHZ+GFVDV
+FGnL2J4KblNxSG/ZTJZ1KB0c771RFwAAAABJlgLTAAAEAwAKc2lnbmF0dXJlMjAN
+BgkqhkiG9w0BAQsFAAOCAYEAcBqrKka4kKbCWADW6IAvqTYrLc5vavoF0O/Il0Ti
+DmPvouZyXxhosu7+UOQEbe+C2x7wLx0w3jIG9bGvNjxR5pdHn56erCJZPusnHYYr
+qdwn6yF6Cid1tTqfKzbrNwzpgnWZ2x/YLilxkBe8ZTjhIjWk30oK/4ylpw57iQ8G
+o3cQ7+X/9U4Zlm9oV0Ihy28wjI8mwcLsAzGAkK//JADAHLSX6hxA8RGNWr917WSl
+/5CX3992jRErOAjOuh0JQuxKAbqhC6fbMZS5SCia/IE+wO17NyYcRpFmPBiPHgqo
+NGy9ccz/o6xek0iMLP5XU7VBG80HBeyL/Cyyq1rG9uq2CWqaTGyKQ3/aa7vCmtzw
+Pjg9XBa8o6sxpo6NOSwFNURJy8SjBNTV9n6NX4nzk4ydf8nHjXK54xwjE9lESUpv
+/a1oSIDqkN6vx/ryGEg28vLp8Bz5ZBFfngqmIiqL3MHbb/DSngCgzucD3TtAQYTQ
+qYFXNXxxqjZ10BRZszLDDE+q
+-----END CERTIFICATE-----


### PR DESCRIPTION
Added a lint to require subject organization presence for EV and Non-EV code signing certificates.

### Reference with sections:
https://cabforum.org/working-groups/code-signing/requirements/

Section 7.1.4.2.3
> 7.1.4.2.3 Subject distinguished name field - Non-EV Code Signing Certificates
> 
>     Certificate Field: subject:organizationName (OID 2.5.4.10)
>     Required/Optional: Required
>     Contents: The subject:organizationName field MUST contain either the Subject’s name or DBA as verified under BR Section 3.2. The CA MAY include information in this field that differs slightly from the verified name, such as common variations or abbreviations, provided that the CA documents the difference and any abbreviations used are locally accepted abbreviations; e.g., if the official record shows “Company Name Incorporated”, the CA MAY use “Company Name Inc.” or “Company Name”. Because subject name attributes for individuals (e.g. subject:givenName (2.5.4.42) and subject:surname (2.5.4.4)) are not broadly supported by application software, the CA MAY use the subject:organizationName field to convey a natural person Subject’s name or DBA. The CA MUST have a documented process for verifying that the information included in the subject:organizationName field is not misleading to a Relying Party.

Section 7.1.4.2.4

> 7.1.4.2.4 Subject distinguished name fields - EV Code Signing Certificates
> 
>     Certificate Field: subject:organizationName (OID 2.5.4.10)
>     Required/Optional: Required
>     Contents: This field MUST contain the Subject’s full legal organization name as listed in the official records of the Incorporating or Registration Agency in the Subject’s Jurisdiction of Incorporation or Registration or as otherwise verified by the CA as provided herein. A CA MAY abbreviate the organization prefixes or suffixes in the organization name, e.g., if the official record shows “Company Name Incorporated” the CA MAY include “Company Name, Inc.”
> 
> When abbreviating a Subject’s full legal name as allowed by this subsection, the CA MUST use abbreviations that are not misleading in the Jurisdiction of Incorporation or Registration.
> 
> In addition, an assumed name or DBA name used by the Subject MAY be included at the beginning of this field, provided that it is followed by the full legal organization name in parenthesis.
> 
> If the combination of names or the organization name by itself exceeds 64 characters, the CA MAY abbreviate parts of the organization name, and/or omit non-material words in the organization name in such a way that the text in this field does not exceed the 64-character limit; provided that the CA checks this field in accordance with the High Risk Certificate Request requirements of [Section 4.2.1](https://cabforum.org/working-groups/code-signing/requirements/#421-performing-identification-and-authentication-functions) and a Relying Party will not be misled into thinking that they are dealing with a different organization. In cases where this is not possible, the CA MUST NOT issue the EV Code Signing Certificate.