### PR TITLE
Add lint and unit tests for ev subject org length requirement

### DIFF
--- a/v3/lints/cabf_cs_br/lint_cs_ev_subject_org_max_length.go
+++ b/v3/lints/cabf_cs_br/lint_cs_ev_subject_org_max_length.go
@@ -1,0 +1,69 @@
+package cabf_cs_br
+
+/*
+ * ZLint Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"unicode/utf8"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+type csEVSubjectOrgMaxLength struct{}
+
+/************************************************
+CSBRs: 7.1.4.2.4
+Certificate Field: subject:organizationName (OID 2.5.4.10)
+
+If the combination of names or the organization name by itself exceeds 64 characters, the CA
+MAY abbreviate parts of the organization name, and/or omit non-material words in the
+organization name in such a way that the text in this field does not exceed the 64-character
+limit; provided that the CA checks this field in accordance with the High Risk Certificate
+Request requirements of Section 4.2.1 and a Relying Party will not be misled into thinking
+that they are dealing with a different organization. In cases where this is not possible, the
+CA MUST NOT issue the EV Code Signing Certificate.
+************************************************/
+
+func init() {
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cs_ev_subject_org_max_length",
+			Description:   "EV Code Signing certificate organizationName MUST NOT exceed 64 characters",
+			Citation:      "CSBRs: 7.1.4.2.4",
+			Source:        lint.CABFCSBaselineRequirements,
+			EffectiveDate: util.CABF_CS_BRs_1_2_Date,
+		},
+		Lint: NewCsEVSubjectOrgMaxLength,
+	})
+}
+
+func NewCsEVSubjectOrgMaxLength() lint.LintInterface {
+	return &csEVSubjectOrgMaxLength{}
+}
+
+func (l *csEVSubjectOrgMaxLength) CheckApplies(cert *x509.Certificate) bool {
+	return util.IsSubscriberCert(cert) && util.IsEVCodeSigning(cert.PolicyIdentifiers) && len(cert.Subject.Organization) > 0
+}
+
+func (l *csEVSubjectOrgMaxLength) Execute(cert *x509.Certificate) *lint.LintResult {
+	for _, org := range cert.Subject.Organization {
+		if utf8.RuneCountInString(org) > 64 {
+			return &lint.LintResult{Status: lint.Error, Details: "EV Code Signing certificate organizationName exceeds 64 characters."}
+		}
+	}
+
+	return &lint.LintResult{Status: lint.Pass}
+}

--- a/v3/lints/cabf_cs_br/lint_cs_ev_subject_org_max_length_test.go
+++ b/v3/lints/cabf_cs_br/lint_cs_ev_subject_org_max_length_test.go
@@ -1,0 +1,45 @@
+package cabf_cs_br
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestCsEVSubjectOrgMaxLength(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		InputFilename  string
+		ExpectedResult lint.LintStatus
+	}{
+		{
+			Name:           "pass - EV CS certificate with organizationName within 64 characters",
+			InputFilename:  "code_signing/cs_ev_subject_org_present.pem",
+			ExpectedResult: lint.Pass,
+		},
+		{
+			Name:           "pass - EV CS certificate with organizationName exactly 64 characters",
+			InputFilename:  "code_signing/cs_ev_subject_org_64_chars.pem",
+			ExpectedResult: lint.Pass,
+		},
+		{
+			Name:           "error - EV CS certificate with organizationName exceeding 64 characters",
+			InputFilename:  "code_signing/cs_ev_subject_org_65_chars.pem",
+			ExpectedResult: lint.Error,
+		},
+		{
+			Name:           "NA - EV CS certificate missing organizationName",
+			InputFilename:  "code_signing/cs_ev_subject_org_missing.pem",
+			ExpectedResult: lint.NA,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := test.TestLint("e_cs_ev_subject_org_max_length", tc.InputFilename)
+			if result.Status != tc.ExpectedResult {
+				t.Errorf("expected result %v was %v - details: %v", tc.ExpectedResult, result.Status, result.Details)
+			}
+		})
+	}
+}

