### PR TITLE
Add required locality or province lint for code signing certificates

### DIFF
--- a/v3/lints/cabf_cs_br/lint_cs_subject_locality_or_province.go
+++ b/v3/lints/cabf_cs_br/lint_cs_subject_locality_or_province.go
@@ -1,0 +1,48 @@
+package cabf_cs_br
+
+import (
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+/*
+7.1.4.2.3 Subject distinguished name field - Non-EV Code Signing Certificates
+g. Certificate Field: subject:localityName (OID: 2.5.4.7)
+Required/Optional: Required if the subject:stateOrProvinceName field is absent. Optional if
+the subject:stateOrProvinceName field is present.
+
+h. Certificate Field: subject:stateOrProvinceName (OID: 2.5.4.8)
+Required/Optional: Required if the subject:localityName field is absent. Optional if
+the subject:localityName field is present.
+*/
+
+func init() {
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cs_subject_locality_or_province_required",
+			Description:   "Non-EV Code Signing Certificate: at least one of subject:localityName or subject:stateOrProvinceName must be present.",
+			Citation:      "CABF CS BRs 7.1.4.2.3.g, 7.1.4.2.3.h",
+			Source:        lint.CABFCSBaselineRequirements,
+			EffectiveDate: util.CABF_CS_BRs_1_2_Date,
+		},
+		Lint: NewCsSubjectLocalityOrProvince,
+	})
+}
+
+type csSubjectLocalityOrProvince struct{}
+
+func NewCsSubjectLocalityOrProvince() lint.LintInterface {
+	return &csSubjectLocalityOrProvince{}
+}
+
+func (l *csSubjectLocalityOrProvince) CheckApplies(c *x509.Certificate) bool {
+	return util.IsSubscriberCert(c) && !util.IsEVCodeSigning(c.PolicyIdentifiers)
+}
+
+func (l *csSubjectLocalityOrProvince) Execute(c *x509.Certificate) *lint.LintResult {
+	if len(c.Subject.Locality) == 0 && len(c.Subject.Province) == 0 {
+		return &lint.LintResult{Status: lint.Error, Details: "at least one of subject:localityName or subject:stateOrProvinceName must be present."}
+	}
+	return &lint.LintResult{Status: lint.Pass}
+}

