### PR TITLE
Add subject country lint

### DIFF
--- a/v3/lints/cabf_cs_br/lint_cs_subject_country_name.go
+++ b/v3/lints/cabf_cs_br/lint_cs_subject_country_name.go
@@ -36,7 +36,7 @@ func NewCsSubjectCountryName() lint.LintInterface {
 }
 
 func (l *csSubjectCountryName) CheckApplies(c *x509.Certificate) bool {
-	return util.IsSubscriberCert(c)
+	return util.IsSubscriberCert(c) && !util.IsEVCodeSigning(c.PolicyIdentifiers)
 }
 
 func (l *csSubjectCountryName) Execute(c *x509.Certificate) *lint.LintResult {

--- a/v3/lints/cabf_cs_br/lint_cs_subject_country_name.go
+++ b/v3/lints/cabf_cs_br/lint_cs_subject_country_name.go
@@ -1,0 +1,52 @@
+package cabf_cs_br
+
+import (
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+/*
+7.1.4.2.3 Subject distinguished name field - Non-EV Code Signing Certificates
+f. Certificate Field: subject:countryName (OID: 2.5.4.6)
+Required/Optional: Required
+Contents: The subject:countryName MUST contain the two-letter ISO 3166-1 country code associated with the location of
+the Subject verified under BR Section 3.2.2.3. If a Country is not represented by an official ISO 3166-1 country code,
+the CA MAY specify the ISO 3166-1 user-assigned code of XX indicating that an official ISO 3166-1 alpha-2 code has not
+been assigned.
+*/
+
+func init() {
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_cs_subject_country_name",
+			Description:   "The subject:countryName MUST contain the two-letter ISO 3166-1 country code associated with the location of the Subject verified under BR Section 3.2.2.3.",
+			Citation:      "CABF CS BRs 7.1.4.2.3.f",
+			Source:        lint.CABFCSBaselineRequirements,
+			EffectiveDate: util.CABF_CS_BRs_1_2_Date,
+		},
+		Lint: NewCsSubjectCountryName,
+	})
+}
+
+type csSubjectCountryName struct{}
+
+func NewCsSubjectCountryName() lint.LintInterface {
+	return &csSubjectCountryName{}
+}
+
+func (l *csSubjectCountryName) CheckApplies(c *x509.Certificate) bool {
+	return util.IsSubscriberCert(c)
+}
+
+func (l *csSubjectCountryName) Execute(c *x509.Certificate) *lint.LintResult {
+	if len(c.Subject.Country) == 0 {
+		return &lint.LintResult{Status: lint.Error, Details: "No country name found in subject."}
+	}
+
+	if !util.IsISOCountryCode(c.Subject.Country[0]) && c.Subject.Country[0] != "XX" {
+		return &lint.LintResult{Status: lint.Error, Details: "Country name in subject is not a valid ISO 3166-1 alpha-2 code."}
+	}
+
+	return &lint.LintResult{Status: lint.Pass}
+}

--- a/v3/lints/cabf_cs_br/lint_cs_subject_country_name_test.go
+++ b/v3/lints/cabf_cs_br/lint_cs_subject_country_name_test.go
@@ -1,0 +1,45 @@
+package cabf_cs_br
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestCsSubjectCountryName(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		InputFilename  string
+		ExpectedResult lint.LintStatus
+	}{
+		{
+			Name:           "pass - code signing certificate with RSA key size >= 3072",
+			InputFilename:  "code_signing/validCodeSigningCertificate.pem",
+			ExpectedResult: lint.Pass,
+		},
+		{
+			Name:           "fail - code signing certificate with no countryName in subject",
+			InputFilename:  "code_signing/no_country_name_in_subject.pem",
+			ExpectedResult: lint.Error,
+		},
+		{
+			Name:           "fail - code signing certificate with non-iso countryName in subject",
+			InputFilename:  "code_signing/non_iso_country_name_in_subject.pem",
+			ExpectedResult: lint.Error,
+		},
+		{
+			Name:           "fail - code signing certificate with only metadata in countryName",
+			InputFilename:  "code_signing/only_meta_data_in_country_name.pem",
+			ExpectedResult: lint.Error,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := test.TestLint("e_cs_subject_country_name", tc.InputFilename)
+			if result.Status != tc.ExpectedResult {
+				t.Errorf("expected result %v was %v - details: %v", tc.ExpectedResult, result.Status, result.Details)
+			}
+		})
+	}
+}

--- a/v3/lints/cabf_cs_br/lint_cs_subject_country_name_test.go
+++ b/v3/lints/cabf_cs_br/lint_cs_subject_country_name_test.go
@@ -33,6 +33,11 @@ func TestCsSubjectCountryName(t *testing.T) {
 			InputFilename:  "code_signing/only_meta_data_in_country_name.pem",
 			ExpectedResult: lint.Error,
 		},