--- a/v3/testdata/code_signing/cs_ev_subject_org_64_chars.pem
+++ b/v3/testdata/code_signing/cs_ev_subject_org_64_chars.pem
@@ -1,0 +1,125 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            1d:48:7d:02:ff:cf:56:42:8b:98:9e:3b:a4:33:ce:2f
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=EV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 15 00:20:20 2026 GMT
+            Not After : Jun 15 00:20:20 2027 GMT
+        Subject: CN=Example Co, O=Example Co123456789012345678901234567890123456789012341234, L=Mountain View, ST=California, C=US, jurisdictionL=Mountain View, jurisdictionST=California, jurisdictionC=US, serialNumber=12345678, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:b6:56:65:cd:9c:33:73:3b:ef:18:fc:86:b9:43:
+                    6d:b1:0f:2b:43:02:5c:65:c1:73:a4:1d:5f:5d:5c:
+                    94:b8:b3:14:0a:93:bc:59:00:f7:5f:0c:bb:dc:03:
+                    d7:b1:c9:ff:2c:94:61:72:8d:07:df:da:f4:9f:25:
+                    6b:9e:d4:cb:05:f4:af:6b:f5:3f:3d:95:7c:af:93:
+                    3b:54:a3:71:c0:1e:34:09:e4:60:03:2e:87:3e:21:
+                    9b:a5:8f:e5:be:ab:c1:38:99:81:01:15:2c:9a:4e:
+                    b4:99:f5:15:f8:d6:5f:7f:19:d5:33:d3:dd:b6:f9:
+                    7c:34:18:96:dd:c2:44:3c:b6:f3:5f:e2:96:af:7e:
+                    d0:40:35:78:f0:f9:fc:46:97:c1:d0:1a:8b:c9:3b:
+                    91:d3:04:73:b6:c5:f3:52:4e:eb:bf:79:20:ea:e7:
+                    b7:82:64:15:26:be:0e:a5:94:8f:a9:23:93:5c:cf:
+                    9b:f0:7a:de:85:0a:b1:3d:b9:1e:31:03:0f:cb:fd:
+                    4d:87:e5:0c:70:a5:13:02:a0:9c:e8:d6:2d:fe:4b:
+                    52:41:4e:11:76:ed:b1:f6:34:44:2f:d9:fc:87:db:
+                    43:93:e4:a9:60:0a:2e:7c:9b:37:35:33:a1:55:4f:
+                    79:52:ad:94:1a:56:37:7f:b7:55:9a:74:1f:ea:20:
+                    3b:d2:99:8c:ad:3a:9a:37:27:86:25:d5:f5:3c:6a:
+                    81:77:17:44:2f:95:57:a6:f8:28:9b:24:4a:f6:56:
+                    1b:70:bc:26:c5:41:1e:65:47:f9:df:ad:dc:57:99:
+                    9c:92:db:35:ef:70:c6:15:3c:cd:33:6f:9e:21:e3:
+                    2b:a9:61:2b:b5:3b:55:5c:90:55:e7:d0:09:a4:9e:
+                    7a:19:ad:f2:15:d8:c8:02:c1:52:19:c6:da:85:e6:
+                    4d:e0:ab:a1:78:35:99:25:5e:90:cd:02:d9:50:6a:
+                    74:01:3d:12:44:fa:14:b1:f0:a8:96:83:eb:c9:26:
+                    e2:13:1f:f7:4f:d4:2c:ea:e7:f3
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                14:D7:96:D6:BA:87:26:9E:29:C7:AA:30:E9:82:AC:24:67:7F:96:6E
+            X509v3 Authority Key Identifier: 
+                06:83:25:D3:6B:AE:4B:5D:2F:B7:29:99:94:B3:68:CF:A0:E1:33:7B
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.3
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        ae:ed:b2:87:c6:f0:96:f2:0a:0a:b5:b0:c2:30:b0:e0:dd:27:
+        00:66:3a:5e:f0:29:50:29:ea:da:49:4c:fe:16:24:03:44:c4:
+        bb:38:5c:d7:b9:58:7c:1a:a4:29:8d:4e:3f:94:bf:d3:59:83:
+        ce:d5:b5:f1:b2:e8:b6:14:8a:9b:06:69:46:59:be:6c:fb:29:
+        b7:69:65:8d:0a:34:03:71:ea:cb:89:74:09:df:f9:61:f4:22:
+        ec:20:d7:a5:67:cc:4a:92:4b:f8:8b:4c:c7:0f:ca:72:5b:06:
+        2a:c6:4c:1f:9e:5d:f8:c0:fe:63:f6:c5:d7:e8:54:bd:99:f8:
+        03:aa:3d:ed:cb:0a:7b:35:a9:ae:5b:25:50:d6:e2:5f:f8:61:
+        35:86:ec:a3:d1:66:e5:0f:3f:44:94:d9:b6:4c:07:42:29:66:
+        c6:fe:77:db:8d:bc:7e:4d:d9:15:07:7f:ad:f8:d6:fa:e0:53:
+        29:8e:13:7e:a7:2f:e6:03:8e:70:c9:32:87:06:db:01:b5:2b:
+        2e:23:b0:64:c1:e2:84:35:46:eb:f8:58:7e:9b:13:5a:0a:0b:
+        87:a1:6d:e7:93:58:13:25:3d:c7:5c:06:ac:28:74:f3:ac:53:
+        f0:07:64:c5:60:1e:24:9a:63:6f:31:7a:de:61:f6:8c:e7:6e:
+        73:f6:af:4c:05:06:87:8f:d4:16:6a:46:c4:1c:8e:d8:c0:3b:
+        e1:c7:30:8f:e4:4f:e1:2d:84:e6:5c:56:09:05:31:44:7e:7d:
+        e2:45:7e:d8:a7:97:bd:1c:cd:0f:b9:9c:c7:a9:0e:20:b8:61:
+        99:a2:d6:02:cb:51:1b:8a:5f:81:52:6d:75:a5:2f:72:73:c9:
+        95:a8:20:70:b3:82:19:24:12:0b:3c:3b:4d:5f:e9:32:1d:9b:
+        20:3e:8b:d9:81:95:5d:18:54:e0:66:c8:b9:e7:d4:de:ba:9b:
+        89:12:a0:c8:b9:8b:db:a9:48:7e:2b:11:f3:a4:bb:f5:9c:98:
+        42:04:48:45:ef:81
+-----BEGIN CERTIFICATE-----
+MIIGMzCCBJugAwIBAgIQHUh9Av/PVkKLmJ47pDPOLzANBgkqhkiG9w0BAQsFADBM
+MRswGQYDVQQDExJFViBDb2RlIFNpZ25pbmcgQ0ExCzAJBgNVBAsTAkNBMRMwEQYD
+VQQKEwpFeGFtcGxlIENvMQswCQYDVQQGEwJVUzAeFw0yNjA2MTUwMDIwMjBaFw0y
+NzA2MTUwMDIwMjBaMIIBGDETMBEGA1UEAxMKRXhhbXBsZSBDbzFDMEEGA1UEChM6
+RXhhbXBsZSBDbzEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4
+OTAxMjM0MTIzNDEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzETMBEGA1UECBMKQ2Fs
+aWZvcm5pYTELMAkGA1UEBhMCVVMxHjAcBgsrBgEEAYI3PAIBARMNTW91bnRhaW4g
+VmlldzEbMBkGCysGAQQBgjc8AgECEwpDYWxpZm9ybmlhMRMwEQYLKwYBBAGCNzwC
+AQMTAlVTMREwDwYDVQQFEwgxMjM0NTY3ODEdMBsGA1UEDxMUUHJpdmF0ZSBPcmdh
+bml6YXRpb24wggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQC2VmXNnDNz
+O+8Y/Ia5Q22xDytDAlxlwXOkHV9dXJS4sxQKk7xZAPdfDLvcA9exyf8slGFyjQff
+2vSfJWue1MsF9K9r9T89lXyvkztUo3HAHjQJ5GADLoc+IZulj+W+q8E4mYEBFSya
+TrSZ9RX41l9/GdUz0922+Xw0GJbdwkQ8tvNf4pavftBANXjw+fxGl8HQGovJO5HT
+BHO2xfNSTuu/eSDq57eCZBUmvg6llI+pI5Ncz5vwet6FCrE9uR4xAw/L/U2H5Qxw
+pRMCoJzo1i3+S1JBThF27bH2NEQv2fyH20OT5KlgCi58mzc1M6FVT3lSrZQaVjd/
+t1WadB/qIDvSmYytOpo3J4Yl1fU8aoF3F0QvlVem+CibJEr2VhtwvCbFQR5lR/nf
+rdxXmZyS2zXvcMYVPM0zb54h4yupYSu1O1VckFXn0AmknnoZrfIV2MgCwVIZxtqF
+5k3gq6F4NZklXpDNAtlQanQBPRJE+hSx8KiWg+vJJuITH/dP1Czq5/MCAwEAAaOC
+AUEwggE9MA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAMBgNV
+HRMBAf8EAjAAMB0GA1UdDgQWBBQU15bWuocmninHqjDpgqwkZ3+WbjAfBgNVHSME
+GDAWgBQGgyXTa65LXS+3KZmUs2jPoOEzezBbBggrBgEFBQcBAQRPME0wIwYIKwYB
+BQUHMAGGF2h0dHA6Ly9vY3NwLmV4YW1wbGUuY29tMCYGCCsGAQUFBzAChhpodHRw
+Oi8vZXhhbXBsZS5jb20vY2ExLmNydDASBgNVHSAECzAJMAcGBWeBDAEDMFcGA1Ud
+HwRQME4wJaAjoCGGH2h0dHA6Ly9jcmwxLmV4YW1wbGUuY29tL2NhMS5jcmwwJaAj
+oCGGH2h0dHA6Ly9jcmwyLmV4YW1wbGUuY29tL2NhMS5jcmwwDQYJKoZIhvcNAQEL
+BQADggGBAK7tsofG8JbyCgq1sMIwsODdJwBmOl7wKVAp6tpJTP4WJANExLs4XNe5
+WHwapCmNTj+Uv9NZg87VtfGy6LYUipsGaUZZvmz7KbdpZY0KNANx6suJdAnf+WH0
+Iuwg16VnzEqSS/iLTMcPynJbBirGTB+eXfjA/mP2xdfoVL2Z+AOqPe3LCns1qa5b
+JVDW4l/4YTWG7KPRZuUPP0SU2bZMB0IpZsb+d9uNvH5N2RUHf6341vrgUymOE36n
+L+YDjnDJMocG2wG1Ky4jsGTB4oQ1Ruv4WH6bE1oKC4ehbeeTWBMlPcdcBqwodPOs
+U/AHZMVgHiSaY28xet5h9oznbnP2r0wFBoeP1BZqRsQcjtjAO+HHMI/kT+EthOZc
+VgkFMUR+feJFftinl70czQ+5nMepDiC4YZmi1gLLURuKX4FSbXWlL3JzyZWoIHCz
+ghkkEgs8O01f6TIdmyA+i9mBlV0YVOBmyLnn1N66m4kSoMi5i9upSH4rEfOku/Wc
+mEIESEXvgQ==
+-----END CERTIFICATE-----