--- a/v3/lints/cabf_cs_br/lint_cs_subject_locality_or_province.go
+++ b/v3/lints/cabf_cs_br/lint_cs_subject_locality_or_province.go
@@ -8,13 +8,18 @@ import (
 
 /*
 7.1.4.2.3 Subject distinguished name field - Non-EV Code Signing Certificates
-g. Certificate Field: subject:localityName (OID: 2.5.4.7)
-Required/Optional: Required if the subject:stateOrProvinceName field is absent. Optional if
-the subject:stateOrProvinceName field is present.
+c. Certificate Field: subject:localityName (OID: 2.5.4.7)
+Required/Optional: Required if the subject:stateOrProvinceName field is absent. Optional if the subject:stateOrProvinceName field is present.
+Contents: If present, the subject:localityName field MUST contain the Subject’s locality information as verified under BR Section 3.2.
+If the subject:countryName field specifies the ISO 3166-1 user-assigned code of XX in accordance with BR Section 7.1.4.2.2.h., the
+subject:localityName field MAY contain the Subject’s locality and/or state or province information as verified under BR Section 3.2.2.1 or 3.2.3.
 
-h. Certificate Field: subject:stateOrProvinceName (OID: 2.5.4.8)
-Required/Optional: Required if the subject:localityName field is absent. Optional if
-the subject:localityName field is present.
+d. Certificate Field: subject:stateOrProvinceName (OID: 2.5.4.8)
+Required/Optional: Required if the subject:localityName field is absent. Optional if the subject:localityName field is present.
+Contents: If present, the subject:stateOrProvinceName field MUST contain the Subject’s state or province information as verified
+under BR Section 3.2.2.1 or 3.2.3. If the subject:countryName field specifies the ISO 3166-1 user-assigned code of XX in accordance with
+BR Section 7.1.4.2.2.h., the subject:stateOrProvinceName field MAY contain the full name of the Subject’s country information as verified
+under BR Section 3.2.2.1 or 3.2.3.
 */
 
 func init() {
@@ -22,7 +27,7 @@ func init() {
 		LintMetadata: lint.LintMetadata{
 			Name:          "e_cs_subject_locality_or_province_required",
 			Description:   "Non-EV Code Signing Certificate: at least one of subject:localityName or subject:stateOrProvinceName must be present.",
-			Citation:      "CABF CS BRs 7.1.4.2.3.g, 7.1.4.2.3.h",
+			Citation:      "CABF CS BRs 7.1.4.2.3.c, 7.1.4.2.3.d",
 			Source:        lint.CABFCSBaselineRequirements,
 			EffectiveDate: util.CABF_CS_BRs_1_2_Date,
 		},

--- a/v3/lints/cabf_cs_br/lint_cs_subject_locality_or_province_test.go
+++ b/v3/lints/cabf_cs_br/lint_cs_subject_locality_or_province_test.go
@@ -1,0 +1,45 @@
+package cabf_cs_br
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestCsSubjectLocalityOrProvince(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		InputFilename  string
+		ExpectedResult lint.LintStatus
+	}{
+		{
+			Name:           "pass - locality and province both present",
+			InputFilename:  "code_signing/validCodeSigningCertificate.pem",
+			ExpectedResult: lint.Pass,
+		},
+		{
+			Name:           "pass - locality present, province absent",
+			InputFilename:  "code_signing/cs_locality_only.pem",
+			ExpectedResult: lint.Pass,
+		},
+		{
+			Name:           "pass - province present, locality absent",
+			InputFilename:  "code_signing/cs_province_only.pem",
+			ExpectedResult: lint.Pass,
+		},
+		{
+			Name:           "fail - locality and province both absent",
+			InputFilename:  "code_signing/cs_no_locality_no_province.pem",
+			ExpectedResult: lint.Error,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := test.TestLint("e_cs_subject_locality_or_province_required", tc.InputFilename)
+			if result.Status != tc.ExpectedResult {
+				t.Errorf("expected result %v was %v - details: %v", tc.ExpectedResult, result.Status, result.Details)
+			}
+		})
+	}
+}

--- a/v3/testdata/code_signing/cs_locality_only.pem
+++ b/v3/testdata/code_signing/cs_locality_only.pem
@@ -1,0 +1,141 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            d8:4d:37:7b:13:46:33:12:2d:b6:8c:3c:13:07:e0:a5
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=OV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 15 04:38:41 2026 GMT
+            Not After : Jun 15 04:38:41 2027 GMT
+        Subject: CN=Example Co, O=Example Co, L=Mountain View, C=US, jurisdictionC=US, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:b6:20:0b:15:db:29:c8:20:3f:b4:62:d9:81:80:
+                    e1:da:e6:48:86:72:8e:66:0b:6c:66:4c:5c:01:28:
+                    e4:3a:85:db:42:67:f4:54:b8:b8:f8:79:b2:43:60:
+                    71:02:78:4b:d8:83:6c:85:dd:c0:bc:34:97:43:65:
+                    98:a4:bd:7d:07:97:06:45:0e:51:b4:98:f2:88:1d:
+                    27:b4:f5:5e:16:b2:3f:cd:06:23:20:02:48:a8:1c:
+                    1a:a0:0e:47:05:dd:4e:7e:18:c9:c4:9c:89:76:21:
+                    ec:02:d5:00:97:51:d0:92:75:ca:08:ad:81:ba:4a:
+                    73:18:ca:22:0d:e5:d8:f4:52:8f:28:13:30:71:62:
+                    97:2c:cd:34:92:d4:40:5b:c4:7b:b4:be:4f:08:bc:
+                    87:aa:83:ba:74:13:57:a7:de:ad:ca:f2:95:52:58:
+                    35:4a:28:0d:80:51:48:e0:fc:0e:fd:a5:11:bb:a4:
+                    d2:4e:50:8b:d7:32:ef:3c:08:54:09:89:d9:86:ed:
+                    97:5c:1e:c6:c7:7b:c7:fa:10:ae:a3:c2:0f:71:9a:
+                    50:8c:ba:9e:1a:09:c1:4e:63:c6:b8:7e:65:83:56:
+                    31:2a:73:77:62:4e:16:5b:25:f9:a5:e3:16:96:37:
+                    53:65:e9:ff:0e:d6:3a:03:73:2e:17:a6:d4:9a:32:
+                    fd:52:96:54:23:2e:9e:d2:6e:d4:7e:92:7d:73:69:
+                    f9:6e:23:2e:92:c4:dc:2f:f7:d0:f2:24:ae:77:21:
+                    4e:82:f2:ca:19:09:99:b9:ed:4f:64:b2:68:7d:60:
+                    fb:6f:7b:31:e3:5e:54:c2:dc:47:88:38:dc:c4:d8:
+                    f0:2d:f5:a0:62:a4:8d:63:9c:d1:f3:8b:2c:cb:04:
+                    4b:a2:c8:e3:61:a0:dc:60:48:b1:73:b8:5d:dc:d6:
+                    5a:88:35:51:e8:c4:87:c8:11:09:35:bd:42:f1:95:
+                    44:75:07:cb:cb:b5:68:5e:a8:55:69:61:94:e5:4a:
+                    44:f2:a3:52:ef:68:e7:6d:55:ed
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                90:B4:83:2D:15:B4:F1:22:8F:E6:22:6A:4C:99:03:28:17:EE:E0:F1
+            X509v3 Authority Key Identifier: 
+                E1:F4:64:D7:86:45:55:DD:34:2E:85:99:16:99:46:67:09:FA:59:D4
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.4.1
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : C4:69:28:BC:87:DE:23:B9:A8:BD:23:5A:A1:FE:67:CC:
+                                B1:54:2C:83:89:AD:3F:02:BF:4A:B5:CF:F5:06:E9:8F
+                    Timestamp : Jan 15 06:56:07.890 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:31
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 73:AA:A5:07:1D:9F:86:15:50:D5:14:69:CB:D8:9E:0A:
+                                6E:53:71:48:6F:D9:4C:96:75:28:1D:1C:EF:BD:51:17
+                    Timestamp : Jan 15 06:56:07.891 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:32
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        55:c6:6e:9d:13:c7:2a:07:58:c1:cd:f1:a5:56:da:33:dd:82:
+        9f:e0:7d:34:6c:b8:66:9c:14:1f:dd:01:90:9f:8f:cd:b7:7c:
+        34:dc:46:a1:ca:6f:18:5b:45:04:32:f8:16:81:2d:76:df:da:
+        5d:62:0a:bd:7c:14:23:2e:a4:a1:41:29:3a:76:5f:87:80:7d:
+        62:4e:1a:75:4a:f0:47:f8:75:4e:55:93:59:e8:44:1c:a5:f8:
+        df:c4:61:40:39:73:0d:f1:88:46:7e:c7:a0:fb:1c:56:05:81:
+        08:4b:03:2d:68:c2:ec:7c:4c:d6:33:82:f2:de:2e:84:d0:50:
+        fc:53:cc:5e:04:78:24:62:4a:f1:37:87:d3:f2:06:f7:42:3a:
+        72:c3:dc:2d:46:da:68:fc:57:f8:f9:31:56:03:e5:57:a1:4c:
+        19:57:1e:fc:89:94:4f:8f:30:be:cf:0a:47:d3:dd:91:d3:2d:
+        fe:66:53:ba:e2:7c:b5:f3:80:c4:d0:11:f6:d1:4b:80:e0:a0:
+        9d:93:fd:e9:52:10:df:b1:09:7d:51:33:39:eb:f9:6c:c0:b3:
+        18:55:0e:f9:7d:36:6c:5f:1f:e7:7d:14:2a:99:7e:f5:04:b9:
+        9c:c8:c8:95:9a:9a:5a:7e:b6:1c:81:9b:af:dc:65:56:24:66:
+        b3:79:19:65:e1:cd:87:22:5e:67:66:29:54:5d:f7:26:0a:71:
+        9d:ee:d8:de:d2:b5:d2:9a:84:79:25:a8:13:be:ca:90:36:55:
+        36:10:b5:f6:ad:58:fb:f8:0e:09:26:90:d5:f4:db:cd:83:0a:
+        bb:69:34:fa:a2:34:d5:c1:31:79:3a:13:7b:2e:2a:23:52:36:
+        e4:00:d8:12:e5:42:75:d5:9d:ce:08:18:fe:fb:89:23:60:df:
+        a5:54:a5:6c:c0:ec:a6:be:91:27:c9:2f:e5:cb:26:c5:c5:95:
+        bb:67:fc:c6:ce:71:6b:14:75:c3:96:e7:24:da:c7:7c:20:97:
+        06:b0:34:dc:64:5b
+-----BEGIN CERTIFICATE-----
+MIIGKjCCBJKgAwIBAgIRANhNN3sTRjMSLbaMPBMH4KUwDQYJKoZIhvcNAQELBQAw
+TDEbMBkGA1UEAxMST1YgQ29kZSBTaWduaW5nIENBMQswCQYDVQQLEwJDQTETMBEG
+A1UEChMKRXhhbXBsZSBDbzELMAkGA1UEBhMCVVMwHhcNMjYwNjE1MDQzODQxWhcN
+MjcwNjE1MDQzODQxWjCBgzETMBEGA1UEAxMKRXhhbXBsZSBDbzETMBEGA1UEChMK
+RXhhbXBsZSBDbzEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzELMAkGA1UEBhMCVVMx
+EzARBgsrBgEEAYI3PAIBAxMCVVMxHTAbBgNVBA8TFFByaXZhdGUgT3JnYW5pemF0
+aW9uMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAtiALFdspyCA/tGLZ
+gYDh2uZIhnKOZgtsZkxcASjkOoXbQmf0VLi4+HmyQ2BxAnhL2INshd3AvDSXQ2WY
+pL19B5cGRQ5RtJjyiB0ntPVeFrI/zQYjIAJIqBwaoA5HBd1OfhjJxJyJdiHsAtUA
+l1HQknXKCK2BukpzGMoiDeXY9FKPKBMwcWKXLM00ktRAW8R7tL5PCLyHqoO6dBNX
+p96tyvKVUlg1SigNgFFI4PwO/aURu6TSTlCL1zLvPAhUCYnZhu2XXB7Gx3vH+hCu
+o8IPcZpQjLqeGgnBTmPGuH5lg1YxKnN3Yk4WWyX5peMWljdTZen/DtY6A3MuF6bU
+mjL9UpZUIy6e0m7UfpJ9c2n5biMuksTcL/fQ8iSudyFOgvLKGQmZue1PZLJofWD7
+b3sx415UwtxHiDjcxNjwLfWgYqSNY5zR84ssywRLosjjYaDcYEixc7hd3NZaiDVR
+6MSHyBEJNb1C8ZVEdQfLy7VoXqhVaWGU5UpE8qNS72jnbVXtAgMBAAGjggHNMIIB
+yTAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwMwDAYDVR0TAQH/
+BAIwADAdBgNVHQ4EFgQUkLSDLRW08SKP5iJqTJkDKBfu4PEwHwYDVR0jBBgwFoAU
+4fRk14ZFVd00LoWZFplGZwn6WdQwWwYIKwYBBQUHAQEETzBNMCMGCCsGAQUFBzAB
+hhdodHRwOi8vb2NzcC5leGFtcGxlLmNvbTAmBggrBgEFBQcwAoYaaHR0cDovL2V4
+YW1wbGUuY29tL2NhMS5jcnQwEwYDVR0gBAwwCjAIBgZngQwBBAEwVwYDVR0fBFAw
+TjAloCOgIYYfaHR0cDovL2NybDEuZXhhbXBsZS5jb20vY2ExLmNybDAloCOgIYYf
+aHR0cDovL2NybDIuZXhhbXBsZS5jb20vY2ExLmNybDCBiAYKKwYBBAHWeQIEAgR6
+BHgAdgA5AMRpKLyH3iO5qL0jWqH+Z8yxVCyDia0/Ar9Ktc/1BumPAAAAAEmWAtIA
+AAQDAApzaWduYXR1cmUxADkAc6qlBx2fhhVQ1RRpy9ieCm5TcUhv2UyWdSgdHO+9
+URcAAAAASZYC0wAABAMACnNpZ25hdHVyZTIwDQYJKoZIhvcNAQELBQADggGBAFXG
+bp0TxyoHWMHN8aVW2jPdgp/gfTRsuGacFB/dAZCfj823fDTcRqHKbxhbRQQy+BaB
+LXbf2l1iCr18FCMupKFBKTp2X4eAfWJOGnVK8Ef4dU5Vk1noRByl+N/EYUA5cw3x
+iEZ+x6D7HFYFgQhLAy1owux8TNYzgvLeLoTQUPxTzF4EeCRiSvE3h9PyBvdCOnLD
+3C1G2mj8V/j5MVYD5VehTBlXHvyJlE+PML7PCkfT3ZHTLf5mU7rifLXzgMTQEfbR
+S4DgoJ2T/elSEN+xCX1RMznr+WzAsxhVDvl9NmxfH+d9FCqZfvUEuZzIyJWamlp+
+thyBm6/cZVYkZrN5GWXhzYciXmdmKVRd9yYKcZ3u2N7StdKahHklqBO+ypA2VTYQ
+tfatWPv4DgkmkNX0282DCrtpNPqiNNXBMXk6E3suKiNSNuQA2BLlQnXVnc4IGP77
+iSNg36VUpWzA7Ka+kSfJL+XLJsXFlbtn/MbOcWsUdcOW5yTax3wglwawNNxkWw==
+-----END CERTIFICATE-----

--- a/v3/testdata/code_signing/cs_no_locality_no_province.pem
+++ b/v3/testdata/code_signing/cs_no_locality_no_province.pem
@@ -1,0 +1,141 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            cf:12:49:92:fe:ec:d8:02:13:bc:35:fa:6f:30:df:0d
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=OV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 15 04:45:24 2026 GMT
+            Not After : Jun 15 04:45:24 2027 GMT
+        Subject: CN=Example Co, O=Example Co, C=US, jurisdictionC=US, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:b0:20:ba:08:be:7d:60:11:07:cf:a3:7b:7a:94:
+                    9a:19:b4:c2:5c:a4:ed:22:90:03:ee:6f:fc:67:b5:
+                    92:b8:ab:9a:b2:1b:8a:ca:ce:98:24:d4:dd:27:07:
+                    57:bb:65:ae:71:dc:13:3a:b5:bd:af:35:73:ef:75:
+                    da:77:c7:87:b6:62:da:87:1b:28:5d:0c:bb:82:bf:
+                    1d:de:27:85:f9:8e:5d:27:75:e8:a1:da:7f:89:ea:
+                    0d:65:78:f2:40:18:ae:ad:2b:0d:e0:a4:9d:48:e3:
+                    08:e6:92:6d:bb:3e:02:c3:59:69:96:42:0e:f9:bf:
+                    d6:36:fd:ed:c3:95:a5:02:20:46:7d:ce:98:81:a7:
+                    4d:f7:5d:fe:50:dc:58:e5:41:99:6f:cc:a3:78:f5:
+                    8f:28:24:05:ff:4d:9f:9b:c7:f6:d3:e5:df:37:e4:
+                    a8:c4:8e:2d:6d:b2:c7:32:47:ac:0e:a3:3c:b7:0f:
+                    75:fc:d3:53:2c:80:cc:60:71:83:a7:b3:44:0a:ad:
+                    f8:a9:15:ea:3c:7b:51:4a:4c:52:00:e7:98:3c:83:
+                    d1:f7:ce:89:8a:25:87:b5:15:ec:e9:5c:d5:cf:9f:
+                    f1:75:24:e1:40:ba:16:2f:19:01:02:35:a3:0d:62:
+                    09:ac:bf:fc:82:30:23:f3:31:97:b8:fc:69:6b:d7:
+                    05:b0:23:0d:b2:21:7f:9f:96:87:d3:ee:2b:5b:cd:
+                    3e:cb:df:7d:69:d7:a4:c1:6b:0e:6c:9f:21:b7:7d:
+                    98:cc:10:67:ce:65:26:a0:c9:2e:12:8e:bf:10:5c:
+                    80:38:f3:e7:b1:d3:70:a9:fb:ba:ad:e8:6d:2e:fa:
+                    c8:13:a8:a9:46:cc:7b:fa:a0:e2:9a:4b:93:2f:81:
+                    54:86:73:0b:e2:0a:4e:b9:60:79:ff:a2:b6:c9:de:
+                    f5:fb:70:15:78:91:ba:ae:15:0c:a8:6f:77:58:be:
+                    c9:90:06:20:79:44:98:3c:c3:a1:0d:2c:4d:e0:a3:
+                    c5:64:70:3d:00:c9:ae:1a:ba:4f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                D6:5C:45:B0:BF:92:13:82:BB:EE:D5:CC:D1:F4:78:93:AD:CE:3A:54
+            X509v3 Authority Key Identifier: 
+                5B:04:B3:58:CC:F8:0D:66:C4:0B:92:20:3F:B1:F7:1D:35:6C:31:4C
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.4.1
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : C4:69:28:BC:87:DE:23:B9:A8:BD:23:5A:A1:FE:67:CC:
+                                B1:54:2C:83:89:AD:3F:02:BF:4A:B5:CF:F5:06:E9:8F
+                    Timestamp : Jan 15 06:56:07.890 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:31
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 73:AA:A5:07:1D:9F:86:15:50:D5:14:69:CB:D8:9E:0A:
+                                6E:53:71:48:6F:D9:4C:96:75:28:1D:1C:EF:BD:51:17
+                    Timestamp : Jan 15 06:56:07.891 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:32
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        ab:b3:9e:c5:78:bd:f0:aa:c6:23:b7:fc:20:7e:f1:e8:41:f6:
+        22:1c:1a:0d:d7:61:21:9d:e5:b9:4a:6c:57:2d:c9:2f:1f:9e:
+        71:ab:4d:00:f5:35:d7:71:4b:f7:b8:0c:a8:15:bf:cd:f9:fa:
+        44:02:d0:67:fd:70:27:6b:85:05:9b:00:02:38:58:66:12:58:
+        ad:9f:72:8c:9a:58:83:31:2c:bc:cd:26:a0:bd:41:fd:f0:1d:
+        45:46:ac:bd:4a:71:d6:28:da:e8:b4:06:0d:73:b6:6b:96:ca:
+        c6:6f:18:82:85:f4:b1:36:aa:4d:7f:7a:1b:d3:8d:fa:21:af:
+        72:e9:f9:2c:10:bc:10:21:50:df:ee:ef:28:ad:cd:8e:a7:aa:
+        37:e4:10:f5:3d:e5:b3:a7:9a:ef:bf:72:ef:6c:7b:ee:53:f5:
+        8f:4b:1c:4d:c4:26:0c:65:d9:c1:80:66:36:eb:6e:0d:10:4e:
+        fd:ae:8f:97:a7:57:a1:96:83:1e:e6:78:4a:4e:83:d2:ad:b0:
+        e6:f2:73:63:24:95:0d:11:88:e5:9e:c6:d8:5b:f0:2c:b3:d3:
+        01:8f:6b:15:4b:59:2c:5e:1f:06:d4:e6:1f:f0:fb:aa:d9:4b:
+        46:21:d1:54:08:d9:22:c5:b2:8d:fa:1e:1f:1c:a0:d3:77:c4:
+        be:e8:b7:96:f5:ec:73:e2:de:25:f7:70:32:c7:87:76:a7:39:
+        ad:e4:64:ef:dd:0c:a7:0c:4b:ba:4b:bc:9d:bf:d1:c1:92:6c:
+        29:95:65:49:9f:c0:37:f1:ae:3b:40:11:4e:71:5c:18:f0:c5:
+        0c:7f:85:75:71:38:0c:1a:ea:7e:5a:0c:1d:be:65:ca:39:46:
+        3a:87:16:3c:b3:ba:0a:e5:9a:aa:39:9c:da:3c:f8:b9:31:67:
+        f1:59:e3:2f:81:a2:f9:da:d8:1e:98:6b:fc:4f:d0:e0:8e:56:
+        5b:de:44:51:37:fd:05:60:24:13:2d:2f:6c:8f:9e:bf:0d:98:
+        65:e0:b9:04:8b:16
+-----BEGIN CERTIFICATE-----
+MIIGETCCBHmgAwIBAgIRAM8SSZL+7NgCE7w1+m8w3w0wDQYJKoZIhvcNAQELBQAw
+TDEbMBkGA1UEAxMST1YgQ29kZSBTaWduaW5nIENBMQswCQYDVQQLEwJDQTETMBEG
+A1UEChMKRXhhbXBsZSBDbzELMAkGA1UEBhMCVVMwHhcNMjYwNjE1MDQ0NTI0WhcN
+MjcwNjE1MDQ0NTI0WjBrMRMwEQYDVQQDEwpFeGFtcGxlIENvMRMwEQYDVQQKEwpF
+eGFtcGxlIENvMQswCQYDVQQGEwJVUzETMBEGCysGAQQBgjc8AgEDEwJVUzEdMBsG
+A1UEDxMUUHJpdmF0ZSBPcmdhbml6YXRpb24wggGiMA0GCSqGSIb3DQEBAQUAA4IB
+jwAwggGKAoIBgQCwILoIvn1gEQfPo3t6lJoZtMJcpO0ikAPub/xntZK4q5qyG4rK
+zpgk1N0nB1e7Za5x3BM6tb2vNXPvddp3x4e2YtqHGyhdDLuCvx3eJ4X5jl0ndeih
+2n+J6g1lePJAGK6tKw3gpJ1I4wjmkm27PgLDWWmWQg75v9Y2/e3DlaUCIEZ9zpiB
+p033Xf5Q3FjlQZlvzKN49Y8oJAX/TZ+bx/bT5d835KjEji1tsscyR6wOozy3D3X8
+01MsgMxgcYOns0QKrfipFeo8e1FKTFIA55g8g9H3zomKJYe1FezpXNXPn/F1JOFA
+uhYvGQECNaMNYgmsv/yCMCPzMZe4/Glr1wWwIw2yIX+flofT7itbzT7L331p16TB
+aw5snyG3fZjMEGfOZSagyS4Sjr8QXIA48+ex03Cp+7qt6G0u+sgTqKlGzHv6oOKa
+S5MvgVSGcwviCk65YHn/orbJ3vX7cBV4kbquFQyob3dYvsmQBiB5RJg8w6ENLE3g
+o8VkcD0Aya4auk8CAwEAAaOCAc0wggHJMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUE
+DDAKBggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBTWXEWwv5ITgrvu
+1czR9HiTrc46VDAfBgNVHSMEGDAWgBRbBLNYzPgNZsQLkiA/sfcdNWwxTDBbBggr
+BgEFBQcBAQRPME0wIwYIKwYBBQUHMAGGF2h0dHA6Ly9vY3NwLmV4YW1wbGUuY29t
+MCYGCCsGAQUFBzAChhpodHRwOi8vZXhhbXBsZS5jb20vY2ExLmNydDATBgNVHSAE
+DDAKMAgGBmeBDAEEATBXBgNVHR8EUDBOMCWgI6Ahhh9odHRwOi8vY3JsMS5leGFt
+cGxlLmNvbS9jYTEuY3JsMCWgI6Ahhh9odHRwOi8vY3JsMi5leGFtcGxlLmNvbS9j
+YTEuY3JsMIGIBgorBgEEAdZ5AgQCBHoEeAB2ADkAxGkovIfeI7movSNaof5nzLFU
+LIOJrT8Cv0q1z/UG6Y8AAAAASZYC0gAABAMACnNpZ25hdHVyZTEAOQBzqqUHHZ+G
+FVDVFGnL2J4KblNxSG/ZTJZ1KB0c771RFwAAAABJlgLTAAAEAwAKc2lnbmF0dXJl
+MjANBgkqhkiG9w0BAQsFAAOCAYEAq7OexXi98KrGI7f8IH7x6EH2IhwaDddhIZ3l
+uUpsVy3JLx+ecatNAPU113FL97gMqBW/zfn6RALQZ/1wJ2uFBZsAAjhYZhJYrZ9y
+jJpYgzEsvM0moL1B/fAdRUasvUpx1ija6LQGDXO2a5bKxm8YgoX0sTaqTX96G9ON
++iGvcun5LBC8ECFQ3+7vKK3NjqeqN+QQ9T3ls6ea779y72x77lP1j0scTcQmDGXZ
+wYBmNutuDRBO/a6Pl6dXoZaDHuZ4Sk6D0q2w5vJzYySVDRGI5Z7G2FvwLLPTAY9r
+FUtZLF4fBtTmH/D7qtlLRiHRVAjZIsWyjfoeHxyg03fEvui3lvXsc+LeJfdwMseH
+dqc5reRk790MpwxLuku8nb/RwZJsKZVlSZ/AN/GuO0ARTnFcGPDFDH+FdXE4DBrq
+floMHb5lyjlGOocWPLO6CuWaqjmc2jz4uTFn8VnjL4Gi+drYHphr/E/Q4I5WW95E
+UTf9BWAkEy0vbI+evw2YZeC5BIsW
+-----END CERTIFICATE-----

--- a/v3/testdata/code_signing/cs_province_only.pem
+++ b/v3/testdata/code_signing/cs_province_only.pem
@@ -1,0 +1,142 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            e1:c4:b2:e8:5d:7c:b4:5d:49:28:63:60:20:94:6f:b0
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=OV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 15 04:40:59 2026 GMT
+            Not After : Jun 15 04:40:59 2027 GMT
+        Subject: CN=Example Co, O=Example Co, ST=California, C=US, jurisdictionC=US, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:b8:c1:b7:41:16:21:33:8c:30:10:60:a8:ec:0c:
+                    94:a7:79:8c:83:f2:f3:dc:a3:f8:bd:a0:86:75:cc:
+                    0e:7b:4d:a0:a6:13:23:bc:be:c1:3d:a6:b9:e1:49:
+                    ff:ff:53:d8:26:2c:ed:36:1f:3a:5a:fb:33:a9:25:
+                    8c:58:90:3c:ce:25:6d:3a:f4:21:4f:ff:24:6a:f1:
+                    ce:67:97:51:ad:b9:d5:9a:82:2b:ee:42:6e:4c:cc:
+                    e9:16:f2:c4:7c:1c:10:c6:3e:14:2a:fa:a6:4b:a2:
+                    2a:b6:56:e0:1f:53:8b:4c:4f:b7:17:72:17:48:df:
+                    3d:bc:5a:59:ad:a8:ad:d8:76:09:4c:a4:3d:df:30:
+                    37:90:f7:d9:b2:cf:5a:5f:b6:ec:48:5d:7d:0c:7a:
+                    df:ef:05:2e:17:3a:8c:fa:de:a7:6a:9b:07:32:ee:
+                    66:dd:09:55:bd:c7:87:d1:7b:f4:18:28:00:27:01:
+                    32:d2:3c:08:f0:5d:58:c7:6c:65:8b:c2:a5:73:f1:
+                    73:a7:d3:2b:23:ed:19:21:27:41:7e:a4:a0:28:91:
+                    76:99:8a:a0:b3:c3:bb:01:bc:c7:61:5b:9a:a9:2a:
+                    30:dd:8e:7d:53:f7:a0:6a:ad:6f:bd:2b:f5:eb:0e:
+                    82:4c:19:b2:1f:37:da:1c:94:9b:9f:9d:27:0d:b7:
+                    74:e1:87:99:07:57:21:82:39:95:ea:2a:73:86:23:
+                    96:42:39:c1:9c:9b:ba:fd:1a:4d:60:7c:8c:19:83:
+                    a3:39:dd:5c:a8:b7:62:34:66:5b:8c:b1:c2:2e:f5:
+                    38:e4:78:04:8d:98:46:66:b4:fb:50:80:70:1d:9c:
+                    a9:6b:1d:a7:08:27:0c:cc:99:00:f2:f7:a7:ce:e1:
+                    30:b9:54:14:f0:b9:5c:d6:50:f3:f8:ae:fc:06:6f:
+                    79:21:0a:7d:62:33:e3:0a:ca:c6:3a:28:cb:e2:bc:
+                    13:7e:ca:cf:91:35:3e:34:98:e2:5e:ab:bf:7a:60:
+                    ba:0a:c8:8b:d4:0d:4e:3d:a0:6d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                1C:EA:C0:EC:98:8A:FB:1B:AF:CB:AD:10:57:8A:6F:59:3C:DB:84:60
+            X509v3 Authority Key Identifier: 
+                53:D8:C9:F2:EE:98:66:0A:7E:F1:E3:BF:F7:BD:11:F6:A2:37:5C:10
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.4.1
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : C4:69:28:BC:87:DE:23:B9:A8:BD:23:5A:A1:FE:67:CC:
+                                B1:54:2C:83:89:AD:3F:02:BF:4A:B5:CF:F5:06:E9:8F
+                    Timestamp : Jan 15 06:56:07.890 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:31
+
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 73:AA:A5:07:1D:9F:86:15:50:D5:14:69:CB:D8:9E:0A:
+                                6E:53:71:48:6F:D9:4C:96:75:28:1D:1C:EF:BD:51:17
+                    Timestamp : Jan 15 06:56:07.891 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:32
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        2d:c3:ba:7c:05:80:cb:91:a2:ad:6c:92:4a:4e:28:1f:1d:c2:
+        a6:45:7d:89:f8:4b:03:43:5f:df:03:e2:e9:cc:10:e4:da:76:
+        14:fc:3d:42:3f:0e:94:f6:4d:09:9f:43:86:7b:02:2f:6b:1b:
+        21:10:f1:a8:1a:92:90:4a:63:cc:bc:f3:5e:e7:06:87:f9:04:
+        70:ac:e6:36:12:f1:98:21:57:52:61:88:7f:9a:09:7d:2d:cb:
+        77:fe:a5:ed:3e:0e:50:fc:7a:4f:73:bd:37:c4:87:44:97:56:
+        aa:6f:1a:98:99:ed:5d:5c:d9:25:9a:70:64:0d:12:a6:8f:a2:
+        ab:c2:d8:af:17:80:0d:6c:16:74:86:ce:16:ac:25:84:fc:0b:
+        ab:a7:bd:ab:9b:9f:d0:55:f6:d2:87:33:e6:a6:59:ee:33:44:
+        a9:42:d0:9a:a2:5a:95:f6:99:9a:3c:25:87:73:b1:89:56:1b:
+        a4:6e:af:be:7c:f3:37:4a:c3:9d:92:89:6a:ef:36:fb:a4:cb:
+        f1:00:58:9d:6d:0d:ec:d0:1a:1a:91:33:eb:8e:53:d8:07:7a:
+        a5:a8:5c:10:03:8e:e7:a0:c7:c7:5b:9b:58:dd:f9:e6:b1:10:
+        f8:06:ad:78:08:53:cc:47:c8:f8:5a:aa:88:08:e0:8f:6d:88:
+        e4:5b:67:2f:3d:4b:c0:f7:22:89:d8:4c:f2:67:89:e9:90:6c:
+        7d:88:8a:0e:42:c9:c4:f8:73:3e:c7:b2:37:53:0a:75:3f:3c:
+        6a:c1:e1:33:7d:76:4e:bb:b7:c7:d8:bc:52:2b:a6:2d:8f:12:
+        ba:4d:26:ce:7a:24:e1:b4:9e:6e:d2:da:00:e4:41:3e:be:44:
+        8b:90:60:03:f3:37:74:32:cd:a6:10:a8:9d:c5:12:a4:ea:ad:
+        f9:86:c3:48:24:84:39:8a:00:6c:4c:58:97:3e:f5:50:62:39:
+        41:14:92:b4:08:bc:cb:9e:3b:d3:52:56:6c:46:ee:c6:63:7a:
+        62:2d:77:1f:e5:b0
+-----BEGIN CERTIFICATE-----
+MIIGJzCCBI+gAwIBAgIRAOHEsuhdfLRdSShjYCCUb7AwDQYJKoZIhvcNAQELBQAw
+TDEbMBkGA1UEAxMST1YgQ29kZSBTaWduaW5nIENBMQswCQYDVQQLEwJDQTETMBEG
+A1UEChMKRXhhbXBsZSBDbzELMAkGA1UEBhMCVVMwHhcNMjYwNjE1MDQ0MDU5WhcN
+MjcwNjE1MDQ0MDU5WjCBgDETMBEGA1UEAxMKRXhhbXBsZSBDbzETMBEGA1UEChMK
+RXhhbXBsZSBDbzETMBEGA1UECBMKQ2FsaWZvcm5pYTELMAkGA1UEBhMCVVMxEzAR
+BgsrBgEEAYI3PAIBAxMCVVMxHTAbBgNVBA8TFFByaXZhdGUgT3JnYW5pemF0aW9u
+MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAuMG3QRYhM4wwEGCo7AyU
+p3mMg/Lz3KP4vaCGdcwOe02gphMjvL7BPaa54Un//1PYJiztNh86WvszqSWMWJA8
+ziVtOvQhT/8kavHOZ5dRrbnVmoIr7kJuTMzpFvLEfBwQxj4UKvqmS6IqtlbgH1OL
+TE+3F3IXSN89vFpZrait2HYJTKQ93zA3kPfZss9aX7bsSF19DHrf7wUuFzqM+t6n
+apsHMu5m3QlVvceH0Xv0GCgAJwEy0jwI8F1Yx2xli8Klc/Fzp9MrI+0ZISdBfqSg
+KJF2mYqgs8O7AbzHYVuaqSow3Y59U/egaq1vvSv16w6CTBmyHzfaHJSbn50nDbd0
+4YeZB1chgjmV6ipzhiOWQjnBnJu6/RpNYHyMGYOjOd1cqLdiNGZbjLHCLvU45HgE
+jZhGZrT7UIBwHZypax2nCCcMzJkA8venzuEwuVQU8Llc1lDz+K78Bm95IQp9YjPj
+CsrGOijL4rwTfsrPkTU+NJjiXqu/emC6CsiL1A1OPaBtAgMBAAGjggHNMIIByTAO
+BgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwMwDAYDVR0TAQH/BAIw
+ADAdBgNVHQ4EFgQUHOrA7JiK+xuvy60QV4pvWTzbhGAwHwYDVR0jBBgwFoAUU9jJ
+8u6YZgp+8eO/970R9qI3XBAwWwYIKwYBBQUHAQEETzBNMCMGCCsGAQUFBzABhhdo
+dHRwOi8vb2NzcC5leGFtcGxlLmNvbTAmBggrBgEFBQcwAoYaaHR0cDovL2V4YW1w
+bGUuY29tL2NhMS5jcnQwEwYDVR0gBAwwCjAIBgZngQwBBAEwVwYDVR0fBFAwTjAl
+oCOgIYYfaHR0cDovL2NybDEuZXhhbXBsZS5jb20vY2ExLmNybDAloCOgIYYfaHR0
+cDovL2NybDIuZXhhbXBsZS5jb20vY2ExLmNybDCBiAYKKwYBBAHWeQIEAgR6BHgA
+dgA5AMRpKLyH3iO5qL0jWqH+Z8yxVCyDia0/Ar9Ktc/1BumPAAAAAEmWAtIAAAQD
+AApzaWduYXR1cmUxADkAc6qlBx2fhhVQ1RRpy9ieCm5TcUhv2UyWdSgdHO+9URcA
+AAAASZYC0wAABAMACnNpZ25hdHVyZTIwDQYJKoZIhvcNAQELBQADggGBAC3DunwF
+gMuRoq1skkpOKB8dwqZFfYn4SwNDX98D4unMEOTadhT8PUI/DpT2TQmfQ4Z7Ai9r
+GyEQ8agakpBKY8y8817nBof5BHCs5jYS8ZghV1JhiH+aCX0ty3f+pe0+DlD8ek9z
+vTfEh0SXVqpvGpiZ7V1c2SWacGQNEqaPoqvC2K8XgA1sFnSGzhasJYT8C6unvaub
+n9BV9tKHM+amWe4zRKlC0JqiWpX2mZo8JYdzsYlWG6Rur7588zdKw52SiWrvNvuk
+y/EAWJ1tDezQGhqRM+uOU9gHeqWoXBADjuegx8dbm1jd+eaxEPgGrXgIU8xHyPha
+qogI4I9tiORbZy89S8D3IonYTPJniemQbH2Iig5CycT4cz7HsjdTCnU/PGrB4TN9
+dk67t8fYvFIrpi2PErpNJs56JOG0nm7S2gDkQT6+RIuQYAPzN3QyzaYQqJ3FEqTq
+rfmGw0gkhDmKAGxMWJc+9VBiOUEUkrQIvMueO9NSVmxG7sZjemItdx/lsA==
+-----END CERTIFICATE-----

--- a/v3/util/cs.go
+++ b/v3/util/cs.go
@@ -16,3 +16,13 @@ func IsCodeSigning(policies []asn1.ObjectIdentifier) bool {
 
 	return false
 }
+
+func IsEVCodeSigning(policies []asn1.ObjectIdentifier) bool {
+	for _, policy := range policies {
+		if policy.String() == evCodeSigningPolicy {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Added lint to check that either province or locality is included in the sdn.

### Reference and sections
https://cabforum.org/working-groups/code-signing/requirements/

7.1.4.2.3 Subject distinguished name field - Non-EV Code Signing Certificates 

> c. Certificate Field: subject:localityName (OID: 2.5.4.7)
> Required/Optional: Required if the subject:stateOrProvinceName field is absent. Optional if the subject:stateOrProvinceName field is present.
> Contents: If present, the subject:localityName field MUST contain the Subject’s locality information as verified under BR Section 3.2. If the subject:countryName field specifies the ISO 3166-1 user-assigned code of XX in accordance with BR Section 7.1.4.2.2.h., the subject:localityName field MAY contain the Subject’s locality and/or state or province information as verified under BR Section 3.2.2.1 or 3.2.3.
> 
> d. Certificate Field: subject:stateOrProvinceName (OID: 2.5.4.8)
> Required/Optional: Required if the subject:localityName field is absent. Optional if the subject:localityName field is present.
> Contents: If present, the subject:stateOrProvinceName field MUST contain the Subject’s state or province information as verified under BR Section 3.2.2.1 or 3.2.3. If the subject:countryName field specifies the ISO 3166-1 user-assigned code of XX in accordance with BR Section 7.1.4.2.2.h., the subject:stateOrProvinceName field MAY contain the full name of the Subject’s country information as verified under BR Section 3.2.2.1 or 3.2.3.