### PR TITLE
Fix typo: "X.590 v3" -> "X.509 v3" in e_invalid_certificate_version lintcabf_br: fix typo in invalid certificate version lint description

### DIFF
--- a/v3/lints/cabf_br/lint_invalid_certificate_version.go
+++ b/v3/lints/cabf_br/lint_invalid_certificate_version.go
@@ -30,7 +30,7 @@ func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
 			Name:          "e_invalid_certificate_version",
-			Description:   "Certificates MUST be of type X.590 v3",
+			Description:   "Certificates MUST be of type X.509 v3",
 			Citation:      "BRs: 7.1.1",
 			Source:        lint.CABFBaselineRequirements,
 			EffectiveDate: util.CABV130Date,


### PR DESCRIPTION
Fix a typo in `v3/lints/cabf_br/lint_invalid_certificate_version.go`:

- from: `Certificates MUST be of type X.590 v3`
- to: `Certificates MUST be of type X.509 v3`

No logic change; description string only.