--- a/v3/testdata/code_signing/cs_ev_subject_org_65_chars.pem
+++ b/v3/testdata/code_signing/cs_ev_subject_org_65_chars.pem
@@ -1,0 +1,125 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            6f:f1:ee:4c:23:c3:9a:ad:28:f4:33:8b:f9:32:9e:be
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=EV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 15 00:23:37 2026 GMT
+            Not After : Jun 15 00:23:37 2027 GMT
+        Subject: CN=Example Co, O=Example Co1234567890123456789012345678901234567890123412345678945, L=Mountain View, ST=California, C=US, jurisdictionL=Mountain View, jurisdictionST=California, jurisdictionC=US, serialNumber=12345678, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:d2:70:cf:cb:aa:ed:96:ac:3a:c9:50:ab:96:b7:
+                    00:35:8a:10:4a:fb:7c:52:72:b5:ae:6f:65:be:de:
+                    9d:cc:cb:67:af:db:bd:90:ee:25:cf:ff:bf:c1:c0:
+                    61:ff:5e:32:af:25:3b:5b:e9:8b:8c:78:38:5f:69:
+                    1e:c1:bd:3d:a3:78:f7:4b:f4:64:94:88:a6:e3:ee:
+                    ed:49:96:05:b8:40:85:5e:2f:f6:a0:49:d6:e0:14:
+                    97:15:07:31:c9:68:9b:b5:48:40:ab:4f:a3:7d:45:
+                    10:8d:24:f6:66:a3:f1:9f:c9:92:83:4c:8e:68:c8:
+                    d0:38:f8:64:fc:05:ca:6b:df:bc:5b:8d:d9:92:57:
+                    b3:1a:ba:31:e2:72:fe:fb:a8:e0:38:34:64:41:64:
+                    95:3e:2f:96:7f:6b:20:95:14:79:a7:57:14:e9:76:
+                    8c:46:07:00:fc:d5:c6:9c:3d:95:cf:d6:43:c0:85:
+                    4b:da:4e:6b:b0:fe:13:cf:3e:4d:71:30:09:fd:f5:
+                    3e:d8:9d:fb:e2:c0:a1:f5:3c:94:8f:f3:e5:41:e5:
+                    e0:9c:08:7b:a2:d3:87:86:68:3a:2b:6e:62:40:42:
+                    f5:3a:d2:86:b9:c5:79:71:b1:e2:c9:f2:5c:27:2a:
+                    4c:83:9c:d0:14:79:c3:06:ae:77:71:0f:e4:64:93:
+                    a2:13:53:64:54:65:01:65:c2:b6:06:24:d8:c5:da:
+                    93:f5:d1:c9:fb:f2:db:1c:04:aa:74:4a:52:53:a3:
+                    bd:cd:54:94:fb:54:a3:4b:e2:9a:ac:04:33:f9:da:
+                    f7:e2:e7:d4:2a:51:54:de:e8:f1:e6:7a:9d:ef:57:
+                    bb:63:36:43:03:88:f2:2c:6c:88:93:cb:97:fa:ee:
+                    ff:14:c6:63:a9:c7:76:60:ab:3b:c7:72:02:39:b0:
+                    47:e3:1b:d6:ac:cf:e3:4c:a1:c0:49:cd:eb:09:15:
+                    8f:c5:78:f0:7b:da:32:67:40:62:45:cb:06:e1:0b:
+                    8f:e7:ac:5f:01:59:77:41:87:2b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                E6:F0:F4:CD:90:FA:72:57:01:A8:B7:85:09:AF:BD:CA:23:E7:D9:89
+            X509v3 Authority Key Identifier: 
+                EF:2E:7E:D5:84:DC:43:5E:11:A3:A5:29:3F:38:A8:ED:C6:30:0E:33
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.3
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        17:4c:77:60:f8:12:7e:77:5f:3c:14:a0:40:c3:78:ef:70:ec:
+        ab:30:e7:7f:5b:b8:3b:3e:ce:8f:9f:36:86:cb:13:0b:b1:22:
+        e5:41:2f:f6:86:54:29:f9:56:95:57:b0:4a:07:e8:78:a9:fa:
+        e6:fd:b6:63:b5:f5:42:d1:8d:cf:80:92:7d:68:f0:34:d7:8c:
+        43:f5:33:11:8a:fd:7e:86:ea:a7:49:1a:1c:39:6d:d7:41:6e:
+        7c:44:ad:54:a7:ba:3a:25:67:af:91:ff:2d:a1:8d:77:3b:fa:
+        0a:60:e1:37:ce:9e:68:96:3d:9f:5b:1b:08:3c:19:c7:ab:33:
+        c9:7f:64:aa:7c:8b:03:10:a1:8f:38:f9:b4:c9:74:34:e1:09:
+        fe:5a:1c:8e:0b:a7:80:45:67:89:58:68:e7:89:49:fa:13:a1:
+        04:e1:05:92:64:83:49:11:d6:64:6f:6d:45:dc:3f:94:8b:61:
+        8c:70:f3:52:fc:ae:4b:e0:2c:2f:ad:18:6a:3f:bd:e1:af:e4:
+        c8:4d:5f:4d:e2:81:94:3e:93:60:f5:57:50:d5:1a:fd:c5:d1:
+        1b:f2:b6:28:f3:62:b0:7f:0a:7c:33:73:7d:ba:33:ca:71:db:
+        9a:eb:20:ca:7c:c4:4d:05:54:31:66:44:77:4b:1f:4a:8c:ec:
+        a6:b6:0e:a7:0b:0c:00:12:79:97:54:52:6d:05:55:6d:18:b5:
+        84:96:85:c1:da:aa:73:0a:05:d1:07:80:6e:85:85:99:a5:b1:
+        19:44:64:df:5c:65:cf:ca:52:19:f0:19:11:6c:7e:61:dd:e1:
+        7a:35:98:c3:87:4d:38:a8:99:65:67:0b:20:26:c2:7c:18:6c:
+        17:a5:8a:2f:b8:53:fb:14:15:cf:c4:62:20:42:fe:8d:e2:5e:
+        3a:2c:ab:72:68:78:85:05:8e:00:ea:cb:b4:d5:98:d7:04:27:
+        05:72:d1:06:73:1d:d0:f0:c5:42:e4:5d:8d:13:07:c0:43:b3:
+        a1:d2:ca:ef:c4:4d
+-----BEGIN CERTIFICATE-----
+MIIGOjCCBKKgAwIBAgIQb/HuTCPDmq0o9DOL+TKevjANBgkqhkiG9w0BAQsFADBM
+MRswGQYDVQQDExJFViBDb2RlIFNpZ25pbmcgQ0ExCzAJBgNVBAsTAkNBMRMwEQYD
+VQQKEwpFeGFtcGxlIENvMQswCQYDVQQGEwJVUzAeFw0yNjA2MTUwMDIzMzdaFw0y
+NzA2MTUwMDIzMzdaMIIBHzETMBEGA1UEAxMKRXhhbXBsZSBDbzFKMEgGA1UEChNB
+RXhhbXBsZSBDbzEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4
+OTAxMjM0MTIzNDU2Nzg5NDUxFjAUBgNVBAcTDU1vdW50YWluIFZpZXcxEzARBgNV
+BAgTCkNhbGlmb3JuaWExCzAJBgNVBAYTAlVTMR4wHAYLKwYBBAGCNzwCAQETDU1v
+dW50YWluIFZpZXcxGzAZBgsrBgEEAYI3PAIBAhMKQ2FsaWZvcm5pYTETMBEGCysG
+AQQBgjc8AgEDEwJVUzERMA8GA1UEBRMIMTIzNDU2NzgxHTAbBgNVBA8TFFByaXZh
+dGUgT3JnYW5pemF0aW9uMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA
+0nDPy6rtlqw6yVCrlrcANYoQSvt8UnK1rm9lvt6dzMtnr9u9kO4lz/+/wcBh/14y
+ryU7W+mLjHg4X2kewb09o3j3S/RklIim4+7tSZYFuECFXi/2oEnW4BSXFQcxyWib
+tUhAq0+jfUUQjST2ZqPxn8mSg0yOaMjQOPhk/AXKa9+8W43ZklezGrox4nL++6jg
+ODRkQWSVPi+Wf2sglRR5p1cU6XaMRgcA/NXGnD2Vz9ZDwIVL2k5rsP4Tzz5NcTAJ
+/fU+2J374sCh9TyUj/PlQeXgnAh7otOHhmg6K25iQEL1OtKGucV5cbHiyfJcJypM
+g5zQFHnDBq53cQ/kZJOiE1NkVGUBZcK2BiTYxdqT9dHJ+/LbHASqdEpSU6O9zVSU
++1SjS+KarAQz+dr34ufUKlFU3ujx5nqd71e7YzZDA4jyLGyIk8uX+u7/FMZjqcd2
+YKs7x3ICObBH4xvWrM/jTKHASc3rCRWPxXjwe9oyZ0BiRcsG4QuP56xfAVl3QYcr
+AgMBAAGjggFBMIIBPTAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUH
+AwMwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQU5vD0zZD6clcBqLeFCa+9yiPn2Ykw
+HwYDVR0jBBgwFoAU7y5+1YTcQ14Ro6UpPzio7cYwDjMwWwYIKwYBBQUHAQEETzBN
+MCMGCCsGAQUFBzABhhdodHRwOi8vb2NzcC5leGFtcGxlLmNvbTAmBggrBgEFBQcw
+AoYaaHR0cDovL2V4YW1wbGUuY29tL2NhMS5jcnQwEgYDVR0gBAswCTAHBgVngQwB
+AzBXBgNVHR8EUDBOMCWgI6Ahhh9odHRwOi8vY3JsMS5leGFtcGxlLmNvbS9jYTEu
+Y3JsMCWgI6Ahhh9odHRwOi8vY3JsMi5leGFtcGxlLmNvbS9jYTEuY3JsMA0GCSqG
+SIb3DQEBCwUAA4IBgQAXTHdg+BJ+d188FKBAw3jvcOyrMOd/W7g7Ps6PnzaGyxML
+sSLlQS/2hlQp+VaVV7BKB+h4qfrm/bZjtfVC0Y3PgJJ9aPA014xD9TMRiv1+huqn
+SRocOW3XQW58RK1Up7o6JWevkf8toY13O/oKYOE3zp5olj2fWxsIPBnHqzPJf2Sq
+fIsDEKGPOPm0yXQ04Qn+WhyOC6eARWeJWGjniUn6E6EE4QWSZINJEdZkb21F3D+U
+i2GMcPNS/K5L4CwvrRhqP73hr+TITV9N4oGUPpNg9VdQ1Rr9xdEb8rYo82Kwfwp8
+M3N9ujPKcdua6yDKfMRNBVQxZkR3Sx9KjOymtg6nCwwAEnmXVFJtBVVtGLWEloXB
+2qpzCgXRB4BuhYWZpbEZRGTfXGXPylIZ8BkRbH5h3eF6NZjDh004qJllZwsgJsJ8
+GGwXpYovuFP7FBXPxGIgQv6N4l46LKtyaHiFBY4A6su01ZjXBCcFctEGcx3Q8MVC
+5F2NEwfAQ7Oh0srvxE0=
+-----END CERTIFICATE-----