+		{
+			Name:           "NA - code signing certificate with valid EV code signing",
+			InputFilename:  "code_signing/valid_ev_code_signing.pem",
+			ExpectedResult: lint.NA,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {

--- a/v3/testdata/code_signing/no_country_name_in_subject.pem
+++ b/v3/testdata/code_signing/no_country_name_in_subject.pem
@@ -1,0 +1,142 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            93:f6:f5:1e:7d:f3:1e:6e:c7:6d:81:2a:b8:2c:17:28
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=OV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: May 24 04:57:08 2026 GMT
+            Not After : May 24 04:57:08 2027 GMT
+        Subject: CN=Example Co, O=Example Co, L=Mountain View, ST=California, jurisdictionC=US, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:c4:2e:92:38:71:7c:d2:e6:2a:24:b0:43:e4:23:
+                    06:0d:ab:c8:9c:64:cb:7b:ab:c4:c3:61:6f:84:fb:
+                    44:de:bc:1f:f8:da:99:d7:7b:24:be:ac:91:52:c9:
+                    a4:df:92:b2:41:82:d2:7d:30:e0:f9:12:59:1a:fb:
+                    32:93:87:b2:4f:2a:ad:34:de:61:cf:b2:78:c7:f3:
+                    1f:ab:33:20:40:65:3a:01:d5:59:e6:2e:94:d2:c1:
+                    42:6f:9e:9a:e3:66:38:3b:12:c6:4f:a5:50:58:7f:
+                    7c:13:7d:fe:78:44:03:9c:ef:c2:40:8b:e4:3c:de:
+                    5e:bd:5d:11:90:67:0d:e1:83:1f:4b:0d:6f:94:8c:
+                    2e:4b:a9:a4:78:e3:a1:a8:83:4f:b6:41:bf:a0:96:
+                    37:e1:6d:78:e3:08:8a:52:a1:5a:c7:91:66:87:f1:
+                    3f:c9:6c:94:54:5f:8a:56:29:c2:af:a1:c0:d8:d5:
+                    fe:82:ab:17:82:cc:af:39:63:d6:34:a1:99:c6:a4:
+                    53:00:81:38:38:71:97:58:1a:fd:68:6c:ad:9a:50:
+                    77:32:1a:1f:dc:72:06:07:0c:a2:e0:70:a0:f0:30:
+                    4f:9f:ac:0f:17:73:72:22:3a:62:43:b4:f5:ef:36:
+                    41:98:ed:03:a7:12:a8:2c:87:07:87:37:23:2c:62:
+                    68:81:f2:a1:f8:b1:bd:ac:e4:42:15:27:54:dd:b5:
+                    0a:c4:ce:f5:75:4d:28:df:5c:8c:5e:a0:15:3d:e7:
+                    21:38:c2:da:5b:aa:95:79:29:21:2a:90:e4:7d:65:
+                    2a:b4:6a:9e:e2:92:e4:57:00:d5:93:9f:3f:78:7e:
+                    4e:6d:0d:50:8d:09:c9:68:d6:1f:3b:a7:a0:42:d4:
+                    1c:c8:0a:74:28:4d:64:38:29:1a:f8:5c:f5:7e:2d:
+                    83:56:be:18:26:ac:1d:b5:fd:f0:04:69:c1:92:d7:
+                    c2:15:81:ef:8d:d0:73:22:5d:4f:ea:d2:1e:c0:99:
+                    6e:93:96:22:47:7e:1f:84:d6:4f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                19:C6:A1:78:E3:83:BD:62:9B:47:D8:09:75:5A:65:26:4D:F6:91:27
+            X509v3 Authority Key Identifier: 
+                ED:6F:9D:4E:15:24:E2:55:EE:A3:01:6A:6D:21:91:E5:82:9C:37:CE
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.4.1
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : C4:69:28:BC:87:DE:23:B9:A8:BD:23:5A:A1:FE:67:CC:
+                                B1:54:2C:83:89:AD:3F:02:BF:4A:B5:CF:F5:06:E9:8F
+                    Timestamp : Jan 15 06:56:07.890 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:31
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 73:AA:A5:07:1D:9F:86:15:50:D5:14:69:CB:D8:9E:0A:
+                                6E:53:71:48:6F:D9:4C:96:75:28:1D:1C:EF:BD:51:17
+                    Timestamp : Jan 15 06:56:07.891 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:32
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        47:9c:ef:38:00:e2:af:82:08:ee:e6:05:f0:b9:fa:c8:2d:f2:
+        3b:de:1a:c0:78:3b:1d:61:be:f0:c8:5e:20:dd:57:43:15:b8:
+        56:55:96:ae:74:df:51:ad:db:1e:e5:d8:5d:d6:1b:a8:06:d1:
+        76:b1:1a:3b:aa:5e:1d:ea:85:0a:8c:ca:78:dc:55:ce:7f:f1:
+        41:de:ad:0d:bc:01:74:28:a9:4e:ce:24:d3:f7:98:ff:cf:21:
+        a3:1a:d6:e8:c0:71:19:a3:92:20:c5:89:c2:84:fa:15:1e:50:
+        b8:94:dc:f6:06:f3:35:aa:45:ad:4d:73:91:67:ee:44:b0:99:
+        5e:b9:d7:8a:0b:ea:02:8a:00:98:1d:ac:aa:8e:0e:f5:d0:d4:
+        2b:2c:1f:7d:80:70:4b:65:78:7f:af:7f:69:42:b0:08:9c:41:
+        77:74:7f:38:3c:31:29:16:b4:39:11:88:72:1c:c3:90:f3:01:
+        d4:da:ee:57:ae:69:5d:89:21:05:d3:7a:ac:a4:65:2e:d2:bf:
+        77:86:b6:a7:70:b9:d6:31:8e:a5:11:a2:00:92:6f:ec:47:9e:
+        77:e8:12:a0:41:88:95:78:9d:3b:ee:ab:92:52:da:a9:48:ff:
+        ee:d9:b3:59:b2:da:f7:92:d5:a6:7d:36:47:2d:e0:e5:2e:f0:
+        29:ab:66:1e:75:e4:db:86:99:97:5f:00:78:51:56:65:54:5a:
+        38:fa:65:90:a6:e0:93:8a:f6:ad:57:82:02:9a:6a:35:9b:76:
+        c1:10:d0:27:af:b7:f3:88:94:ca:f4:62:3b:24:90:b7:9a:fa:
+        35:e3:59:59:e1:0e:99:ea:54:42:4d:b4:cc:5f:d3:96:3d:93:
+        29:11:ba:70:a3:84:cc:0c:90:36:d7:a1:6e:10:44:a3:0b:f5:
+        0f:ea:61:0c:db:d6:48:01:6c:a6:1b:82:ce:0c:a4:a1:f5:90:
+        48:3b:84:87:46:7c:4d:e2:20:b4:df:63:57:4c:25:0a:b9:47:
+        23:4e:22:b3:50:dd
+-----BEGIN CERTIFICATE-----
+MIIGMjCCBJqgAwIBAgIRAJP29R598x5ux22BKrgsFygwDQYJKoZIhvcNAQELBQAw
+TDEbMBkGA1UEAxMST1YgQ29kZSBTaWduaW5nIENBMQswCQYDVQQLEwJDQTETMBEG
+A1UEChMKRXhhbXBsZSBDbzELMAkGA1UEBhMCVVMwHhcNMjYwNTI0MDQ1NzA4WhcN
+MjcwNTI0MDQ1NzA4WjCBizETMBEGA1UEAxMKRXhhbXBsZSBDbzETMBEGA1UEChMK
+RXhhbXBsZSBDbzEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzETMBEGA1UECBMKQ2Fs
+aWZvcm5pYTETMBEGCysGAQQBgjc8AgEDEwJVUzEdMBsGA1UEDxMUUHJpdmF0ZSBP
+cmdhbml6YXRpb24wggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQDELpI4
+cXzS5ioksEPkIwYNq8icZMt7q8TDYW+E+0TevB/42pnXeyS+rJFSyaTfkrJBgtJ9
+MOD5Elka+zKTh7JPKq003mHPsnjH8x+rMyBAZToB1VnmLpTSwUJvnprjZjg7EsZP
+pVBYf3wTff54RAOc78JAi+Q83l69XRGQZw3hgx9LDW+UjC5LqaR446Gog0+2Qb+g
+ljfhbXjjCIpSoVrHkWaH8T/JbJRUX4pWKcKvocDY1f6CqxeCzK85Y9Y0oZnGpFMA
+gTg4cZdYGv1obK2aUHcyGh/ccgYHDKLgcKDwME+frA8Xc3IiOmJDtPXvNkGY7QOn
+EqgshweHNyMsYmiB8qH4sb2s5EIVJ1TdtQrEzvV1TSjfXIxeoBU95yE4wtpbqpV5
+KSEqkOR9ZSq0ap7ikuRXANWTnz94fk5tDVCNCclo1h87p6BC1BzICnQoTWQ4KRr4
+XPV+LYNWvhgmrB21/fAEacGS18IVge+N0HMiXU/q0h7AmW6TliJHfh+E1k8CAwEA
+AaOCAc0wggHJMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAM
+BgNVHRMBAf8EAjAAMB0GA1UdDgQWBBQZxqF444O9YptH2Al1WmUmTfaRJzAfBgNV
+HSMEGDAWgBTtb51OFSTiVe6jAWptIZHlgpw3zjBbBggrBgEFBQcBAQRPME0wIwYI
+KwYBBQUHMAGGF2h0dHA6Ly9vY3NwLmV4YW1wbGUuY29tMCYGCCsGAQUFBzAChhpo
+dHRwOi8vZXhhbXBsZS5jb20vY2ExLmNydDATBgNVHSAEDDAKMAgGBmeBDAEEATBX
+BgNVHR8EUDBOMCWgI6Ahhh9odHRwOi8vY3JsMS5leGFtcGxlLmNvbS9jYTEuY3Js
+MCWgI6Ahhh9odHRwOi8vY3JsMi5leGFtcGxlLmNvbS9jYTEuY3JsMIGIBgorBgEE
+AdZ5AgQCBHoEeAB2ADkAxGkovIfeI7movSNaof5nzLFULIOJrT8Cv0q1z/UG6Y8A
+AAAASZYC0gAABAMACnNpZ25hdHVyZTEAOQBzqqUHHZ+GFVDVFGnL2J4KblNxSG/Z
+TJZ1KB0c771RFwAAAABJlgLTAAAEAwAKc2lnbmF0dXJlMjANBgkqhkiG9w0BAQsF
+AAOCAYEAR5zvOADir4II7uYF8Ln6yC3yO94awHg7HWG+8MheIN1XQxW4VlWWrnTf
+Ua3bHuXYXdYbqAbRdrEaO6peHeqFCozKeNxVzn/xQd6tDbwBdCipTs4k0/eY/88h
+oxrW6MBxGaOSIMWJwoT6FR5QuJTc9gbzNapFrU1zkWfuRLCZXrnXigvqAooAmB2s
+qo4O9dDUKywffYBwS2V4f69/aUKwCJxBd3R/ODwxKRa0ORGIchzDkPMB1NruV65p
+XYkhBdN6rKRlLtK/d4a2p3C51jGOpRGiAJJv7Eeed+gSoEGIlXidO+6rklLaqUj/
+7tmzWbLa95LVpn02Ry3g5S7wKatmHnXk24aZl18AeFFWZVRaOPplkKbgk4r2rVeC
+AppqNZt2wRDQJ6+384iUyvRiOySQt5r6NeNZWeEOmepUQk20zF/Tlj2TKRG6cKOE
+zAyQNtehbhBEowv1D+phDNvWSAFsphuCzgykofWQSDuEh0Z8TeIgtN9jV0wlCrlH
+I04is1Dd
+-----END CERTIFICATE-----

--- a/v3/testdata/code_signing/non_iso_country_name_in_subject.pem
+++ b/v3/testdata/code_signing/non_iso_country_name_in_subject.pem
@@ -1,0 +1,142 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            62:ae:e4:11:d1:bc:46:d8:6c:a2:26:44:41:78:98:3e
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=OV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 21 01:48:33 2026 GMT
+            Not After : Jun 21 01:48:33 2027 GMT
+        Subject: CN=Example Co, O=Example Co, L=Mountain View, ST=California, C=ZZ, jurisdictionC=US, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:b6:88:54:c1:c2:b6:6e:a5:44:a3:c3:bd:e8:31:
+                    99:c9:7e:f8:76:15:9e:1e:86:e9:51:d8:0d:62:15:
+                    62:8f:9a:74:c9:a5:67:4f:98:9d:e7:eb:31:59:7d:
+                    bb:58:b4:b9:44:0d:1f:3a:b2:58:13:5b:f6:0a:79:
+                    1d:94:8d:2f:e2:d9:0c:c4:22:32:49:78:f4:4f:3c:
+                    c0:c3:55:77:c7:9b:50:47:71:1f:f4:54:0d:47:8d:
+                    18:6c:c4:ba:6b:f4:38:0e:fe:41:84:86:fb:23:fd:
+                    d7:5a:79:3a:ce:a4:4b:4a:e2:fa:f4:d6:70:6d:a9:
+                    11:54:8d:6d:fb:9e:41:47:d1:98:e4:72:63:20:37:
+                    5a:98:5c:a1:50:47:dd:ff:5a:ce:64:bf:7d:0f:50:
+                    2e:32:35:33:cb:c8:33:b6:85:6f:c2:dc:f8:2e:c7:
+                    68:a4:4f:79:00:0d:32:cc:f9:73:19:db:8a:f0:55:
+                    28:19:10:94:93:9e:cc:53:29:9e:94:81:46:b9:f2:
+                    be:14:31:62:08:1c:1b:95:2c:01:39:48:13:05:f5:
+                    d3:2b:76:a1:85:66:4a:52:f2:2c:54:2f:47:81:98:
+                    28:cd:2c:40:35:a9:3a:8c:d9:d8:81:88:2f:b6:c9:
+                    b3:cc:a8:eb:f3:10:11:65:22:df:4f:96:a7:b1:85:
+                    20:c5:77:59:86:b6:23:43:99:49:42:3d:cb:34:e5:
+                    a7:f3:67:c3:43:fc:9c:6d:04:b6:da:cc:98:09:35:
+                    7f:62:c2:ac:c2:f1:a2:50:b3:e8:ca:03:96:68:c3:
+                    f0:fb:ef:65:a8:f0:58:93:85:ee:e7:cc:08:6d:9d:
+                    d1:6f:16:16:e3:78:88:60:7c:87:f3:c9:b6:9f:4c:
+                    a0:d9:d1:b5:69:98:88:dc:aa:e5:68:9c:0b:07:38:
+                    2b:96:4b:76:79:21:ff:93:9d:57:f3:72:71:15:be:
+                    6e:0a:2a:01:92:9d:e3:1f:33:00:35:d6:b4:71:b9:
+                    04:9c:f6:bf:cc:b3:bb:65:5e:e1
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                1B:63:EE:BC:37:F5:16:49:FA:A8:48:A0:5A:4B:C2:55:2B:D2:59:96
+            X509v3 Authority Key Identifier: 
+                05:D1:C4:D2:B5:A7:30:2F:7C:05:F9:A9:88:04:6A:F2:DE:BD:6F:57
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.4.1
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : C4:69:28:BC:87:DE:23:B9:A8:BD:23:5A:A1:FE:67:CC:
+                                B1:54:2C:83:89:AD:3F:02:BF:4A:B5:CF:F5:06:E9:8F
+                    Timestamp : Jan 15 06:56:07.890 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:31
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 73:AA:A5:07:1D:9F:86:15:50:D5:14:69:CB:D8:9E:0A:
+                                6E:53:71:48:6F:D9:4C:96:75:28:1D:1C:EF:BD:51:17
+                    Timestamp : Jan 15 06:56:07.891 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:32
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        16:61:2c:fd:b4:3f:07:25:c9:bc:91:31:cf:a0:82:90:6f:7f:
+        f7:57:fa:2c:77:7d:da:8e:3d:62:10:0b:46:d8:23:fd:54:89:
+        de:f9:a5:23:1e:a8:be:14:d9:aa:aa:d0:55:d0:50:4b:93:8c:
+        27:ad:a2:76:70:0d:b7:6c:30:c6:96:19:a9:76:36:7a:a5:94:
+        15:f3:29:dc:22:f5:2b:b8:8a:05:bf:47:07:04:36:9e:65:cc:
+        5a:7d:66:8b:0d:dc:2d:18:be:dd:fe:f6:0a:aa:f3:fa:c0:f7:
+        ae:61:3f:97:d2:2c:46:9a:70:be:74:5e:6d:5a:47:08:db:2f:
+        6a:2f:85:4a:d6:62:85:ba:e1:7e:75:67:42:f8:7d:f0:64:59:
+        4f:4b:c0:e2:e0:4c:81:04:d8:06:f4:44:f7:11:74:ca:2f:83:
+        9c:3b:f3:dc:36:24:c1:79:7a:7f:e4:08:af:ba:31:02:9e:b6:
+        0b:82:78:cc:bb:f9:34:c0:d0:f9:21:e6:96:40:cf:24:66:b2:
+        aa:6a:de:65:39:f1:de:a8:3e:ad:14:52:e8:c9:9f:46:93:db:
+        a4:cd:c4:68:3c:dd:b3:29:d7:bc:96:13:02:8f:f5:8a:2b:e8:
+        52:29:a6:62:ee:9f:27:28:59:06:d2:59:2f:e4:60:63:15:c9:
+        a3:72:42:ee:0d:cc:bd:61:b2:e6:e8:b1:e2:67:19:27:84:cb:
+        38:f6:3c:38:ec:3f:80:e9:cd:e3:55:2d:7e:ec:ff:82:e7:cf:
+        0b:12:0d:e8:7d:7b:ed:32:6f:c4:65:d4:c9:e7:d6:2f:37:07:
+        1f:f9:e8:b7:2a:ac:bf:f6:cc:e4:d1:d0:3b:cc:37:6f:16:69:
+        d2:cf:a9:1b:0b:c9:89:f0:02:f2:77:c4:fd:ff:c1:93:13:a1:
+        0b:31:bf:96:93:64:66:7a:bd:46:50:0c:da:bf:93:f1:8b:57:
+        bd:4e:71:3f:2e:ab:92:c0:9b:d1:29:7a:45:47:7d:dc:44:f0:
+        b9:97:48:37:7a:30
+-----BEGIN CERTIFICATE-----
+MIIGPjCCBKagAwIBAgIQYq7kEdG8RthsoiZEQXiYPjANBgkqhkiG9w0BAQsFADBM
+MRswGQYDVQQDExJPViBDb2RlIFNpZ25pbmcgQ0ExCzAJBgNVBAsTAkNBMRMwEQYD
+VQQKEwpFeGFtcGxlIENvMQswCQYDVQQGEwJVUzAeFw0yNjA2MjEwMTQ4MzNaFw0y
+NzA2MjEwMTQ4MzNaMIGYMRMwEQYDVQQDEwpFeGFtcGxlIENvMRMwEQYDVQQKEwpF
+eGFtcGxlIENvMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRMwEQYDVQQIEwpDYWxp
+Zm9ybmlhMQswCQYDVQQGEwJaWjETMBEGCysGAQQBgjc8AgEDEwJVUzEdMBsGA1UE
+DxMUUHJpdmF0ZSBPcmdhbml6YXRpb24wggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAw
+ggGKAoIBgQC2iFTBwrZupUSjw73oMZnJfvh2FZ4ehulR2A1iFWKPmnTJpWdPmJ3n
+6zFZfbtYtLlEDR86slgTW/YKeR2UjS/i2QzEIjJJePRPPMDDVXfHm1BHcR/0VA1H
+jRhsxLpr9DgO/kGEhvsj/ddaeTrOpEtK4vr01nBtqRFUjW37nkFH0ZjkcmMgN1qY
+XKFQR93/Ws5kv30PUC4yNTPLyDO2hW/C3Pgux2ikT3kADTLM+XMZ24rwVSgZEJST
+nsxTKZ6UgUa58r4UMWIIHBuVLAE5SBMF9dMrdqGFZkpS8ixUL0eBmCjNLEA1qTqM
+2diBiC+2ybPMqOvzEBFlIt9PlqexhSDFd1mGtiNDmUlCPcs05afzZ8ND/JxtBLba
+zJgJNX9iwqzC8aJQs+jKA5Zow/D772Wo8FiThe7nzAhtndFvFhbjeIhgfIfzybaf
+TKDZ0bVpmIjcquVonAsHOCuWS3Z5If+TnVfzcnEVvm4KKgGSneMfMwA11rRxuQSc
+9r/Ms7tlXuECAwEAAaOCAc0wggHJMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAK
+BggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBQbY+68N/UWSfqoSKBa
+S8JVK9JZljAfBgNVHSMEGDAWgBQF0cTStacwL3wF+amIBGry3r1vVzBbBggrBgEF
+BQcBAQRPME0wIwYIKwYBBQUHMAGGF2h0dHA6Ly9vY3NwLmV4YW1wbGUuY29tMCYG
+CCsGAQUFBzAChhpodHRwOi8vZXhhbXBsZS5jb20vY2ExLmNydDATBgNVHSAEDDAK
+MAgGBmeBDAEEATBXBgNVHR8EUDBOMCWgI6Ahhh9odHRwOi8vY3JsMS5leGFtcGxl
+LmNvbS9jYTEuY3JsMCWgI6Ahhh9odHRwOi8vY3JsMi5leGFtcGxlLmNvbS9jYTEu
+Y3JsMIGIBgorBgEEAdZ5AgQCBHoEeAB2ADkAxGkovIfeI7movSNaof5nzLFULIOJ
+rT8Cv0q1z/UG6Y8AAAAASZYC0gAABAMACnNpZ25hdHVyZTEAOQBzqqUHHZ+GFVDV
+FGnL2J4KblNxSG/ZTJZ1KB0c771RFwAAAABJlgLTAAAEAwAKc2lnbmF0dXJlMjAN
+BgkqhkiG9w0BAQsFAAOCAYEAFmEs/bQ/ByXJvJExz6CCkG9/91f6LHd92o49YhAL
+Rtgj/VSJ3vmlIx6ovhTZqqrQVdBQS5OMJ62idnANt2wwxpYZqXY2eqWUFfMp3CL1
+K7iKBb9HBwQ2nmXMWn1miw3cLRi+3f72Cqrz+sD3rmE/l9IsRppwvnRebVpHCNsv
+ai+FStZihbrhfnVnQvh98GRZT0vA4uBMgQTYBvRE9xF0yi+DnDvz3DYkwXl6f+QI
+r7oxAp62C4J4zLv5NMDQ+SHmlkDPJGayqmreZTnx3qg+rRRS6MmfRpPbpM3EaDzd
+synXvJYTAo/1iivoUimmYu6fJyhZBtJZL+RgYxXJo3JC7g3MvWGy5uix4mcZJ4TL
+OPY8OOw/gOnN41Utfuz/gufPCxIN6H177TJvxGXUyefWLzcHH/notyqsv/bM5NHQ
+O8w3bxZp0s+pGwvJifAC8nfE/f/BkxOhCzG/lpNkZnq9RlAM2r+T8YtXvU5xPy6r
+ksCb0Sl6RUd93ETwuZdIN3ow
+-----END CERTIFICATE-----

--- a/v3/testdata/code_signing/only_meta_data_in_country_name.pem
+++ b/v3/testdata/code_signing/only_meta_data_in_country_name.pem
@@ -1,0 +1,142 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            e5:87:f1:41:a3:b5:74:a0:33:e5:2b:bf:83:59:3c:bf
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=OV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: May 24 04:58:56 2026 GMT
+            Not After : May 24 04:58:56 2027 GMT
+        Subject: CN=Example Co, O=Example Co, L=Mountain View, ST=California, C=., jurisdictionC=US, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:ce:32:c3:a9:92:8d:be:9c:64:05:a5:0a:3e:b5:
+                    53:f3:19:42:2a:9a:27:cb:af:e0:19:ad:56:6c:3f:
+                    b3:7f:1c:1f:4a:50:31:55:a5:83:f1:77:6f:30:3a:
+                    80:de:c1:b5:c0:4e:94:2f:1f:b1:35:02:f7:16:67:
+                    ff:2b:1d:8f:a8:eb:00:ad:73:bd:8c:53:24:2b:b3:
+                    17:bf:ff:81:2d:f8:8d:5e:94:0d:93:56:a6:2b:dc:
+                    d0:f7:61:f2:cc:23:0d:4a:af:03:75:fa:31:05:1e:
+                    9a:7b:40:b3:f4:c7:1e:7b:61:0a:49:ba:4f:7b:ae:
+                    3f:7d:94:31:d5:d8:b6:20:55:e5:58:b1:05:ba:0a:
+                    18:d7:72:bd:a1:33:32:41:76:25:0b:c4:ee:5a:ac:
+                    f7:8d:d8:ad:67:f8:44:a5:c8:64:19:d3:0a:31:cf:
+                    93:00:e4:69:98:f0:9c:b9:ce:fc:e2:7b:c5:69:f0:
+                    29:eb:c0:fe:78:ca:b5:e5:67:d3:a4:2d:f9:2c:bc:
+                    e2:70:38:ef:d5:15:1a:87:81:10:24:24:f4:97:9e:
+                    ab:59:68:19:78:d9:36:c6:fa:c9:49:f9:79:ca:c6:
+                    73:c8:77:ee:59:92:5e:ec:00:8d:e4:ae:37:b4:22:
+                    3f:06:c7:4c:4f:9c:d9:49:95:da:7a:87:59:8e:96:
+                    58:e2:4a:0c:a2:1e:1f:22:f8:c9:ed:db:e7:94:a3:
+                    49:05:c8:ea:9a:ec:0f:7a:b9:f9:c3:42:05:5d:a9:
+                    a0:20:c6:32:b5:97:00:4a:03:e2:4e:69:72:e1:83:
+                    0f:45:36:f1:96:13:de:20:33:53:87:22:bb:b4:51:
+                    81:94:27:ad:48:0b:46:a4:33:e9:41:4f:33:be:ed:
+                    2f:df:e4:69:64:f4:29:92:43:1d:4d:63:b6:1f:d1:
+                    0a:c5:9d:33:d4:45:fb:2f:6d:9f:ca:45:5d:50:e5:
+                    df:3c:6a:02:c0:82:77:e4:a9:86:d9:b3:5d:b8:80:
+                    f2:bb:87:fc:b9:08:a1:d8:1f:f5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                3B:8A:6A:94:29:4B:D0:04:40:FD:2F:66:FF:10:BF:D4:77:CE:92:2D
+            X509v3 Authority Key Identifier: 
+                8A:BC:22:43:A1:5D:67:23:5A:3E:1F:FC:E8:77:2F:7A:90:F3:9E:4E
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.4.1
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+            CT Precertificate SCTs: 
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : C4:69:28:BC:87:DE:23:B9:A8:BD:23:5A:A1:FE:67:CC:
+                                B1:54:2C:83:89:AD:3F:02:BF:4A:B5:CF:F5:06:E9:8F
+                    Timestamp : Jan 15 06:56:07.890 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:31
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 73:AA:A5:07:1D:9F:86:15:50:D5:14:69:CB:D8:9E:0A:
+                                6E:53:71:48:6F:D9:4C:96:75:28:1D:1C:EF:BD:51:17
+                    Timestamp : Jan 15 06:56:07.891 1970 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                73:69:67:6E:61:74:75:72:65:32
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        22:6b:12:5d:de:59:b8:bf:d8:fe:2a:49:8b:88:c0:af:26:c2:
+        81:64:df:02:df:c3:3f:c6:ba:34:db:dc:7c:1f:bb:d2:fd:49:
+        9f:13:14:b4:94:8a:88:a1:4b:bf:07:a9:c4:68:32:9c:57:b3:
+        ea:32:20:3d:d9:08:c1:2d:6b:cf:06:3e:f0:03:2d:6f:e0:fb:
+        b0:f6:05:63:fa:20:7c:af:b3:d9:3b:ee:9a:58:9a:1f:ac:07:
+        fc:5a:18:8f:42:dc:fb:3a:11:38:11:8e:6c:0f:49:7a:f4:18:
+        9f:9b:63:4f:38:7b:26:27:58:57:47:ab:ea:54:84:ee:8f:a1:
+        f0:a1:c2:9d:9d:ed:20:fc:0e:dc:82:79:e8:cd:a9:53:1c:d9:
+        06:de:42:08:3d:82:7b:b8:34:92:cc:00:30:be:2b:ca:5e:df:
+        71:83:8b:db:07:29:fa:07:31:c9:36:e0:b0:d1:8f:7b:88:7c:
+        7d:9d:a1:c9:2a:00:7d:2f:8a:f3:95:a4:f4:db:d1:08:be:31:
+        e9:c9:f6:59:14:46:63:36:8c:97:2d:04:41:50:ae:87:ff:fd:
+        48:72:cd:f3:92:13:ed:e0:26:83:9d:f0:b0:c4:86:74:1d:7b:
+        a2:54:17:32:ef:ab:b7:d3:24:40:30:ae:f2:cf:d9:8e:4e:0a:
+        d6:2d:f5:e9:9e:57:a0:43:84:4a:76:1e:e0:83:94:bb:a4:bd:
+        25:72:e4:16:bd:45:f6:28:5f:71:c7:b9:2d:02:bb:d5:6a:e2:
+        38:97:3f:5e:c4:04:9a:83:ae:4d:ea:8a:7a:29:fa:9a:27:9c:
+        ed:ef:4e:aa:9e:c2:8c:b8:4a:82:65:5e:76:d9:f4:f0:8e:f7:
+        4e:5b:d7:91:9c:c8:e0:b5:33:80:13:5e:1a:40:ce:32:4b:f3:
+        21:ab:2d:14:74:91:11:20:c7:68:10:44:b9:aa:19:dd:85:3f:
+        63:93:4b:ea:33:d4:96:3d:aa:94:e2:8d:12:94:15:73:64:f8:
+        c9:fe:5e:93:9e:8c
+-----BEGIN CERTIFICATE-----
+MIIGPjCCBKagAwIBAgIRAOWH8UGjtXSgM+Urv4NZPL8wDQYJKoZIhvcNAQELBQAw
+TDEbMBkGA1UEAxMST1YgQ29kZSBTaWduaW5nIENBMQswCQYDVQQLEwJDQTETMBEG
+A1UEChMKRXhhbXBsZSBDbzELMAkGA1UEBhMCVVMwHhcNMjYwNTI0MDQ1ODU2WhcN
+MjcwNTI0MDQ1ODU2WjCBlzETMBEGA1UEAxMKRXhhbXBsZSBDbzETMBEGA1UEChMK
+RXhhbXBsZSBDbzEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzETMBEGA1UECBMKQ2Fs
+aWZvcm5pYTEKMAgGA1UEBhMBLjETMBEGCysGAQQBgjc8AgEDEwJVUzEdMBsGA1UE
+DxMUUHJpdmF0ZSBPcmdhbml6YXRpb24wggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAw
+ggGKAoIBgQDOMsOpko2+nGQFpQo+tVPzGUIqmifLr+AZrVZsP7N/HB9KUDFVpYPx
+d28wOoDewbXATpQvH7E1AvcWZ/8rHY+o6wCtc72MUyQrsxe//4Et+I1elA2TVqYr
+3ND3YfLMIw1KrwN1+jEFHpp7QLP0xx57YQpJuk97rj99lDHV2LYgVeVYsQW6ChjX
+cr2hMzJBdiULxO5arPeN2K1n+ESlyGQZ0woxz5MA5GmY8Jy5zvzie8Vp8CnrwP54
+yrXlZ9OkLfksvOJwOO/VFRqHgRAkJPSXnqtZaBl42TbG+slJ+XnKxnPId+5Zkl7s
+AI3krje0Ij8Gx0xPnNlJldp6h1mOlljiSgyiHh8i+Mnt2+eUo0kFyOqa7A96ufnD
+QgVdqaAgxjK1lwBKA+JOaXLhgw9FNvGWE94gM1OHIru0UYGUJ61IC0akM+lBTzO+
+7S/f5Glk9CmSQx1NY7Yf0QrFnTPURfsvbZ/KRV1Q5d88agLAgnfkqYbZs124gPK7
+h/y5CKHYH/UCAwEAAaOCAc0wggHJMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAK
+BggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBQ7imqUKUvQBED9L2b/
+EL/Ud86SLTAfBgNVHSMEGDAWgBSKvCJDoV1nI1o+H/zody96kPOeTjBbBggrBgEF
+BQcBAQRPME0wIwYIKwYBBQUHMAGGF2h0dHA6Ly9vY3NwLmV4YW1wbGUuY29tMCYG
+CCsGAQUFBzAChhpodHRwOi8vZXhhbXBsZS5jb20vY2ExLmNydDATBgNVHSAEDDAK
+MAgGBmeBDAEEATBXBgNVHR8EUDBOMCWgI6Ahhh9odHRwOi8vY3JsMS5leGFtcGxl
+LmNvbS9jYTEuY3JsMCWgI6Ahhh9odHRwOi8vY3JsMi5leGFtcGxlLmNvbS9jYTEu
+Y3JsMIGIBgorBgEEAdZ5AgQCBHoEeAB2ADkAxGkovIfeI7movSNaof5nzLFULIOJ
+rT8Cv0q1z/UG6Y8AAAAASZYC0gAABAMACnNpZ25hdHVyZTEAOQBzqqUHHZ+GFVDV
+FGnL2J4KblNxSG/ZTJZ1KB0c771RFwAAAABJlgLTAAAEAwAKc2lnbmF0dXJlMjAN
+BgkqhkiG9w0BAQsFAAOCAYEAImsSXd5ZuL/Y/ipJi4jArybCgWTfAt/DP8a6NNvc
+fB+70v1JnxMUtJSKiKFLvwepxGgynFez6jIgPdkIwS1rzwY+8AMtb+D7sPYFY/og
+fK+z2TvumliaH6wH/FoYj0Lc+zoROBGObA9JevQYn5tjTzh7JidYV0er6lSE7o+h
+8KHCnZ3tIPwO3IJ56M2pUxzZBt5CCD2Ce7g0kswAML4ryl7fcYOL2wcp+gcxyTbg
+sNGPe4h8fZ2hySoAfS+K85Wk9NvRCL4x6cn2WRRGYzaMly0EQVCuh//9SHLN85IT
+7eAmg53wsMSGdB17olQXMu+rt9MkQDCu8s/Zjk4K1i316Z5XoEOESnYe4IOUu6S9
+JXLkFr1F9ihfcce5LQK71WriOJc/XsQEmoOuTeqKein6miec7e9Oqp7CjLhKgmVe
+dtn08I73TlvXkZzI4LUzgBNeGkDOMkvzIastFHSRESDHaBBEuaoZ3YU/Y5NL6jPU
+lj2qlOKNEpQVc2T4yf5ek56M
+-----END CERTIFICATE-----

--- a/v3/testdata/code_signing/valid_ev_code_signing.pem
+++ b/v3/testdata/code_signing/valid_ev_code_signing.pem
@@ -1,0 +1,124 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            31:67:f6:1a:50:76:a2:e9:b9:10:f2:2e:f4:7f:d9:42
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=EV Code Signing CA, OU=CA, O=Example Co, C=US
+        Validity
+            Not Before: Jun 21 05:45:17 2026 GMT
+            Not After : Jun 21 05:45:17 2027 GMT
+        Subject: CN=Example Co, O=Example Co, L=Mountain View, ST=California, C=US, jurisdictionL=Mountain View, jurisdictionST=California, jurisdictionC=US, serialNumber=12345678, businessCategory=Private Organization
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:ed:37:09:3f:78:82:72:7a:f8:c5:b7:c2:fc:70:
+                    e9:37:7c:db:0a:e7:ed:7e:3f:04:ef:3d:49:24:a9:
+                    07:7f:71:03:e8:0e:ce:a1:c7:db:ed:da:32:a9:27:
+                    ac:ef:1b:f3:bb:22:03:19:70:11:30:35:dc:26:88:
+                    41:fd:4a:b1:03:ea:f5:02:32:0a:3d:2a:27:34:4c:
+                    7c:aa:e6:b5:51:7d:f3:1d:3a:24:10:88:92:d2:a8:
+                    1a:e9:5f:e8:fe:45:62:11:ea:d0:8f:5f:2f:92:c4:
+                    04:90:56:9c:44:8b:06:f6:07:4b:25:d6:da:09:3f:
+                    b5:ee:b5:1d:8a:7b:43:f2:ff:38:03:40:4b:10:1b:
+                    da:3b:f6:ba:ee:ea:36:15:23:9f:21:71:3e:67:a5:
+                    cb:0c:34:b8:b8:42:a6:a8:a0:68:50:4b:ad:dc:b4:
+                    68:cd:10:c9:9f:a5:c5:fe:fb:40:3d:78:7a:21:37:
+                    66:84:5a:8a:a9:b2:78:a3:26:8d:4c:2d:26:0b:b2:
+                    29:44:ca:61:38:6e:97:b2:10:08:9b:fb:8e:e2:54:
+                    55:9e:ed:c0:b6:73:bc:e8:1e:94:50:e2:aa:5f:1e:
+                    97:b4:66:b3:cf:8a:a8:7b:0b:26:ba:75:6b:29:48:
+                    53:be:5a:0b:49:5b:e9:68:52:13:5f:ac:75:b2:6d:
+                    9b:ac:e4:27:7b:74:59:c4:24:74:ad:ac:a6:7d:e0:
+                    42:4e:b8:81:36:3f:79:52:21:38:bd:6e:7b:4a:e5:
+                    dc:22:f8:b7:c6:3f:32:dd:42:da:45:6a:95:f3:07:
+                    1b:3d:a5:c9:65:57:bb:13:19:99:0d:09:30:4b:72:
+                    a0:c1:bc:5c:a3:fe:7d:01:84:70:35:24:3f:09:04:
+                    ce:54:04:be:62:4a:6f:c5:fa:a7:d7:e9:2e:7e:6b:
+                    73:bd:12:f3:df:e0:31:8e:8a:69:7d:ba:19:40:42:
+                    70:de:fd:e9:91:28:b4:74:c6:c9:18:68:73:d3:dd:
+                    34:02:24:7f:ec:e6:20:4d:99:27
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage: 
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                16:19:FE:94:2B:5E:3E:E9:5A:1C:F1:1D:37:CA:78:F7:E5:E2:96:10
+            X509v3 Authority Key Identifier: 
+                1F:74:42:4D:F0:63:F2:77:D1:E2:86:BF:B5:1B:78:77:41:23:50:5E
+            Authority Information Access: 
+                OCSP - URI:http://ocsp.example.com
+                CA Issuers - URI:http://example.com/ca1.crt
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.3
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://crl1.example.com/ca1.crl
+
+                Full Name:
+                  URI:http://crl2.example.com/ca1.crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        27:e9:b7:93:c0:a8:8d:84:ce:50:f8:06:41:41:a8:4b:18:8b:
+        4f:a1:12:1c:83:87:ba:04:0f:ba:d8:67:ae:57:8d:6f:50:5a:
+        b8:a7:f2:dd:d5:25:85:9e:80:61:1b:8e:9d:24:7a:8a:55:47:
+        06:c0:13:1f:9c:74:ab:69:a4:02:31:c7:74:c3:a8:ec:f7:c0:
+        2a:12:ab:83:36:69:f6:6c:9f:c7:d5:76:10:30:5d:0c:f6:61:
+        ee:f0:f6:73:9a:95:4c:5d:50:7b:de:45:8a:b7:36:29:3e:28:
+        af:33:08:3f:f9:d6:6a:1c:33:cf:1a:e9:05:66:20:e8:88:ca:
+        b7:ba:24:3c:c2:24:f5:e5:35:30:da:5c:83:03:9c:d9:91:cd:
+        60:ca:31:3d:be:af:ec:69:ef:70:2d:cd:a9:c6:e3:b4:96:00:
+        85:e4:8e:32:93:86:2b:ef:78:8c:a0:5f:39:2c:be:4b:b8:cc:
+        06:b3:14:c9:6c:ec:c3:95:fc:59:ef:f0:fd:6b:be:9d:72:ba:
+        1c:42:df:6e:62:7b:1e:35:b5:f9:50:94:f6:40:c2:be:a5:8e:
+        27:ae:d0:fb:50:68:d8:14:9d:1f:72:e9:67:d7:91:9a:fa:60:
+        14:0c:93:6f:33:04:d0:9b:10:6d:3a:96:d7:65:6e:24:9c:fb:
+        17:15:d0:07:ac:e2:94:3f:c9:52:8e:01:1a:eb:ac:a2:bb:b1:
+        58:ce:2d:11:70:39:7e:a4:24:81:8c:ca:bb:24:44:cc:a1:6b:
+        c7:4d:42:c5:19:d3:c3:c7:2a:c0:63:14:77:29:61:9b:0a:69:
+        1e:bd:6c:47:97:67:1b:23:33:60:d6:12:56:fe:ea:9a:f1:f3:
+        e9:0e:f6:2a:3e:6d:40:73:3b:b7:5e:80:2a:f8:d7:b4:43:8f:
+        b3:3e:ee:f0:e0:7d:e0:58:72:21:f5:c8:e6:3b:bd:4c:54:e3:
+        0b:20:19:08:f7:6d:fc:0d:67:eb:d1:fc:36:89:16:13:51:14:
+        7d:92:c4:2f:c3:4f
+-----BEGIN CERTIFICATE-----
+MIIGAjCCBGqgAwIBAgIQMWf2GlB2oum5EPIu9H/ZQjANBgkqhkiG9w0BAQsFADBM
+MRswGQYDVQQDExJFViBDb2RlIFNpZ25pbmcgQ0ExCzAJBgNVBAsTAkNBMRMwEQYD
+VQQKEwpFeGFtcGxlIENvMQswCQYDVQQGEwJVUzAeFw0yNjA2MjEwNTQ1MTdaFw0y
+NzA2MjEwNTQ1MTdaMIHoMRMwEQYDVQQDEwpFeGFtcGxlIENvMRMwEQYDVQQKEwpF
+eGFtcGxlIENvMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRMwEQYDVQQIEwpDYWxp
+Zm9ybmlhMQswCQYDVQQGEwJVUzEeMBwGCysGAQQBgjc8AgEBEw1Nb3VudGFpbiBW
+aWV3MRswGQYLKwYBBAGCNzwCAQITCkNhbGlmb3JuaWExEzARBgsrBgEEAYI3PAIB
+AxMCVVMxETAPBgNVBAUTCDEyMzQ1Njc4MR0wGwYDVQQPExRQcml2YXRlIE9yZ2Fu
+aXphdGlvbjCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoCggGBAO03CT94gnJ6
++MW3wvxw6Td82wrn7X4/BO89SSSpB39xA+gOzqHH2+3aMqknrO8b87siAxlwETA1
+3CaIQf1KsQPq9QIyCj0qJzRMfKrmtVF98x06JBCIktKoGulf6P5FYhHq0I9fL5LE
+BJBWnESLBvYHSyXW2gk/te61HYp7Q/L/OANASxAb2jv2uu7qNhUjnyFxPmelyww0
+uLhCpqigaFBLrdy0aM0QyZ+lxf77QD14eiE3ZoRaiqmyeKMmjUwtJguyKUTKYThu
+l7IQCJv7juJUVZ7twLZzvOgelFDiql8el7Rms8+KqHsLJrp1aylIU75aC0lb6WhS
+E1+sdbJtm6zkJ3t0WcQkdK2spn3gQk64gTY/eVIhOL1ue0rl3CL4t8Y/Mt1C2kVq
+lfMHGz2lyWVXuxMZmQ0JMEtyoMG8XKP+fQGEcDUkPwkEzlQEvmJKb8X6p9fpLn5r
+c70S89/gMY6KaX26GUBCcN796ZEotHTGyRhoc9PdNAIkf+zmIE2ZJwIDAQABo4IB
+QTCCAT0wDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMAwGA1Ud
+EwEB/wQCMAAwHQYDVR0OBBYEFBYZ/pQrXj7pWhzxHTfKePfl4pYQMB8GA1UdIwQY
+MBaAFB90Qk3wY/J30eKGv7UbeHdBI1BeMFsGCCsGAQUFBwEBBE8wTTAjBggrBgEF
+BQcwAYYXaHR0cDovL29jc3AuZXhhbXBsZS5jb20wJgYIKwYBBQUHMAKGGmh0dHA6
+Ly9leGFtcGxlLmNvbS9jYTEuY3J0MBIGA1UdIAQLMAkwBwYFZ4EMAQMwVwYDVR0f
+BFAwTjAloCOgIYYfaHR0cDovL2NybDEuZXhhbXBsZS5jb20vY2ExLmNybDAloCOg
+IYYfaHR0cDovL2NybDIuZXhhbXBsZS5jb20vY2ExLmNybDANBgkqhkiG9w0BAQsF
+AAOCAYEAJ+m3k8CojYTOUPgGQUGoSxiLT6ESHIOHugQPuthnrleNb1BauKfy3dUl
+hZ6AYRuOnSR6ilVHBsATH5x0q2mkAjHHdMOo7PfAKhKrgzZp9myfx9V2EDBdDPZh
+7vD2c5qVTF1Qe95Firc2KT4orzMIP/nWahwzzxrpBWYg6IjKt7okPMIk9eU1MNpc
+gwOc2ZHNYMoxPb6v7GnvcC3NqcbjtJYAheSOMpOGK+94jKBfOSy+S7jMBrMUyWzs
+w5X8We/w/Wu+nXK6HELfbmJ7HjW1+VCU9kDCvqWOJ67Q+1Bo2BSdH3LpZ9eRmvpg
+FAyTbzME0JsQbTqW12VuJJz7FxXQB6zilD/JUo4BGuusoruxWM4tEXA5fqQkgYzK
+uyREzKFrx01CxRnTw8cqwGMUdylhmwppHr1sR5dnGyMzYNYSVv7qmvHz6Q72Kj5t
+QHM7t16AKvjXtEOPsz7u8OB94FhyIfXI5ju9TFTjCyAZCPdt/A1n69H8NokWE1EU
+fZLEL8NP
+-----END CERTIFICATE-----

--- a/v3/util/cs.go
+++ b/v3/util/cs.go
@@ -16,3 +16,13 @@ func IsCodeSigning(policies []asn1.ObjectIdentifier) bool {
 
 	return false
 }
+
+func IsEVCodeSigning(policies []asn1.ObjectIdentifier) bool {
+	for _, policy := range policies {
+		if policy.String() == evCodeSigningPolicy {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Added a lint requiring subject countryName for non-ev code signing certificates.

### Reference with sections:
https://cabforum.org/working-groups/code-signing/requirements/

7.1.4.2.3 Subject distinguished name field - Non-EV Code Signing Certificates 
> f. Certificate Field: subject:countryName (OID: 2.5.4.6)
> Required/Optional: Required
> Contents: The subject:countryName MUST contain the two-letter ISO 3166-1 country code associated with the location of the Subject verified under BR Section 3.2.2.3. If a Country is not represented by an official ISO 3166-1 country code, the CA MAY specify the ISO 3166-1 user-assigned code of XX indicating that an official ISO 3166-1 alpha-2 code has not been assigned.