--- a/v3/testdata/code_signing/cs_ev_subject_org_missing.pem
+++ b/v3/testdata/code_signing/cs_ev_subject_org_missing.pem
@@ -1,0 +1,124 @@
+
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            99:aa:a1:bb:8e:2c:7d:6e:c6:81:e3:86:a1:ea:53:e4
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=EV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 14 18:00:26 2026 GMT
+            Not After : Jun 14 18:00:26 2027 GMT
+        Subject: CN=Example Co, L=Mountain View, ST=California, C=US, jurisdictionL=Mountain View, jurisdictionST=California, jurisdictionC=US, serialNumber=12345678, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:b6:f5:b2:62:47:38:6e:11:ea:19:07:a0:80:1a:
+                    fb:ca:a6:09:27:8f:a0:89:88:28:4e:48:b6:b2:4b:
+                    16:ff:81:85:55:16:37:27:e3:0e:2b:9c:0d:b1:34:
+                    5d:c6:55:80:9f:18:d3:ff:f7:f8:ca:6e:66:26:d2:
+                    4a:37:08:80:16:d9:70:49:c8:ae:e2:b7:5d:16:9c:
+                    2e:4a:46:5f:f8:ee:23:63:32:4b:2f:41:36:29:d6:
+                    76:19:f0:b5:37:76:61:01:1e:0e:f2:4d:40:6c:b0:
+                    76:82:98:82:32:82:f3:80:9e:c2:2a:1b:86:9c:96:
+                    be:50:f2:d4:54:33:a0:01:5b:5d:6b:48:61:bb:0d:
+                    6e:ab:54:9a:9a:7c:45:1a:39:2c:f1:57:de:a7:f7:
+                    c7:46:dc:76:17:7e:28:74:a7:3e:20:3e:0d:f8:77:
+                    75:19:db:10:dc:f1:65:a4:81:c5:98:f8:63:dc:10:
+                    dd:af:19:c1:66:c4:2d:dd:43:f5:94:1a:36:99:d5:
+                    58:5d:22:da:f3:c6:7b:cd:99:d3:ca:9f:a1:b2:70:
+                    03:d6:d0:99:bb:de:f2:1a:8e:41:e3:e5:ee:1f:ac:
+                    38:00:31:2e:5d:c4:1b:49:89:16:6f:74:d9:5f:a8:
+                    8d:57:dc:8c:f5:8c:ad:06:8b:f0:15:aa:fb:aa:f7:
+                    92:97:6d:dd:6d:39:49:1a:f7:52:71:7d:ea:cd:aa:
+                    41:24:38:b9:f5:7a:b2:fb:a8:a3:82:f5:f1:dc:ba:
+                    cf:13:af:6f:e6:d1:6e:d4:d9:7d:31:37:2b:4b:4a:
+                    e8:e4:82:05:07:84:5d:a6:22:81:b4:bc:d1:0a:14:
+                    0c:61:93:2b:9c:34:c5:e8:bc:cb:af:d6:61:29:09:
+                    05:38:fb:52:da:30:1a:a3:2b:60:99:86:b3:80:63:
+                    8c:48:7d:2f:77:ac:e4:97:b8:97:25:94:d7:0c:88:
+                    9e:57:76:6b:8c:66:74:5b:56:1b:32:db:d7:7e:78:
+                    c5:a8:76:d7:d1:1f:50:a5:ae:df
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                37:34:35:F1:6B:EE:7C:C7:98:57:01:A8:9A:0E:C1:36:28:44:46:A9
+            X509v3 Authority Key Identifier: 
+                7F:D8:4C:DB:5B:24:99:C7:C8:4C:2C:61:F0:F8:AD:9E:02:11:B7:80
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.3
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        9d:0f:59:14:4d:aa:c9:77:ba:9b:54:17:58:40:c0:4d:e7:fb:
+        9d:92:82:d4:f3:83:78:3c:2c:ee:f6:2f:9a:d5:39:7b:65:12:
+        01:1f:6d:65:80:4e:bd:23:9e:9b:c4:7f:3e:ff:3f:46:dc:f8:
+        2f:41:bc:b7:08:36:10:b4:77:51:26:59:ce:89:b3:09:29:02:
+        f2:ac:20:9c:67:41:08:53:29:ee:ae:03:d3:89:e9:a3:6b:12:
+        ee:4e:37:18:07:4a:25:41:d0:b6:89:43:ab:33:0b:b3:49:1f:
+        a4:15:e2:35:2c:c9:74:4e:c3:22:6f:79:61:a4:38:0c:e9:de:
+        53:69:84:5e:ff:e4:a4:91:f9:73:99:63:94:67:c0:7d:91:89:
+        0e:d2:5f:b9:b1:90:28:61:1b:b9:7a:33:28:5e:b6:e7:4c:c6:
+        a4:31:8e:5e:09:75:b4:85:3b:7d:f2:87:88:dd:03:17:b1:b2:
+        45:5b:47:5d:47:f4:5a:b9:37:de:2a:ff:31:91:90:d4:d2:d0:
+        b4:84:26:47:34:a6:11:fa:49:4f:50:50:05:02:48:57:5e:22:
+        1c:19:9f:dc:b9:54:ac:4f:b6:b5:1c:f7:bf:4a:08:8e:19:14:
+        a7:fc:6f:34:f3:f0:35:f1:22:25:b1:5d:51:a9:f5:55:05:50:
+        7e:3e:c5:a2:c2:63:74:02:e0:0e:e3:4a:2f:46:d7:84:83:82:
+        0e:78:33:ca:34:07:f2:7c:f5:ce:0d:1c:6c:82:3c:25:68:2c:
+        28:a0:5b:ea:70:0b:49:8a:cf:c7:a9:91:10:ba:5a:9b:4c:1d:
+        a3:90:c6:de:e3:41:8f:80:b7:da:dd:d4:51:7e:62:60:d2:d7:
+        28:2a:ab:a2:53:1a:71:84:08:de:80:a5:38:c8:7a:3d:9b:f7:
+        5d:4d:e5:fe:07:76:12:b6:9d:a3:62:43:c3:08:32:a7:0a:5d:
+        e2:6c:06:b6:4e:35:37:f4:e0:89:55:45:a5:c3:45:96:a3:e2:
+        7c:bf:93:3f:0e:b4
+-----BEGIN CERTIFICATE-----
+MIIF7jCCBFagAwIBAgIRAJmqobuOLH1uxoHjhqHqU+QwDQYJKoZIhvcNAQELBQAw
+TDEbMBkGA1UEAxMSRVYgQ29kZSBTaWduaW5nIENBMQswCQYDVQQLEwJDQTETMBEG
+A1UEChMKRXhhbXBsZSBDbzELMAkGA1UEBhMCVVMwHhcNMjYwNjE0MTgwMDI2WhcN
+MjcwNjE0MTgwMDI2WjCB0zETMBEGA1UEAxMKRXhhbXBsZSBDbzEWMBQGA1UEBxMN
+TW91bnRhaW4gVmlldzETMBEGA1UECBMKQ2FsaWZvcm5pYTELMAkGA1UEBhMCVVMx
+HjAcBgsrBgEEAYI3PAIBARMNTW91bnRhaW4gVmlldzEbMBkGCysGAQQBgjc8AgEC
+EwpDYWxpZm9ybmlhMRMwEQYLKwYBBAGCNzwCAQMTAlVTMREwDwYDVQQFEwgxMjM0
+NTY3ODEdMBsGA1UEDxMUUHJpdmF0ZSBPcmdhbml6YXRpb24wggGiMA0GCSqGSIb3
+DQEBAQUAA4IBjwAwggGKAoIBgQC29bJiRzhuEeoZB6CAGvvKpgknj6CJiChOSLay
+Sxb/gYVVFjcn4w4rnA2xNF3GVYCfGNP/9/jKbmYm0ko3CIAW2XBJyK7it10WnC5K
+Rl/47iNjMksvQTYp1nYZ8LU3dmEBHg7yTUBssHaCmIIygvOAnsIqG4aclr5Q8tRU
+M6ABW11rSGG7DW6rVJqafEUaOSzxV96n98dG3HYXfih0pz4gPg34d3UZ2xDc8WWk
+gcWY+GPcEN2vGcFmxC3dQ/WUGjaZ1VhdItrzxnvNmdPKn6GycAPW0Jm73vIajkHj
+5e4frDgAMS5dxBtJiRZvdNlfqI1X3Iz1jK0Gi/AVqvuq95KXbd1tOUka91JxferN
+qkEkOLn1erL7qKOC9fHcus8Tr2/m0W7U2X0xNytLSujkggUHhF2mIoG0vNEKFAxh
+kyucNMXovMuv1mEpCQU4+1LaMBqjK2CZhrOAY4xIfS93rOSXuJcllNcMiJ5XdmuM
+ZnRbVhsy29d+eMWodtfRH1Clrt8CAwEAAaOCAUEwggE9MA4GA1UdDwEB/wQEAwIH
+gDATBgNVHSUEDDAKBggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBQ3
+NDXxa+58x5hXAaiaDsE2KERGqTAfBgNVHSMEGDAWgBR/2EzbWySZx8hMLGHw+K2e
+AhG3gDBbBggrBgEFBQcBAQRPME0wIwYIKwYBBQUHMAGGF2h0dHA6Ly9vY3NwLmV4
+YW1wbGUuY29tMCYGCCsGAQUFBzAChhpodHRwOi8vZXhhbXBsZS5jb20vY2ExLmNy
+dDASBgNVHSAECzAJMAcGBWeBDAEDMFcGA1UdHwRQME4wJaAjoCGGH2h0dHA6Ly9j
+cmwxLmV4YW1wbGUuY29tL2NhMS5jcmwwJaAjoCGGH2h0dHA6Ly9jcmwyLmV4YW1w
+bGUuY29tL2NhMS5jcmwwDQYJKoZIhvcNAQELBQADggGBAJ0PWRRNqsl3uptUF1hA
+wE3n+52SgtTzg3g8LO72L5rVOXtlEgEfbWWATr0jnpvEfz7/P0bc+C9BvLcINhC0
+d1EmWc6JswkpAvKsIJxnQQhTKe6uA9OJ6aNrEu5ONxgHSiVB0LaJQ6szC7NJH6QV
+4jUsyXROwyJveWGkOAzp3lNphF7/5KSR+XOZY5RnwH2RiQ7SX7mxkChhG7l6Myhe
+tudMxqQxjl4JdbSFO33yh4jdAxexskVbR11H9Fq5N94q/zGRkNTS0LSEJkc0phH6
+SU9QUAUCSFdeIhwZn9y5VKxPtrUc979KCI4ZFKf8bzTz8DXxIiWxXVGp9VUFUH4+
+xaLCY3QC4A7jSi9G14SDgg54M8o0B/J89c4NHGyCPCVoLCigW+pwC0mKz8epkRC6
+WptMHaOQxt7jQY+At9rd1FF+YmDS1ygqq6JTGnGECN6ApTjIej2b911N5f4HdhK2
+naNiQ8MIMqcKXeJsBrZONTf04IlVRaXDRZaj4ny/kz8OtA==
+-----END CERTIFICATE-----

--- a/v3/testdata/code_signing/cs_ev_subject_org_present.pem
+++ b/v3/testdata/code_signing/cs_ev_subject_org_present.pem
@@ -1,0 +1,125 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            d5:29:2e:56:3f:6c:27:d1:f8:86:47:f2:c7:80:06:25
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=EV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 14 17:54:47 2026 GMT
+            Not After : Jun 14 17:54:47 2027 GMT
+        Subject: CN=Example Co, O=Example Co, L=Mountain View, ST=California, C=US, jurisdictionL=Mountain View, jurisdictionST=California, jurisdictionC=US, serialNumber=12345678, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:cd:ee:b1:79:ac:24:51:76:df:02:bd:4f:82:74:
+                    b3:5d:d4:da:4d:c2:2d:06:5e:d3:5c:81:5a:ad:51:
+                    71:92:1e:7a:c7:b1:9d:ac:0a:d4:90:db:6c:3a:d4:
+                    2b:56:ec:73:3d:00:3d:de:bf:c5:74:35:a6:73:9a:
+                    b6:cd:b4:01:9b:d5:2d:c9:79:bf:71:86:77:b7:d9:
+                    9d:5e:28:01:43:06:b5:6a:64:81:9f:9a:cc:2f:48:
+                    4c:35:75:57:f7:da:91:5a:1e:1a:dd:5c:c5:b5:ca:
+                    a0:ec:ef:91:71:a8:a3:2b:0c:fb:c1:05:60:09:65:
+                    39:8d:c8:db:c7:ca:54:85:06:bd:f5:1b:a1:25:95:
+                    07:bd:bb:5b:18:51:d8:89:a1:7c:5b:8b:16:b6:da:
+                    69:c2:2d:58:96:c3:4e:55:41:73:08:1b:eb:85:bd:
+                    4f:a3:1a:70:6c:ae:99:c7:16:c0:e5:d5:5f:13:72:
+                    68:d9:43:e8:69:22:24:e6:dc:a0:71:9e:ae:fa:8f:
+                    d1:a1:b7:2e:be:00:9c:07:6b:b3:8e:b0:1b:24:fa:
+                    06:6f:b2:76:ca:c3:b0:b4:6a:f8:b2:6b:af:0c:61:
+                    d3:46:62:72:13:c1:e9:87:ab:62:01:fd:c1:97:54:
+                    59:6d:fb:f9:a1:9a:92:64:b4:dd:15:6a:48:c5:b2:
+                    4f:8a:a0:4e:24:a4:03:f7:71:a7:c8:f3:52:7e:33:
+                    bc:58:04:b9:8f:e2:ee:62:8d:4a:90:64:b3:c0:87:
+                    38:74:fc:3e:f2:5e:a9:f0:18:67:26:86:ce:f6:34:
+                    eb:34:4b:80:bb:51:c4:04:e5:74:d5:7f:ac:3a:9e:
+                    3c:0b:16:f0:be:00:30:a8:4f:ff:7e:96:52:5c:ae:
+                    0a:4c:68:55:b9:b9:48:83:a3:9f:61:c3:d4:ed:5e:
+                    05:49:f6:eb:ae:29:fa:18:41:12:44:7e:57:1b:da:
+                    03:55:2e:de:87:23:c1:40:51:f1:3d:ef:7f:0d:f1:
+                    fa:5d:86:89:b5:42:4d:3f:c9:57
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                69:84:FA:C0:A3:30:19:B8:E1:0A:AF:1B:C3:4E:04:BD:26:86:89:FA
+            X509v3 Authority Key Identifier: 
+                F0:6A:F4:B5:52:86:50:0E:5B:34:24:8E:FF:30:8E:C6:DA:B4:16:9B
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.3
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        88:e1:dc:4e:d7:28:bc:03:2d:9d:6a:b2:43:0f:d3:ca:fb:c8:
+        b5:4c:6f:bc:22:2b:a8:d0:f0:ba:1c:f0:98:f7:88:29:7f:fe:
+        6c:22:97:b1:50:fb:6b:ee:6d:55:5c:7e:e3:08:32:a3:2b:5d:
+        c6:00:9b:f8:15:02:20:41:cf:4a:ba:b7:0f:cc:e3:98:5c:a8:
+        cf:13:cb:c6:88:bc:ac:6f:2e:a7:3e:22:45:5e:5f:47:f9:45:
+        07:49:da:8f:7f:6c:ac:87:2d:c4:d6:57:3c:56:d4:8d:f9:28:
+        1e:fe:89:02:e1:d8:48:b2:d0:c5:14:3b:75:18:37:47:28:55:
+        a3:ed:a9:f6:ce:ce:bb:f1:80:81:71:51:b1:97:0e:37:5b:9e:
+        09:03:fd:4d:ca:5c:d4:89:76:72:99:d8:2b:81:65:52:2c:29:
+        e8:2b:7a:c8:a3:42:35:8b:8c:2d:4b:e7:aa:26:3f:09:e1:7c:
+        67:e9:54:b4:cd:85:17:95:86:76:16:6d:2a:28:0e:95:63:d9:
+        68:38:51:e8:23:86:09:dc:2a:82:0f:7a:bf:83:53:62:40:49:
+        72:63:e4:3c:36:74:fc:ff:c0:02:6e:e5:96:5c:7e:d1:32:27:
+        f6:01:b1:ea:35:85:ca:53:16:5e:0b:a5:55:c4:af:6f:2b:69:
+        27:5d:71:1c:6e:3a:12:51:a6:ec:2e:17:b2:96:74:2c:c2:7c:
+        94:1f:b5:16:a3:09:94:c4:1e:4a:d5:3c:15:c5:25:72:41:77:
+        95:23:69:e5:07:68:12:ed:ab:37:39:46:cc:bb:52:9b:91:d6:
+        3b:8e:52:9b:63:18:52:7b:ab:c8:1b:39:52:b0:d6:b0:c8:b2:
+        ea:dc:31:16:4a:85:d0:28:e4:db:5b:42:e1:c0:bd:0a:8d:74:
+        7d:10:96:43:99:e7:f8:7b:6f:5e:bf:a4:62:cc:a7:69:9f:9f:
+        54:ba:18:d3:80:19:92:14:bb:9f:c1:66:61:14:af:07:94:fd:
+        b4:16:93:f5:16:ec
+-----BEGIN CERTIFICATE-----
+MIIGAzCCBGugAwIBAgIRANUpLlY/bCfR+IZH8seABiUwDQYJKoZIhvcNAQELBQAw
+TDEbMBkGA1UEAxMSRVYgQ29kZSBTaWduaW5nIENBMQswCQYDVQQLEwJDQTETMBEG
+A1UEChMKRXhhbXBsZSBDbzELMAkGA1UEBhMCVVMwHhcNMjYwNjE0MTc1NDQ3WhcN
+MjcwNjE0MTc1NDQ3WjCB6DETMBEGA1UEAxMKRXhhbXBsZSBDbzETMBEGA1UEChMK
+RXhhbXBsZSBDbzEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzETMBEGA1UECBMKQ2Fs
+aWZvcm5pYTELMAkGA1UEBhMCVVMxHjAcBgsrBgEEAYI3PAIBARMNTW91bnRhaW4g
+VmlldzEbMBkGCysGAQQBgjc8AgECEwpDYWxpZm9ybmlhMRMwEQYLKwYBBAGCNzwC
+AQMTAlVTMREwDwYDVQQFEwgxMjM0NTY3ODEdMBsGA1UEDxMUUHJpdmF0ZSBPcmdh
+bml6YXRpb24wggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQDN7rF5rCRR
+dt8CvU+CdLNd1NpNwi0GXtNcgVqtUXGSHnrHsZ2sCtSQ22w61CtW7HM9AD3ev8V0
+NaZzmrbNtAGb1S3Jeb9xhne32Z1eKAFDBrVqZIGfmswvSEw1dVf32pFaHhrdXMW1
+yqDs75FxqKMrDPvBBWAJZTmNyNvHylSFBr31G6EllQe9u1sYUdiJoXxbixa22mnC
+LViWw05VQXMIG+uFvU+jGnBsrpnHFsDl1V8TcmjZQ+hpIiTm3KBxnq76j9Ghty6+
+AJwHa7OOsBsk+gZvsnbKw7C0aviya68MYdNGYnITwemHq2IB/cGXVFlt+/mhmpJk
+tN0VakjFsk+KoE4kpAP3cafI81J+M7xYBLmP4u5ijUqQZLPAhzh0/D7yXqnwGGcm
+hs72NOs0S4C7UcQE5XTVf6w6njwLFvC+ADCoT/9+llJcrgpMaFW5uUiDo59hw9Tt
+XgVJ9uuuKfoYQRJEflcb2gNVLt6HI8FAUfE9738N8fpdhom1Qk0/yVcCAwEAAaOC
+AUEwggE9MA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAMBgNV
+HRMBAf8EAjAAMB0GA1UdDgQWBBRphPrAozAZuOEKrxvDTgS9JoaJ+jAfBgNVHSME
+GDAWgBTwavS1UoZQDls0JI7/MI7G2rQWmzBbBggrBgEFBQcBAQRPME0wIwYIKwYB
+BQUHMAGGF2h0dHA6Ly9vY3NwLmV4YW1wbGUuY29tMCYGCCsGAQUFBzAChhpodHRw
+Oi8vZXhhbXBsZS5jb20vY2ExLmNydDASBgNVHSAECzAJMAcGBWeBDAEDMFcGA1Ud
+HwRQME4wJaAjoCGGH2h0dHA6Ly9jcmwxLmV4YW1wbGUuY29tL2NhMS5jcmwwJaAj
+oCGGH2h0dHA6Ly9jcmwyLmV4YW1wbGUuY29tL2NhMS5jcmwwDQYJKoZIhvcNAQEL
+BQADggGBAIjh3E7XKLwDLZ1qskMP08r7yLVMb7wiK6jQ8Loc8Jj3iCl//mwil7FQ
++2vubVVcfuMIMqMrXcYAm/gVAiBBz0q6tw/M45hcqM8Ty8aIvKxvLqc+IkVeX0f5
+RQdJ2o9/bKyHLcTWVzxW1I35KB7+iQLh2Eiy0MUUO3UYN0coVaPtqfbOzrvxgIFx
+UbGXDjdbngkD/U3KXNSJdnKZ2CuBZVIsKegresijQjWLjC1L56omPwnhfGfpVLTN
+hReVhnYWbSooDpVj2Wg4UegjhgncKoIPer+DU2JASXJj5Dw2dPz/wAJu5ZZcftEy
+J/YBseo1hcpTFl4LpVXEr28raSddcRxuOhJRpuwuF7KWdCzCfJQftRajCZTEHkrV
+PBXFJXJBd5UjaeUHaBLtqzc5Rsy7UpuR1juOUptjGFJ7q8gbOVKw1rDIsurcMRZK
+hdAo5NtbQuHAvQqNdH0QlkOZ5/h7b16/pGLMp2mfn1S6GNOAGZIUu5/BZmEUrweU
+/bQWk/UW7A==
+-----END CERTIFICATE-----

--- a/v3/util/cs.go
+++ b/v3/util/cs.go
@@ -16,3 +16,13 @@ func IsCodeSigning(policies []asn1.ObjectIdentifier) bool {
 
 	return false
 }
+
+func IsEVCodeSigning(policies []asn1.ObjectIdentifier) bool {
+	for _, policy := range policies {
+		if policy.String() == evCodeSigningPolicy {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Added validation for the EV Code Signing certificate organizationName field to enforce the 64-character maximum defined by the CA/Browser Forum Code Signing Requirements. Although a generic validation already exists (subject_organization_name_max_length), this rule is duplicated here to keep Code Signing lints self-contained.

### Reference with sections:
https://cabforum.org/working-groups/code-signing/requirements/

Section 7.1.4.2.4:
> Certificate Field: subject:organizationName (OID 2.5.4.10)
> 
> If the combination of names or the organization name by itself exceeds 64 characters, the CA
> MAY abbreviate parts of the organization name, and/or omit non-material words in the
> organization name in such a way that the text in this field does not exceed the 64-character
> limit; provided that the CA checks this field in accordance with the High Risk Certificate
> Request requirements of Section 4.2.1 and a Relying Party will not be misled into thinking
> that they are dealing with a different organization. In cases where this is not possible, the
> CA MUST NOT issue the EV Code Signing Certificate.