### PR TITLE
Add lint to check for a valid commonName in Organization Validated S/MIME certificates

### DIFF
--- a/v3/lints/cabf_smime_br/lint_org_validated_invalid_cn.go
+++ b/v3/lints/cabf_smime_br/lint_org_validated_invalid_cn.go
@@ -1,0 +1,67 @@
+/*
+ * ZLint Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package cabf_smime_br
+
+import (
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+
+	"net/mail"
+)
+
+func init() {
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name:          "e_org_validated_invalid_cn",
+			Description:   "In OV S/MIME certs, the Subject CN must either contain an email address or match organizatioName",
+			Citation:      "CABF SMIME BRs §7.1.4.2.2",
+			Source:        lint.CABFSMIMEBaselineRequirements,
+			EffectiveDate: util.CABF_SMIME_BRs_1_0_0_Date,
+		},
+		Lint: NewOrgValidatedInvalidCN,
+	})
+}
+
+type OrgValidatedInvalidCN struct{}
+
+func NewOrgValidatedInvalidCN() lint.LintInterface {
+	return &OrgValidatedInvalidCN{}
+}
+
+func (l *OrgValidatedInvalidCN) CheckApplies(c *x509.Certificate) bool {
+	return util.IsSubscriberCert(c) && util.IsOrganizationValidatedCertificate(c)
+}
+
+func isEmail(s string) bool {
+	addr, err := mail.ParseAddress(s)
+	if err != nil {
+		return false
+	}
+	return addr.Address == s
+}
+
+func (l *OrgValidatedInvalidCN) Execute(c *x509.Certificate) *lint.LintResult {
+
+	if isEmail(c.Subject.CommonName) ||
+		c.Subject.CommonName == c.Subject.Organization[0] {
+		return &lint.LintResult{Status: lint.Pass}
+	}
+
+	return &lint.LintResult{
+		Status:  lint.Error,
+		Details: "In OV S/MIME certs, the Subject CN must either contain an email address or match organizatioName",
+	}
+}

--- a/v3/lints/cabf_smime_br/lint_org_validated_invalid_cn_test.go
+++ b/v3/lints/cabf_smime_br/lint_org_validated_invalid_cn_test.go
@@ -1,0 +1,76 @@
+/*
+ * ZLint Copyright 2024 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package cabf_smime_br
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestOrgValidatedInvalidCN(t *testing.T) {
+
+	testCases := []struct {
+		desc string
+		path string
+		want lint.LintStatus
+	}{
+		{
+			desc: "CA certificate",
+			path: "smime/sub0_smx_ovx_cnex_cnox_effx.pem",
+			want: lint.NA,
+		},
+		{
+			desc: "Non-S/MIME certificate",
+			path: "smime/sub1_sm0_ovx_cnex_cnox_effx.pem",
+			want: lint.NA,
+		},
+		{
+			desc: "Non-OV S/MIME certificate",
+			path: "smime/sub1_sm1_ov0_cnex_cnox_effx.pem",
+			want: lint.NA,
+		},
+		{
+			desc: "OV S/MIME certificate with email in CN",
+			path: "smime/sub1_sm1_ov1_cne1_cno0_eff1.pem",
+			want: lint.Pass,
+		},
+		{
+			desc: "OV S/MIME certificate with CN matching O",
+			path: "smime/sub1_sm1_ov1_cne0_cno1_eff1.pem",
+			want: lint.Pass,
+		},
+		{
+			desc: "OV S/MIME certificate with bad CN, issued before effective date",
+			path: "smime/sub1_sm1_ov1_cne0_cno0_eff0.pem",
+			want: lint.NE,
+		},
+		{
+			desc: "OV S/MIME certificate with bad CN, issued after effective date",
+			path: "smime/sub1_sm1_ov1_cne0_cno0_eff1.pem",
+			want: lint.Error,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			out := test.TestLint("e_org_validated_invalid_cn", tc.path)
+			if out.Status != tc.want {
+				t.Errorf("expected status %s for %s, got %s", tc.want, tc.path, out.Status)
+			}
+		})
+	}
+}

--- a/v3/testdata/smime/sub0_smx_ovx_cnex_cnox_effx.pem
+++ b/v3/testdata/smime/sub0_smx_ovx_cnex_cnox_effx.pem
@@ -1,0 +1,139 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            36:16:f5:d7:55:83:78:b5:22:b2:c8:d8:b4:5f:14:d7
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=XX, O=Some CA, CN=Fake Root CA for zlint testing
+        Validity
+            Not Before: Jul 28 06:17:12 2026 GMT
+            Not After : Jul 27 06:17:12 2031 GMT
+        Subject: C=XX, ST=Some State, L=Some Locality, O=Some CA, CN=Fake CA for zlint testing
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+                    00:ce:61:1a:da:e6:4d:d1:cb:7b:87:42:24:60:e3:
+                    22:da:88:34:af:6a:7b:0b:1b:bf:fe:9a:ed:03:5b:
+                    5a:34:f1:f6:1f:6a:d6:59:7d:65:4a:2e:05:c5:af:
+                    4c:e6:19:4a:22:f0:a9:cf:2a:c6:5b:f8:85:79:bf:
+                    a4:c1:e0:4d:41:a3:2f:19:57:30:64:b5:40:65:5b:
+                    7d:24:97:3e:8e:6b:9c:e0:d5:28:9a:6c:b1:94:85:
+                    85:6b:e2:cf:97:a8:e5:f1:6d:bb:48:41:3e:25:44:
+                    bb:68:c9:08:b5:70:e2:60:74:3d:e3:29:8a:d3:20:
+                    86:bf:a9:c2:f4:00:6a:c4:6d:72:bb:95:ee:37:86:
+                    73:0c:22:fa:1d:92:65:93:03:08:1c:dd:9c:ad:3a:
+                    28:84:4e:4c:1f:ce:0d:ad:ef:71:d1:70:ca:e1:80:
+                    7d:5c:09:61:8a:24:0f:b1:eb:b1:ed:44:62:0b:0e:
+                    a9:03:19:9d:28:8a:81:f5:f2:9d:da:e3:dd:b0:1c:
+                    87:c2:8b:e4:a3:86:c8:46:b1:b9:8d:c4:b9:ff:31:
+                    d6:88:8b:56:25:17:9b:ea:95:b7:1e:5a:63:b4:f3:
+                    78:d0:01:1d:b1:bf:ff:f8:f9:69:01:42:cb:8f:f4:
+                    60:f8:ef:1e:8e:40:69:cf:ed:5c:3d:3d:8e:dd:27:
+                    9a:ec:7f:58:b4:43:09:8b:54:0a:cf:44:9d:cb:d3:
+                    0b:5c:a9:a3:e5:8a:9d:6e:66:77:f0:55:7a:a8:8b:
+                    02:4f:4c:34:c4:f0:e7:3d:23:0c:71:e9:75:ce:8d:
+                    ad:20:86:e9:1d:64:c7:6b:4d:f0:b9:78:e2:b0:07:
+                    55:a8:37:72:f9:00:94:74:34:7e:f0:fd:77:cc:16:
+                    06:b6:9f:f0:63:d8:aa:5d:06:80:7b:76:5c:98:33:
+                    e6:39:ca:c8:83:ac:7e:b9:41:91:a6:77:87:c0:d9:
+                    99:3c:84:af:ec:3d:31:7e:12:70:42:6e:6b:34:76:
+                    e6:46:db:e9:67:2b:29:ea:28:be:54:d3:70:13:7d:
+                    3e:d6:c9:15:11:f2:fb:ef:cf:80:39:90:5a:44:ca:
+                    e6:df:5a:cd:c0:bd:0c:d3:a4:a8:64:6a:01:29:f3:
+                    d5:5e:96:9a:85:a2:06:e3:40:56:51:6e:5c:eb:82:
+                    90:cd:6a:6c:13:c7:8b:bb:b6:5e:02:ec:f9:0f:71:
+                    70:6f:8d:25:37:95:e4:32:82:5a:bd:46:1c:da:72:
+                    4a:24:63:61:bb:a1:61:51:2d:5f:80:fc:f8:cf:53:
+                    f4:ef:8f:ce:b1:b7:48:f3:c3:9a:fd:cd:b3:8a:46:
+                    9a:91:00:57:2a:89:17:32:f3:82:bc:54:82:56:d8:
+                    87:f3:ef
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier: 
+                0A:1B:4D:A0:43:87:04:3F:A9:94:FD:5A:43:32:0B:16:F7:C4:2D:4E
+            X509v3 Authority Key Identifier: 
+                E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+            Authority Information Access: 
+                OCSP - URI:http://ca.someca-inc.com/ocsp
+                CA Issuers - URI:http://ca.someca-inc.com/root
+            X509v3 Certificate Policies: 
+                Policy: X509v3 Any Policy
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://ca.someca-inc.com/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        87:9a:1e:db:e3:f7:4e:32:88:7c:05:0e:d9:21:75:9b:7a:08:
+        0c:81:18:9b:ab:d5:79:95:fe:b5:60:72:29:2d:5d:35:d2:16:
+        29:3e:91:4b:5f:d8:79:b0:db:92:82:d4:ef:a8:ca:00:71:b7:
+        15:15:6f:e7:b6:4e:6f:fb:03:0b:f7:03:2c:f3:c4:44:0a:87:
+        0e:7a:bb:a7:5c:13:7e:c6:2a:1b:dc:61:1f:c1:d8:76:25:cd:
+        f6:4a:a1:eb:1f:e6:a4:bc:f4:07:65:c2:10:6b:13:b0:5f:0b:
+        b7:68:15:08:e9:a9:a0:f9:8b:3f:bf:a9:1e:13:95:83:d6:96:
+        4f:23:cd:4c:6c:6f:d8:ab:17:78:fd:50:6a:2d:c8:81:31:ba:
+        41:99:28:80:a8:5e:5e:32:a8:8a:64:a1:43:30:89:73:fb:ca:
+        56:f2:f3:1c:a4:41:ef:0c:83:50:0d:9d:31:03:4d:cb:1c:90:
+        7e:12:c7:51:1f:67:a6:00:b1:48:e0:78:2e:f2:cd:34:43:09:
+        db:f8:b9:43:47:0e:7f:82:24:fa:c3:ad:fb:0a:cc:58:1a:a6:
+        c1:6a:ae:4a:5b:2e:34:7d:b9:75:c0:f5:0d:db:7c:c6:2c:c9:
+        44:e5:b5:b0:54:19:32:75:93:8c:dd:e4:a8:f5:53:c0:08:8a:
+        c3:3c:fb:81:54:5c:8a:02:48:ed:3e:a5:a4:df:ae:4b:c4:f3:
+        29:e8:65:43:e1:35:b7:0a:1f:32:39:b7:f2:93:1f:f1:f8:a2:
+        0d:83:48:99:f2:03:35:6e:08:43:ba:25:32:46:52:74:82:a4:
+        93:48:f1:0c:05:ac:90:53:5f:70:8d:41:9a:6a:24:e6:75:eb:
+        02:4e:31:b1:c6:c4:65:5a:52:c1:a8:80:be:98:18:f5:0f:65:
+        88:72:c7:c9:d5:2f:2c:36:b7:f4:5b:46:1e:9e:73:02:3e:5b:
+        f5:78:e9:ae:51:7a:1d:b8:47:93:31:60:e5:4c:3c:c5:5d:74:
+        2b:eb:be:cd:c1:c0:f6:45:8c:c3:a6:e6:09:f2:56:b8:a1:f4:
+        07:96:af:0f:ee:a2:33:e9:cf:54:f1:2e:07:4f:dc:f1:8f:62:
+        b4:ee:ef:23:46:2e:9a:04:08:f3:d2:c0:43:b9:4d:8f:15:0a:
+        5b:2d:b9:07:73:3d:fc:a3:b4:df:94:3d:0e:74:d6:2b:9d:34:
+        0a:7d:f5:e1:b5:3e:01:5d:42:a4:d0:87:67:f5:7e:58:0c:f9:
+        20:a1:c9:a4:da:5a:cc:af:06:6a:19:64:71:d2:2b:8f:21:e4:
+        3e:f1:7b:5f:a3:2a:85:53:b5:fa:23:c6:fc:79:98:20:15:1a:
+        b3:75:a7:e2:bb:9e:c8:29
+-----BEGIN CERTIFICATE-----
+MIIGcDCCBFigAwIBAgIQNhb111WDeLUissjYtF8U1zANBgkqhkiG9w0BAQsFADBI
+MQswCQYDVQQGEwJYWDEQMA4GA1UEChMHU29tZSBDQTEnMCUGA1UEAxMeRmFrZSBS
+b290IENBIGZvciB6bGludCB0ZXN0aW5nMB4XDTI2MDcyODA2MTcxMloXDTMxMDcy
+NzA2MTcxMlowcDELMAkGA1UEBhMCWFgxEzARBgNVBAgTClNvbWUgU3RhdGUxFjAU
+BgNVBAcTDVNvbWUgTG9jYWxpdHkxEDAOBgNVBAoTB1NvbWUgQ0ExIjAgBgNVBAMT
+GUZha2UgQ0EgZm9yIHpsaW50IHRlc3RpbmcwggIiMA0GCSqGSIb3DQEBAQUAA4IC
+DwAwggIKAoICAQDOYRra5k3Ry3uHQiRg4yLaiDSvansLG7/+mu0DW1o08fYfatZZ
+fWVKLgXFr0zmGUoi8KnPKsZb+IV5v6TB4E1Boy8ZVzBktUBlW30klz6Oa5zg1Sia
+bLGUhYVr4s+XqOXxbbtIQT4lRLtoyQi1cOJgdD3jKYrTIIa/qcL0AGrEbXK7le43
+hnMMIvodkmWTAwgc3ZytOiiETkwfzg2t73HRcMrhgH1cCWGKJA+x67HtRGILDqkD
+GZ0oioH18p3a492wHIfCi+SjhshGsbmNxLn/MdaIi1YlF5vqlbceWmO083jQAR2x
+v//4+WkBQsuP9GD47x6OQGnP7Vw9PY7dJ5rsf1i0QwmLVArPRJ3L0wtcqaPlip1u
+ZnfwVXqoiwJPTDTE8Oc9Iwxx6XXOja0ghukdZMdrTfC5eOKwB1WoN3L5AJR0NH7w
+/XfMFga2n/Bj2KpdBoB7dlyYM+Y5ysiDrH65QZGmd4fA2Zk8hK/sPTF+EnBCbms0
+duZG2+lnKynqKL5U03ATfT7WyRUR8vvvz4A5kFpEyubfWs3AvQzTpKhkagEp89Ve
+lpqFogbjQFZRblzrgpDNamwTx4u7tl4C7PkPcXBvjSU3leQyglq9RhzackokY2G7
+oWFRLV+A/PjPU/Tvj86xt0jzw5r9zbOKRpqRAFcqiRcy84K8VIJW2Ifz7wIDAQAB
+o4IBLDCCASgwDgYDVR0PAQH/BAQDAgEGMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQKG02gQ4cEP6mU/VpD
+MgsW98QtTjAfBgNVHSMEGDAWgBTotvZ2S9A75Ual+VTUfgez3g1gPjBkBggrBgEF
+BQcBAQRYMFYwKQYIKwYBBQUHMAGGHWh0dHA6Ly9jYS5zb21lY2EtaW5jLmNvbS9v
+Y3NwMCkGCCsGAQUFBzAChh1odHRwOi8vY2Euc29tZWNhLWluYy5jb20vcm9vdDAR
+BgNVHSAECjAIMAYGBFUdIAAwLQYDVR0fBCYwJDAioCCgHoYcaHR0cDovL2NhLnNv
+bWVjYS1pbmMuY29tL2NybDANBgkqhkiG9w0BAQsFAAOCAgEAh5oe2+P3TjKIfAUO
+2SF1m3oIDIEYm6vVeZX+tWByKS1dNdIWKT6RS1/YebDbkoLU76jKAHG3FRVv57ZO
+b/sDC/cDLPPERAqHDnq7p1wTfsYqG9xhH8HYdiXN9kqh6x/mpLz0B2XCEGsTsF8L
+t2gVCOmpoPmLP7+pHhOVg9aWTyPNTGxv2KsXeP1Qai3IgTG6QZkogKheXjKoimSh
+QzCJc/vKVvLzHKRB7wyDUA2dMQNNyxyQfhLHUR9npgCxSOB4LvLNNEMJ2/i5Q0cO
+f4Ik+sOt+wrMWBqmwWquSlsuNH25dcD1Ddt8xizJROW1sFQZMnWTjN3kqPVTwAiK
+wzz7gVRcigJI7T6lpN+uS8TzKehlQ+E1twofMjm38pMf8fiiDYNImfIDNW4IQ7ol
+MkZSdIKkk0jxDAWskFNfcI1Bmmok5nXrAk4xscbEZVpSwaiAvpgY9Q9liHLHydUv
+LDa39FtGHp5zAj5b9XjprlF6HbhHkzFg5Uw8xV10K+u+zcHA9kWMw6bmCfJWuKH0
+B5avD+6iM+nPVPEuB0/c8Y9itO7vI0YumgQI89LAQ7lNjxUKWy25B3M9/KO035Q9
+DnTWK500Cn314bU+AV1CpNCHZ/V+WAz5IKHJpNpazK8GahlkcdIrjyHkPvF7X6Mq
+hVO1+iPG/HmYIBUas3Wn4rueyCk=
+-----END CERTIFICATE-----

--- a/v3/testdata/smime/sub1_sm0_ovx_cnex_cnox_effx.pem
+++ b/v3/testdata/smime/sub1_sm0_ovx_cnex_cnox_effx.pem
@@ -1,0 +1,96 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            59:0b:9b:ca:66:80:a8:0b:50:1e:18:bc:c1:9b:bb:5d
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=XX, O=Some CA, CN=Fake CA for zlint testing
+        Validity
+            Not Before: Jul 28 06:19:39 2026 GMT
+            Not After : Nov  5 05:19:39 2026 GMT
+        Subject: C=XX, ST=Some State or Province, L=Somewhere, O=Some Company Ltd., serialNumber=1234567890, businessCategory=Non-Commercial Entity
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c4:bd:85:c6:6a:38:a2:dd:c1:e8:38:7b:30:7b:
+                    7e:c0:24:a0:43:a3:d3:62:3a:c9:e8:dc:46:e1:97:
+                    b0:01:e1:9a:c3:bc:b4:d0:99:97:25:ef:f0:58:be:
+                    67:b6:99:d9:36:f5:d0:34:04:5a:35:81:cf:fc:d3:
+                    c8:7f:5d:eb:22:52:be:63:23:bf:47:33:5e:a4:d3:
+                    40:95:f1:9d:d8:cf:28:9a:6d:dd:81:a6:4b:bb:4c:
+                    88:0b:a7:87:0f:38:09:c6:3d:cb:51:a9:61:6f:8a:
+                    d1:50:40:3c:0d:05:f5:1b:71:17:6e:d2:bd:a9:48:
+                    af:e4:6a:eb:15:f2:ba:fb:b6:fa:87:c1:9d:4b:8f:
+                    e1:ae:ee:8a:7a:b4:80:97:44:8f:37:63:c7:cb:02:
+                    6b:f7:66:73:25:41:92:c0:1a:7f:06:11:e5:0d:fe:
+                    2b:0c:6c:40:a4:14:34:33:b0:14:e0:bd:9b:0f:f5:
+                    e9:b6:6a:47:4b:87:1e:70:8f:c4:4f:3d:91:27:ac:
+                    76:a9:27:43:12:85:37:ed:63:de:13:51:4f:27:eb:
+                    9c:9f:0c:66:4c:f8:90:64:56:11:fa:03:00:c5:bd:
+                    0e:19:5d:3c:f4:10:db:05:86:8b:fe:73:56:25:ce:
+                    40:3c:6c:3a:28:f8:52:19:5d:9d:46:7c:88:cf:4a:
+                    9d:7d
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Authority Key Identifier: 
+                E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+            Authority Information Access: 
+                OCSP - URI:http://ca.someca-inc.com/ocsp
+                CA Issuers - URI:http://ca.someca-inc.com/root cert
+            X509v3 Subject Alternative Name: 
+                DNS:example.org
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.1
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://ca.someca-inc.com/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        ac:24:16:96:80:2e:64:90:0d:0c:28:c7:37:39:03:27:4c:bf:
+        1d:3c:dc:e2:9e:a1:9e:3a:3b:f5:a9:dc:91:c7:60:70:cc:50:
+        3c:93:77:4f:86:55:71:b1:ff:3d:00:da:0e:0b:91:52:e0:44:
+        61:7d:46:7c:e6:4b:ef:25:4b:1e:2e:f2:78:08:6a:c6:75:ef:
+        73:19:d1:05:06:64:9e:d1:fc:91:5f:a4:16:d6:b1:11:da:f0:
+        98:28:ff:26:f6:d0:d3:d4:96:43:97:b5:28:fd:1a:db:60:96:
+        60:bd:d7:31:89:4e:55:1a:a9:d6:90:6a:1a:f9:59:94:c2:61:
+        ef:67:a2:65:1e:1b:57:e0:b9:4a:7e:58:cf:fb:48:9d:44:e9:
+        9c:b3:e4:fe:b2:99:a9:fa:c0:20:28:a0:b1:10:8b:a5:c8:8d:
+        ec:96:d9:6e:9e:34:a1:47:b3:db:7e:b1:44:99:90:99:97:aa:
+        41:dc:41:42:f4:da:00:6e:11:99:05:1e:4d:00:96:d2:38:a7:
+        31:cb:03:98:0c:54:0d:91:ae:d3:18:b3:5c:b2:29:44:1d:36:
+        2a:84:ed:96:51:e4:a3:94:39:e0:b7:25:bd:df:7c:bb:4f:49:
+        37:13:a1:8b:5e:1d:02:e3:c8:15:20:3e:d4:e2:ce:5b:b3:a2:
+        5a:68:86:b3
+-----BEGIN CERTIFICATE-----
+MIIEfTCCA2WgAwIBAgIQWQubymaAqAtQHhi8wZu7XTANBgkqhkiG9w0BAQsFADBD
+MQswCQYDVQQGEwJYWDEQMA4GA1UEChMHU29tZSBDQTEiMCAGA1UEAxMZRmFrZSBD
+QSBmb3IgemxpbnQgdGVzdGluZzAeFw0yNjA3MjgwNjE5MzlaFw0yNjExMDUwNTE5
+MzlaMIGTMQswCQYDVQQGEwJYWDEfMB0GA1UECBMWU29tZSBTdGF0ZSBvciBQcm92
+aW5jZTESMBAGA1UEBxMJU29tZXdoZXJlMRowGAYDVQQKExFTb21lIENvbXBhbnkg
+THRkLjETMBEGA1UEBRMKMTIzNDU2Nzg5MDEeMBwGA1UEDxMVTm9uLUNvbW1lcmNp
+YWwgRW50aXR5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxL2Fxmo4
+ot3B6Dh7MHt+wCSgQ6PTYjrJ6NxG4ZewAeGaw7y00JmXJe/wWL5ntpnZNvXQNARa
+NYHP/NPIf13rIlK+YyO/RzNepNNAlfGd2M8omm3dgaZLu0yIC6eHDzgJxj3LUalh
+b4rRUEA8DQX1G3EXbtK9qUiv5GrrFfK6+7b6h8GdS4/hru6KerSAl0SPN2PHywJr
+92ZzJUGSwBp/BhHlDf4rDGxApBQ0M7AU4L2bD/XptmpHS4cecI/ETz2RJ6x2qSdD
+EoU37WPeE1FPJ+ucnwxmTPiQZFYR+gMAxb0OGV089BDbBYaL/nNWJc5APGw6KPhS
+GV2dRnyIz0qdfQIDAQABo4IBGjCCARYwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQW
+MBQGCCsGAQUFBwMCBggrBgEFBQcDATAfBgNVHSMEGDAWgBTotvZ2S9A75Ual+VTU
+fgez3g1gPjBpBggrBgEFBQcBAQRdMFswKQYIKwYBBQUHMAGGHWh0dHA6Ly9jYS5z
+b21lY2EtaW5jLmNvbS9vY3NwMC4GCCsGAQUFBzAChiJodHRwOi8vY2Euc29tZWNh
+LWluYy5jb20vcm9vdCBjZXJ0MBYGA1UdEQQPMA2CC2V4YW1wbGUub3JnMBIGA1Ud
+IAQLMAkwBwYFZ4EMAQEwLQYDVR0fBCYwJDAioCCgHoYcaHR0cDovL2NhLnNvbWVj
+YS1pbmMuY29tL2NybDANBgkqhkiG9w0BAQsFAAOCAQEArCQWloAuZJANDCjHNzkD
+J0y/HTzc4p6hnjo79anckcdgcMxQPJN3T4ZVcbH/PQDaDguRUuBEYX1GfOZL7yVL
+Hi7yeAhqxnXvcxnRBQZkntH8kV+kFtaxEdrwmCj/JvbQ09SWQ5e1KP0a22CWYL3X
+MYlOVRqp1pBqGvlZlMJh72eiZR4bV+C5Sn5Yz/tInUTpnLPk/rKZqfrAICigsRCL
+pciN7JbZbp40oUez236xRJmQmZeqQdxBQvTaAG4RmQUeTQCW0jinMcsDmAxUDZGu
+0xizXLIpRB02KoTtllHko5Q54Lclvd98u09JNxOhi14dAuPIFSA+1OLOW7OiWmiG
+sw==
+-----END CERTIFICATE-----

--- a/v3/testdata/smime/sub1_sm1_ov0_cnex_cnox_effx.pem
+++ b/v3/testdata/smime/sub1_sm1_ov0_cnex_cnox_effx.pem
@@ -1,0 +1,115 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            20:15:c4:15:a1:52:de:fd:9c:9d:bb:aa:7c:98:62:78
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=XX, O=Some CA, CN=Fake CA for Zlint testing
+        Validity
+            Not Before: Jul 28 06:25:40 2026 GMT
+            Not After : Jul 28 06:25:40 2027 GMT
+        Subject: CN=Guenter.Grass@example.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:d6:bb:ad:fe:03:83:b8:27:30:68:f5:9b:19:ae:
+                    f2:66:c9:3f:bc:42:a3:71:77:89:60:54:ab:0d:37:
+                    7f:46:04:e9:77:2e:b8:bd:88:2a:7b:14:bd:27:cf:
+                    5d:03:18:53:33:7d:55:af:bc:99:e4:4b:82:b6:35:
+                    1b:45:cd:1c:72:ec:8e:dd:04:27:72:bb:00:07:03:
+                    15:99:bf:63:b6:47:da:c7:7c:60:7a:da:d8:26:a3:
+                    5a:b3:90:67:a7:ee:c4:4f:fb:59:5d:58:4a:bf:fe:
+                    1e:74:c4:eb:1c:d0:c2:52:43:e8:48:6e:49:dd:0e:
+                    08:14:c7:de:c9:d3:a0:de:66:e6:a7:f6:b6:e9:c7:
+                    13:ef:e3:0b:28:09:40:56:50:a5:98:ed:5b:47:d7:
+                    92:bc:1d:8d:a2:e2:62:0c:b9:d3:c6:c7:de:e1:d7:
+                    30:a4:e4:54:52:cb:22:b6:62:e2:b3:71:a1:a0:cd:
+                    db:9c:45:8b:8f:e4:8b:c9:0e:5a:39:42:25:18:d1:
+                    2e:8f:ab:5a:9a:4e:35:f1:9b:81:d7:80:4a:0e:27:
+                    a1:cf:86:0d:6b:64:7c:3d:a8:31:6a:a5:3c:95:19:
+                    95:0d:c0:75:f0:28:2d:4f:9d:af:b1:ad:29:ab:f9:
+                    75:2e:24:42:08:c2:65:19:d2:f3:c0:3e:37:8d:8b:
+                    b1:95
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, E-mail Protection
+            X509v3 Subject Key Identifier: 
+                E4:A9:BD:B6:1F:DD:56:16:11:93:DC:9A:D6:70:32:76:17:E3:FB:0A
+            X509v3 Authority Key Identifier: 
+                E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+            Authority Information Access: 
+                OCSP - URI:http://ca.someca-inc.com/ocsp
+                CA Issuers - URI:http://ca.someca-inc.com/root
+            X509v3 Subject Alternative Name: 
+                email:Guenter.Grass@example.com
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.5.1.3
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://ca.someca-inc.com/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        aa:5c:2f:79:1e:66:c1:72:db:51:1b:96:86:88:0e:81:8f:74:
+        c4:91:1b:99:70:42:5f:c2:7c:00:51:ea:55:76:d7:0b:d6:8d:
+        7a:34:a3:3c:71:1b:e9:83:12:0b:d5:dd:09:09:64:7d:dd:21:
+        c8:89:fb:3b:26:37:e0:06:73:51:74:38:a5:a4:5b:ce:e1:88:
+        fb:c1:b6:f6:c2:00:2d:99:fa:6d:b6:f0:c0:0e:54:cf:c4:0f:
+        e2:87:45:18:11:82:7b:50:62:fe:d8:6a:48:0b:34:c5:4c:e2:
+        a5:b4:f9:1f:16:35:9e:9d:cb:28:0b:39:4b:56:0c:32:ea:93:
+        ab:09:8f:d6:a5:c8:8f:6f:22:28:a1:0a:e9:31:f9:0b:6d:a1:
+        e7:51:ce:c4:57:13:23:62:81:d1:78:4c:5a:88:ca:80:ae:ce:
+        f5:fb:e7:78:b7:a7:da:2a:c1:df:ee:17:61:92:0f:a0:c4:0c:
+        7c:b8:28:b5:c5:a6:9d:a6:9a:36:81:95:1b:6d:3c:5d:da:80:
+        10:58:98:8d:4e:57:2d:32:ed:9d:28:1b:d5:99:2d:76:e4:d3:
+        31:3c:e7:14:45:5f:e2:16:9f:3d:dd:11:fe:e6:f7:c0:4d:75:
+        30:67:d1:64:31:57:79:9c:72:8e:d7:b2:ec:63:d6:c6:ba:d2:
+        62:30:86:8f:cd:21:97:b4:01:d7:8a:37:29:5f:70:69:f6:f4:
+        1e:d6:99:35:73:c9:2e:0c:24:84:88:3f:52:a8:25:7f:61:2d:
+        89:b3:b7:a9:85:f4:4f:77:fc:42:a7:d6:bb:cb:4d:71:6e:6d:
+        96:36:41:9e:83:9c:99:b0:bc:cb:04:99:de:e6:62:cd:4d:6a:
+        47:f1:99:00:e2:f5:e5:f9:3c:10:ef:25:cb:8e:35:36:f7:27:
+        9f:c6:f4:ef:57:cb:1b:83:40:78:b8:d5:7a:4d:73:fd:8d:65:
+        64:04:b7:3f:29:43:f9:de:dc:43:19:e1:25:f0:d4:9e:58:a0:
+        23:c5:a3:76:b3:33:c2:e7:2e:93:57:4c:b4:16:53:1b:c7:6a:
+        a0:7c:fa:dd:2d:ef:78:53:ee:35:7b:b0:d6:3e:5e:da:87:43:
+        19:d7:5e:aa:8b:c9:b5:d1:54:d6:57:2e:83:4d:8d:fe:8f:b4:
+        77:ad:f5:a5:ce:2b:99:2c:68:95:ea:d0:94:2c:6e:02:f6:f7:
+        71:8c:b9:62:9d:44:ea:16:b4:e5:33:8f:ca:5d:90:b7:27:ae:
+        92:de:e4:94:8e:10:74:85:70:99:e6:f5:33:59:38:83:bb:06:
+        e5:60:01:0b:1f:1b:a2:23:85:23:e8:e4:3b:90:9c:76:e1:d2:
+        78:1a:26:19:f8:03:99:bf
+-----BEGIN CERTIFICATE-----
+MIIFNzCCAx+gAwIBAgIQIBXEFaFS3v2cnbuqfJhieDANBgkqhkiG9w0BAQsFADBD
+MQswCQYDVQQGEwJYWDEQMA4GA1UEChMHU29tZSBDQTEiMCAGA1UEAxMZRmFrZSBD
+QSBmb3IgWmxpbnQgdGVzdGluZzAeFw0yNjA3MjgwNjI1NDBaFw0yNzA3MjgwNjI1
+NDBaMCQxIjAgBgNVBAMMGUd1ZW50ZXIuR3Jhc3NAZXhhbXBsZS5jb20wggEiMA0G
+CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDWu63+A4O4JzBo9ZsZrvJmyT+8QqNx
+d4lgVKsNN39GBOl3Lri9iCp7FL0nz10DGFMzfVWvvJnkS4K2NRtFzRxy7I7dBCdy
+uwAHAxWZv2O2R9rHfGB62tgmo1qzkGen7sRP+1ldWEq//h50xOsc0MJSQ+hIbknd
+DggUx97J06DeZuan9rbpxxPv4wsoCUBWUKWY7VtH15K8HY2i4mIMudPGx97h1zCk
+5FRSyyK2YuKzcaGgzducRYuP5IvJDlo5QiUY0S6Pq1qaTjXxm4HXgEoOJ6HPhg1r
+ZHw9qDFqpTyVGZUNwHXwKC1Pna+xrSmr+XUuJEIIwmUZ0vPAPjeNi7GVAgMBAAGj
+ggFEMIIBQDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsG
+AQUFBwMEMB0GA1UdDgQWBBTkqb22H91WFhGT3JrWcDJ2F+P7CjAfBgNVHSMEGDAW
+gBTotvZ2S9A75Ual+VTUfgez3g1gPjBkBggrBgEFBQcBAQRYMFYwKQYIKwYBBQUH
+MAGGHWh0dHA6Ly9jYS5zb21lY2EtaW5jLmNvbS9vY3NwMCkGCCsGAQUFBzAChh1o
+dHRwOi8vY2Euc29tZWNhLWluYy5jb20vcm9vdDAkBgNVHREEHTAbgRlHdWVudGVy
+LkdyYXNzQGV4YW1wbGUuY29tMBQGA1UdIAQNMAswCQYHZ4EMAQUBAzAtBgNVHR8E
+JjAkMCKgIKAehhxodHRwOi8vY2Euc29tZWNhLWluYy5jb20vY3JsMA0GCSqGSIb3
+DQEBCwUAA4ICAQCqXC95HmbBcttRG5aGiA6Bj3TEkRuZcEJfwnwAUepVdtcL1o16
+NKM8cRvpgxIL1d0JCWR93SHIifs7JjfgBnNRdDilpFvO4Yj7wbb2wgAtmfpttvDA
+DlTPxA/ih0UYEYJ7UGL+2GpICzTFTOKltPkfFjWencsoCzlLVgwy6pOrCY/WpciP
+byIooQrpMfkLbaHnUc7EVxMjYoHReExaiMqArs71++d4t6faKsHf7hdhkg+gxAx8
+uCi1xaadppo2gZUbbTxd2oAQWJiNTlctMu2dKBvVmS125NMxPOcURV/iFp893RH+
+5vfATXUwZ9FkMVd5nHKO17LsY9bGutJiMIaPzSGXtAHXijcpX3Bp9vQe1pk1c8ku
+DCSEiD9SqCV/YS2Js7ephfRPd/xCp9a7y01xbm2WNkGeg5yZsLzLBJne5mLNTWpH
+8ZkA4vXl+TwQ7yXLjjU29yefxvTvV8sbg0B4uNV6TXP9jWVkBLc/KUP53txDGeEl
+8NSeWKAjxaN2szPC5y6TV0y0FlMbx2qgfPrdLe94U+41e7DWPl7ah0MZ116qi8m1
+0VTWVy6DTY3+j7R3rfWlziuZLGiV6tCULG4C9vdxjLlinUTqFrTlM4/KXZC3J66S
+3uSUjhB0hXCZ5vUzWTiDuwblYAELHxuiI4Uj6OQ7kJx24dJ4GiYZ+AOZvw==
+-----END CERTIFICATE-----

--- a/v3/testdata/smime/sub1_sm1_ov1_cne0_cno0_eff0.pem
+++ b/v3/testdata/smime/sub1_sm1_ov1_cne0_cno0_eff0.pem
@@ -1,0 +1,117 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            ff:e0:92:d2:a4:75:95:c4:d4:f9:82:9c:4e:18:79:b7
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=XX, O=Some CA, CN=Fake CA for Zlint testing
+        Validity
+            Not Before: Aug 15 00:00:00 2023 GMT
+            Not After : Aug 14 00:00:00 2024 GMT
+        Subject: C=ES, L=Algún lugar, O=Alguna Compañía, CN=Firma Registros Médicos, organizationIdentifier=ABCES-1234567890
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:cc:ee:5c:f4:9f:e3:3c:44:e6:8c:7f:10:52:f3:
+                    18:a2:8f:dc:c1:33:7b:b3:8b:72:37:44:09:09:e9:
+                    51:93:65:4c:51:48:60:08:51:a5:1c:49:24:ac:04:
+                    07:ad:09:a0:5e:28:ad:53:fb:5c:45:bc:89:fb:09:
+                    00:74:f4:ab:4e:4e:00:75:17:25:70:51:0f:2e:38:
+                    88:bb:b8:41:45:ba:c3:8a:21:57:ee:84:bd:84:c2:
+                    9a:49:b6:9e:aa:3c:53:91:6e:dd:6d:4d:b9:7e:8d:
+                    52:eb:6c:3e:1b:bd:ce:ee:64:4e:90:46:83:76:ac:
+                    5c:a4:f2:37:5b:bf:79:e8:65:98:3a:15:18:ef:0a:
+                    36:d5:33:1f:47:bf:fb:44:51:e4:fc:e1:6b:d9:c7:
+                    44:0e:b6:94:1c:dd:46:31:08:0f:c7:34:67:27:31:
+                    b4:27:16:8c:7c:8a:dc:dc:19:ca:b2:53:e4:81:d1:
+                    0c:37:13:36:30:a8:47:d6:61:85:81:0d:3f:ee:9d:
+                    b9:76:7b:6f:f2:85:74:ec:37:4d:45:7d:c5:22:38:
+                    4b:cd:9d:7f:88:13:43:86:8a:ab:1a:bf:6f:87:bd:
+                    af:e9:48:e0:46:b2:fe:0f:3c:e3:0c:fe:cc:ea:0f:
+                    e9:66:2d:8b:ed:30:67:7f:86:1c:66:56:36:25:64:
+                    2d:4b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, E-mail Protection
+            X509v3 Subject Key Identifier: 
+                9C:82:14:69:5C:E4:FE:55:84:A4:C6:A2:62:43:12:8E:DB:09:5B:9C
+            X509v3 Authority Key Identifier: 
+                E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+            Authority Information Access: 
+                OCSP - URI:http://ca.someca-inc.com/ocsp
+                CA Issuers - URI:http://ca.someca-inc.com/root
+            X509v3 Subject Alternative Name: 
+                email:Leon.Mandrake@example.com
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.5.2.2
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://ca.someca-inc.com/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        a0:95:cc:32:54:db:d5:87:af:cf:72:63:8c:88:18:96:bc:78:
+        b9:89:60:a9:1d:8a:a6:02:e8:98:95:db:7a:20:f7:76:57:1b:
+        87:e3:ec:7f:1f:cf:fb:23:e3:8f:0b:13:4d:f3:27:82:bf:ee:
+        52:0e:3a:65:0d:4d:4c:96:b0:a4:51:be:3d:ab:d2:76:17:54:
+        d1:5d:80:c2:cf:80:c0:e9:3d:54:a1:5b:26:1b:0f:36:66:1a:
+        6b:2d:00:33:d8:94:06:72:23:cc:e1:45:ba:11:9a:46:f5:25:
+        3d:ad:87:1f:e9:e0:d2:26:33:bc:8a:73:6b:66:01:38:d4:af:
+        92:16:8d:d6:35:b5:71:b5:70:09:09:ac:17:e7:bf:db:27:ee:
+        6f:1e:c2:5f:d7:ce:01:2d:be:a2:08:47:d0:de:ad:1e:ed:96:
+        9f:de:5a:fd:f5:86:35:0a:e8:d5:e0:67:52:2f:bf:78:64:7e:
+        d6:a2:13:d4:54:70:02:81:2a:96:25:d5:98:64:90:55:fd:1a:
+        4b:b3:a7:d1:c7:58:1b:d1:b9:35:ae:ca:ee:5e:9c:ae:ff:18:
+        97:e1:fd:9a:48:2d:d7:7d:d2:2d:3c:52:b8:26:0f:84:9f:07:
+        23:c7:87:03:15:16:b1:56:b0:22:8e:95:9d:06:9c:b7:ef:61:
+        98:c5:6a:fc:92:08:92:fa:b1:8f:73:a8:63:7c:a7:19:d5:43:
+        64:b1:d7:6b:98:4b:14:b7:fe:89:3b:fc:56:45:57:ae:7e:a3:
+        37:b0:bb:dd:90:a4:21:e5:c4:35:c2:4a:24:9d:e4:65:b0:b0:
+        a7:ee:e4:43:d8:b5:76:2d:94:cf:80:f4:32:b2:51:37:b9:ad:
+        b3:c5:3a:c2:96:f0:79:37:2a:9f:73:43:7b:02:02:80:9d:4c:
+        5b:37:25:08:9b:79:f3:21:57:1d:4f:91:b4:56:ce:3a:7b:a8:
+        2a:f6:e7:62:85:aa:35:61:d9:92:51:a2:01:26:60:13:d3:a0:
+        18:b9:8f:19:43:04:27:ae:85:fc:88:66:c2:4f:d9:05:0c:3f:
+        ad:ef:59:79:13:95:f5:e1:dd:a3:57:9c:9f:61:72:e0:4e:30:
+        2c:9e:6d:e4:7f:40:88:21:d3:b4:f4:2d:46:7e:f2:65:97:c4:
+        33:ca:d6:a5:4b:e9:a4:3f:54:d0:9f:aa:03:76:8c:82:49:57:
+        ef:a8:a8:77:37:d3:3a:56:07:08:b0:5a:4d:b2:20:80:cd:8e:
+        ee:db:7d:10:c0:c1:77:3b:29:02:88:fb:c0:f6:a0:5a:96:c9:
+        c6:be:4e:13:c0:ff:f3:6c:da:01:59:35:56:ac:c4:e5:6b:af:
+        01:27:dc:3d:fa:6c:c9:0a
+-----BEGIN CERTIFICATE-----
+MIIFkjCCA3qgAwIBAgIRAP/gktKkdZXE1PmCnE4YebcwDQYJKoZIhvcNAQELBQAw
+QzELMAkGA1UEBhMCWFgxEDAOBgNVBAoTB1NvbWUgQ0ExIjAgBgNVBAMTGUZha2Ug
+Q0EgZm9yIFpsaW50IHRlc3RpbmcwHhcNMjMwODE1MDAwMDAwWhcNMjQwODE0MDAw
+MDAwWjB+MQswCQYDVQQGEwJFUzEVMBMGA1UEBwwMQWxnw7puIGx1Z2FyMRowGAYD
+VQQKDBFBbGd1bmEgQ29tcGHDscOtYTEhMB8GA1UEAwwYRmlybWEgUmVnaXN0cm9z
+IE3DqWRpY29zMRkwFwYDVQRhExBBQkNFUy0xMjM0NTY3ODkwMIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzO5c9J/jPETmjH8QUvMYoo/cwTN7s4tyN0QJ
+CelRk2VMUUhgCFGlHEkkrAQHrQmgXiitU/tcRbyJ+wkAdPSrTk4AdRclcFEPLjiI
+u7hBRbrDiiFX7oS9hMKaSbaeqjxTkW7dbU25fo1S62w+G73O7mROkEaDdqxcpPI3
+W7956GWYOhUY7wo21TMfR7/7RFHk/OFr2cdEDraUHN1GMQgPxzRnJzG0JxaMfIrc
+3BnKslPkgdEMNxM2MKhH1mGFgQ0/7p25dntv8oV07DdNRX3FIjhLzZ1/iBNDhoqr
+Gr9vh72v6UjgRrL+DzzjDP7M6g/pZi2L7TBnf4YcZlY2JWQtSwIDAQABo4IBRDCC
+AUAwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcD
+BDAdBgNVHQ4EFgQUnIIUaVzk/lWEpMaiYkMSjtsJW5wwHwYDVR0jBBgwFoAU6Lb2
+dkvQO+VGpflU1H4Hs94NYD4wZAYIKwYBBQUHAQEEWDBWMCkGCCsGAQUFBzABhh1o
+dHRwOi8vY2Euc29tZWNhLWluYy5jb20vb2NzcDApBggrBgEFBQcwAoYdaHR0cDov
+L2NhLnNvbWVjYS1pbmMuY29tL3Jvb3QwJAYDVR0RBB0wG4EZTGVvbi5NYW5kcmFr
+ZUBleGFtcGxlLmNvbTAUBgNVHSAEDTALMAkGB2eBDAEFAgIwLQYDVR0fBCYwJDAi
+oCCgHoYcaHR0cDovL2NhLnNvbWVjYS1pbmMuY29tL2NybDANBgkqhkiG9w0BAQsF
+AAOCAgEAoJXMMlTb1Yevz3JjjIgYlrx4uYlgqR2KpgLomJXbeiD3dlcbh+Psfx/P
++yPjjwsTTfMngr/uUg46ZQ1NTJawpFG+PavSdhdU0V2Aws+AwOk9VKFbJhsPNmYa
+ay0AM9iUBnIjzOFFuhGaRvUlPa2HH+ng0iYzvIpza2YBONSvkhaN1jW1cbVwCQms
+F+e/2yfubx7CX9fOAS2+oghH0N6tHu2Wn95a/fWGNQro1eBnUi+/eGR+1qIT1FRw
+AoEqliXVmGSQVf0aS7On0cdYG9G5Na7K7l6crv8Yl+H9mkgt133SLTxSuCYPhJ8H
+I8eHAxUWsVawIo6VnQact+9hmMVq/JIIkvqxj3OoY3ynGdVDZLHXa5hLFLf+iTv8
+VkVXrn6jN7C73ZCkIeXENcJKJJ3kZbCwp+7kQ9i1di2Uz4D0MrJRN7mts8U6wpbw
+eTcqn3NDewICgJ1MWzclCJt58yFXHU+RtFbOOnuoKvbnYoWqNWHZklGiASZgE9Og
+GLmPGUMEJ66F/Ihmwk/ZBQw/re9ZeROV9eHdo1ecn2Fy4E4wLJ5t5H9AiCHTtPQt
+Rn7yZZfEM8rWpUvppD9U0J+qA3aMgklX76iodzfTOlYHCLBaTbIggM2O7tt9EMDB
+dzspAoj7wPagWpbJxr5OE8D/82zaAVk1VqzE5WuvASfcPfpsyQo=
+-----END CERTIFICATE-----

--- a/v3/testdata/smime/sub1_sm1_ov1_cne0_cno0_eff1.pem
+++ b/v3/testdata/smime/sub1_sm1_ov1_cne0_cno0_eff1.pem
@@ -1,0 +1,117 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            3f:d3:15:1d:48:be:39:9d:a7:4e:66:0e:d6:f2:71:e2
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=XX, O=Some CA, CN=Fake CA for Zlint testing
+        Validity
+            Not Before: Jul 28 06:51:12 2026 GMT
+            Not After : Jul 28 06:51:12 2027 GMT
+        Subject: C=ES, L=Algún lugar, O=Alguna Compañía, CN=Firma Registros Médicos, organizationIdentifier=ABCES-1234567890
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:b7:15:bc:54:9e:5f:eb:1c:01:d9:c5:a5:58:87:
+                    e9:62:69:52:74:a4:18:cb:ac:ad:47:47:83:b0:d6:
+                    8e:18:7d:f0:89:54:78:b6:1d:06:3b:1c:52:52:05:
+                    5f:b1:00:39:d7:66:d9:fc:af:a9:bf:82:97:e0:ff:
+                    d4:8d:69:a0:22:ff:d9:80:b5:1a:77:e6:bf:49:f6:
+                    dd:9d:d3:04:f4:e4:df:48:d8:97:f3:62:3d:28:b8:
+                    a0:95:d3:91:20:c0:24:7b:63:4d:03:3d:14:62:d9:
+                    73:fa:3f:28:4a:df:c6:90:a5:ba:db:1b:d3:d8:1b:
+                    b3:d8:ec:5f:ce:6f:22:25:b9:0e:0c:87:f1:18:cd:
+                    3b:43:2b:f5:79:62:47:16:d5:23:ae:92:0b:a1:63:
+                    59:9e:ff:1c:40:73:08:f0:d9:ea:8d:f9:9d:2f:80:
+                    c9:7e:b1:31:22:d2:02:a9:59:e3:8f:1b:15:63:19:
+                    68:d2:fd:e8:01:71:2d:25:95:bf:eb:a4:9b:3e:94:
+                    47:5d:c9:ef:35:a6:6f:be:bb:9f:77:ef:46:e8:7f:
+                    2e:3c:4c:6c:0c:2e:5f:b2:22:56:06:09:4b:f2:ea:
+                    a3:4e:f0:29:2c:de:3e:d8:9e:d4:8c:82:b1:07:fa:
+                    4a:05:aa:af:36:07:c5:9e:1d:11:52:cb:bb:e4:c1:
+                    7d:a1
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, E-mail Protection
+            X509v3 Subject Key Identifier: 
+                84:70:C9:D2:BE:AD:88:A7:8F:37:4E:26:77:D1:F8:86:4C:96:72:9C
+            X509v3 Authority Key Identifier: 
+                E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+            Authority Information Access: 
+                OCSP - URI:http://ca.someca-inc.com/ocsp
+                CA Issuers - URI:http://ca.someca-inc.com/root
+            X509v3 Subject Alternative Name: 
+                email:Leon.Mandrake@example.com
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.5.2.2
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://ca.someca-inc.com/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        a2:cc:5e:4b:29:35:fd:b4:bd:de:50:90:8e:61:ce:5b:2c:d6:
+        1b:8b:f0:7f:82:8c:db:2f:a6:0d:00:28:3c:9b:53:b3:22:30:
+        38:10:b9:27:c9:a5:fc:8f:82:e5:69:86:a2:d3:3e:bc:8c:07:
+        0a:be:91:f1:b7:6c:e8:8b:84:3d:d6:0f:4d:39:bb:69:6f:ad:
+        0a:22:47:5f:1c:f5:7c:a7:95:b7:2a:c0:73:16:28:19:f9:9f:
+        be:1b:4b:c6:37:86:32:6b:28:e6:18:29:ab:bf:47:ee:58:8a:
+        4b:2d:6c:f9:18:f2:b6:f1:eb:75:3e:e8:31:57:6b:5c:11:87:
+        d9:7c:38:55:6c:23:b1:5a:90:d7:94:9a:0b:65:9e:bb:f8:e8:
+        13:15:95:11:05:65:49:65:39:77:f9:62:e6:8d:de:d0:85:81:
+        1c:85:2c:a5:10:87:01:14:13:f0:4d:ab:97:17:7e:0e:a2:29:
+        56:86:82:37:e9:bc:bb:01:83:4f:68:56:89:7c:b5:df:54:47:
+        73:ed:d3:4d:e2:62:db:6c:40:fe:8f:f3:75:1f:c3:f0:6e:3d:
+        29:f5:69:ab:6d:9b:13:69:8b:73:33:81:ce:a3:e8:6a:13:28:
+        5d:9e:c8:12:d6:bd:a6:c6:0e:a7:e9:64:a0:6d:68:d0:43:f5:
+        72:82:17:98:18:53:3f:27:ed:26:5f:4d:e5:0a:99:21:f5:5a:
+        e3:28:59:db:23:f0:01:6f:91:85:46:07:d5:c9:c1:31:57:77:
+        83:c1:62:50:32:5b:e7:75:55:9d:28:88:33:93:9c:7e:46:ae:
+        3c:0e:f5:ea:33:66:ff:14:13:95:3f:1b:75:90:79:76:d8:9a:
+        57:64:25:ed:4c:cf:05:50:53:a8:6a:f4:6d:d4:6a:42:32:ff:
+        f0:ed:61:87:08:9b:56:67:4e:bd:9f:dc:f7:f4:0c:0c:16:eb:
+        56:28:21:9c:20:bc:6f:8f:33:ca:42:a5:69:50:55:5f:40:0e:
+        97:6a:28:10:59:f8:9c:6e:ff:ab:89:43:db:72:c8:05:37:d9:
+        cb:8d:cc:99:6d:82:33:cb:1b:38:d0:cf:d2:3a:9d:10:7d:12:
+        d2:12:3d:d8:3a:b8:0c:d9:dc:02:08:72:2d:a0:ea:bf:e3:c3:
+        35:e5:9d:02:9f:dc:c0:4d:a9:52:a4:1c:90:f0:15:75:b6:6f:
+        ab:77:34:6f:36:97:ac:42:22:7e:b8:7f:b9:e5:e0:b1:e7:03:
+        7d:d7:3c:c9:68:c6:fa:1b:c4:ec:46:34:2d:20:ac:1a:3f:cf:
+        f8:b6:be:33:6f:54:11:be:07:2d:cb:e1:e6:e9:be:2f:c3:64:
+        3a:75:02:66:e7:57:a7:23
+-----BEGIN CERTIFICATE-----
+MIIFkTCCA3mgAwIBAgIQP9MVHUi+OZ2nTmYO1vJx4jANBgkqhkiG9w0BAQsFADBD
+MQswCQYDVQQGEwJYWDEQMA4GA1UEChMHU29tZSBDQTEiMCAGA1UEAxMZRmFrZSBD
+QSBmb3IgWmxpbnQgdGVzdGluZzAeFw0yNjA3MjgwNjUxMTJaFw0yNzA3MjgwNjUx
+MTJaMH4xCzAJBgNVBAYTAkVTMRUwEwYDVQQHDAxBbGfDum4gbHVnYXIxGjAYBgNV
+BAoMEUFsZ3VuYSBDb21wYcOxw61hMSEwHwYDVQQDDBhGaXJtYSBSZWdpc3Ryb3Mg
+TcOpZGljb3MxGTAXBgNVBGETEEFCQ0VTLTEyMzQ1Njc4OTAwggEiMA0GCSqGSIb3
+DQEBAQUAA4IBDwAwggEKAoIBAQC3FbxUnl/rHAHZxaVYh+liaVJ0pBjLrK1HR4Ow
+1o4YffCJVHi2HQY7HFJSBV+xADnXZtn8r6m/gpfg/9SNaaAi/9mAtRp35r9J9t2d
+0wT05N9I2JfzYj0ouKCV05EgwCR7Y00DPRRi2XP6PyhK38aQpbrbG9PYG7PY7F/O
+byIluQ4Mh/EYzTtDK/V5YkcW1SOukguhY1me/xxAcwjw2eqN+Z0vgMl+sTEi0gKp
+WeOPGxVjGWjS/egBcS0llb/rpJs+lEddye81pm++u59370bofy48TGwMLl+yIlYG
+CUvy6qNO8Cks3j7YntSMgrEH+koFqq82B8WeHRFSy7vkwX2hAgMBAAGjggFEMIIB
+QDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwME
+MB0GA1UdDgQWBBSEcMnSvq2Ip483TiZ30fiGTJZynDAfBgNVHSMEGDAWgBTotvZ2
+S9A75Ual+VTUfgez3g1gPjBkBggrBgEFBQcBAQRYMFYwKQYIKwYBBQUHMAGGHWh0
+dHA6Ly9jYS5zb21lY2EtaW5jLmNvbS9vY3NwMCkGCCsGAQUFBzAChh1odHRwOi8v
+Y2Euc29tZWNhLWluYy5jb20vcm9vdDAkBgNVHREEHTAbgRlMZW9uLk1hbmRyYWtl
+QGV4YW1wbGUuY29tMBQGA1UdIAQNMAswCQYHZ4EMAQUCAjAtBgNVHR8EJjAkMCKg
+IKAehhxodHRwOi8vY2Euc29tZWNhLWluYy5jb20vY3JsMA0GCSqGSIb3DQEBCwUA
+A4ICAQCizF5LKTX9tL3eUJCOYc5bLNYbi/B/gozbL6YNACg8m1OzIjA4ELknyaX8
+j4LlaYai0z68jAcKvpHxt2zoi4Q91g9NObtpb60KIkdfHPV8p5W3KsBzFigZ+Z++
+G0vGN4YyayjmGCmrv0fuWIpLLWz5GPK28et1PugxV2tcEYfZfDhVbCOxWpDXlJoL
+ZZ67+OgTFZURBWVJZTl3+WLmjd7QhYEchSylEIcBFBPwTauXF34OoilWhoI36by7
+AYNPaFaJfLXfVEdz7dNN4mLbbED+j/N1H8Pwbj0p9WmrbZsTaYtzM4HOo+hqEyhd
+nsgS1r2mxg6n6WSgbWjQQ/VygheYGFM/J+0mX03lCpkh9VrjKFnbI/ABb5GFRgfV
+ycExV3eDwWJQMlvndVWdKIgzk5x+Rq48DvXqM2b/FBOVPxt1kHl22JpXZCXtTM8F
+UFOoavRt1GpCMv/w7WGHCJtWZ069n9z39AwMFutWKCGcILxvjzPKQqVpUFVfQA6X
+aigQWficbv+riUPbcsgFN9nLjcyZbYIzyxs40M/SOp0QfRLSEj3YOrgM2dwCCHIt
+oOq/48M15Z0Cn9zATalSpByQ8BV1tm+rdzRvNpesQiJ+uH+55eCx5wN91zzJaMb6
+G8TsRjQtIKwaP8/4tr4zb1QRvgcty+Hm6b4vw2Q6dQJm51enIw==
+-----END CERTIFICATE-----

--- a/v3/testdata/smime/sub1_sm1_ov1_cne0_cno1_eff1.pem
+++ b/v3/testdata/smime/sub1_sm1_ov1_cne0_cno1_eff1.pem
@@ -1,0 +1,117 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            cd:27:0b:69:cb:e1:12:9d:b1:f7:34:6f:16:51:8f:8a
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=XX, O=Some CA, CN=Fake CA for Zlint testing
+        Validity
+            Not Before: Jul 28 06:31:13 2026 GMT
+            Not After : Jul 28 06:31:13 2027 GMT
+        Subject: C=ES, L=Algún lugar, O=Alguna Compañía, CN=Alguna Compañía, organizationIdentifier=ABCES-1234567890
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c5:c2:ac:64:8a:e7:da:b4:d7:6f:a7:05:96:3c:
+                    4e:43:16:12:aa:29:20:27:66:9d:3b:0b:58:fe:73:
+                    38:1a:b0:7c:e4:84:d0:15:4b:44:31:9f:da:ad:53:
+                    53:1c:fd:19:24:f6:4d:51:a9:a3:63:8d:d8:8d:56:
+                    87:69:c1:79:85:26:dc:1e:eb:bb:7e:40:b7:df:6b:
+                    f3:06:ec:eb:f4:88:c5:3c:ff:f2:b5:bc:22:85:25:
+                    30:1f:3f:d2:fe:52:4f:09:eb:ce:0a:8d:14:cf:a9:
+                    4c:5c:36:07:06:62:fd:87:7e:59:0a:c4:c7:65:bd:
+                    32:c2:39:98:79:b8:7b:3c:9e:ba:d6:64:61:66:3f:
+                    59:99:bf:be:06:cf:b1:33:2c:fe:ba:8a:50:db:b6:
+                    26:bc:d7:ce:47:a2:5d:3a:a4:13:f0:47:05:66:73:
+                    2d:5b:0c:bd:b0:b3:12:0d:d0:db:f9:41:bc:f2:29:
+                    31:03:b4:b6:fd:47:12:6c:c1:cd:68:2e:36:d3:43:
+                    44:e8:52:21:37:d8:81:37:25:a6:fe:b4:fd:98:38:
+                    27:32:5e:ca:df:3d:ff:95:f4:e4:0e:11:e0:f2:41:
+                    eb:30:b7:85:cc:75:97:b2:78:4f:69:e3:bb:ee:d4:
+                    b6:58:fc:ec:30:f5:02:ea:70:85:93:23:aa:3c:c5:
+                    c1:f5
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, E-mail Protection
+            X509v3 Subject Key Identifier: 
+                3D:C5:4E:F2:EC:73:BA:CB:8B:FC:F7:8A:A0:B7:D1:37:18:29:4B:41
+            X509v3 Authority Key Identifier: 
+                E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+            Authority Information Access: 
+                OCSP - URI:http://ca.someca-inc.com/ocsp
+                CA Issuers - URI:http://ca.someca-inc.com/root
+            X509v3 Subject Alternative Name: 
+                email:Leon.Mandrake@example.com
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.5.2.2
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://ca.someca-inc.com/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        3d:af:1c:d1:2a:ad:b1:ac:89:c3:3b:2a:66:81:6d:fb:fa:13:
+        1d:39:53:68:36:dc:57:72:25:18:cb:da:f8:98:85:7a:0e:a4:
+        16:7b:3c:6a:b9:ca:41:1d:76:c9:f0:bf:29:f6:d4:50:01:53:
+        e7:d9:61:25:4b:0c:5c:99:89:55:f9:52:31:a0:84:6c:b5:33:
+        6b:b8:68:a2:49:82:09:be:d1:ef:9e:e4:8a:ee:a1:0d:b4:0d:
+        31:73:16:2a:9e:fe:53:42:db:b8:8f:52:66:94:29:cf:ea:52:
+        21:5f:f3:97:5a:04:70:41:08:c7:7b:40:e9:38:f7:b6:f6:c7:
+        65:0f:84:65:80:29:3d:fb:a5:d8:f3:ee:bf:60:f5:f2:39:be:
+        df:d0:13:90:c0:c5:a3:92:b2:26:74:52:ef:59:08:ee:ff:25:
+        ec:fd:e6:93:4a:55:a5:15:47:42:1a:bc:25:dd:a7:4a:83:ac:
+        d8:21:9c:36:48:9d:ad:f1:f5:ce:c9:61:ec:e4:5d:a1:dd:40:
+        00:f5:4f:9b:c4:10:e4:ec:cf:9d:e9:94:65:68:5d:2e:2e:99:
+        00:59:a4:30:64:3b:9e:9f:4e:da:8c:65:01:3d:67:97:56:58:
+        c5:91:b2:f6:38:62:2f:26:9b:6d:b1:28:cc:9c:bd:94:24:6c:
+        c2:43:51:b9:e2:d4:bb:ad:0b:83:28:2a:e8:b5:89:a3:46:bc:
+        6c:49:ed:80:e9:9b:91:e2:a2:c8:e3:7f:05:38:cd:a3:77:84:
+        8d:50:08:7a:ac:70:42:9e:74:06:3f:37:cf:21:7e:9e:b7:a8:
+        e1:8a:0c:f0:68:7c:5c:c4:ad:bb:46:59:63:cb:7a:23:5c:79:
+        5d:ba:ab:2c:f6:6b:08:3d:b6:96:90:1f:dc:bb:a6:84:cd:ca:
+        9c:d6:36:2f:be:ee:aa:ad:08:15:9a:14:ca:66:1d:e0:d3:21:
+        72:8c:a5:08:c3:df:da:7b:c5:1e:e0:16:0c:3e:3d:3e:4b:18:
+        39:96:74:d9:1a:e5:52:9b:ae:de:9a:d9:54:4f:84:02:af:65:
+        d8:eb:ed:5d:23:93:8b:8c:e7:d1:93:21:c8:1b:10:72:e4:6c:
+        64:4f:cc:dd:c2:1a:64:2d:5d:ec:14:d3:85:7f:a3:23:d3:8e:
+        c5:9e:f9:ae:75:35:46:2b:d0:b8:de:e4:48:8f:81:eb:c3:97:
+        4d:a0:6e:08:80:37:fe:04:eb:95:39:80:22:e6:34:86:a8:c4:
+        62:07:59:a6:e0:67:b8:f5:c2:c5:6b:82:c0:40:77:78:f5:8b:
+        84:b4:0e:23:c3:12:7c:c1:e6:38:63:c6:66:d2:93:35:36:4e:
+        5f:5a:ee:cc:c0:94:50:ed
+-----BEGIN CERTIFICATE-----
+MIIFizCCA3OgAwIBAgIRAM0nC2nL4RKdsfc0bxZRj4owDQYJKoZIhvcNAQELBQAw
+QzELMAkGA1UEBhMCWFgxEDAOBgNVBAoTB1NvbWUgQ0ExIjAgBgNVBAMTGUZha2Ug
+Q0EgZm9yIFpsaW50IHRlc3RpbmcwHhcNMjYwNzI4MDYzMTEzWhcNMjcwNzI4MDYz
+MTEzWjB3MQswCQYDVQQGEwJFUzEVMBMGA1UEBwwMQWxnw7puIGx1Z2FyMRowGAYD
+VQQKDBFBbGd1bmEgQ29tcGHDscOtYTEaMBgGA1UEAwwRQWxndW5hIENvbXBhw7HD
+rWExGTAXBgNVBGETEEFCQ0VTLTEyMzQ1Njc4OTAwggEiMA0GCSqGSIb3DQEBAQUA
+A4IBDwAwggEKAoIBAQDFwqxkiufatNdvpwWWPE5DFhKqKSAnZp07C1j+czgasHzk
+hNAVS0Qxn9qtU1Mc/Rkk9k1RqaNjjdiNVodpwXmFJtwe67t+QLffa/MG7Ov0iMU8
+//K1vCKFJTAfP9L+Uk8J684KjRTPqUxcNgcGYv2HflkKxMdlvTLCOZh5uHs8nrrW
+ZGFmP1mZv74Gz7EzLP66ilDbtia8185Hol06pBPwRwVmcy1bDL2wsxIN0Nv5Qbzy
+KTEDtLb9RxJswc1oLjbTQ0ToUiE32IE3Jab+tP2YOCcyXsrfPf+V9OQOEeDyQesw
+t4XMdZeyeE9p47vu1LZY/Oww9QLqcIWTI6o8xcH1AgMBAAGjggFEMIIBQDAOBgNV
+HQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMEMB0GA1Ud
+DgQWBBQ9xU7y7HO6y4v894qgt9E3GClLQTAfBgNVHSMEGDAWgBTotvZ2S9A75Ual
++VTUfgez3g1gPjBkBggrBgEFBQcBAQRYMFYwKQYIKwYBBQUHMAGGHWh0dHA6Ly9j
+YS5zb21lY2EtaW5jLmNvbS9vY3NwMCkGCCsGAQUFBzAChh1odHRwOi8vY2Euc29t
+ZWNhLWluYy5jb20vcm9vdDAkBgNVHREEHTAbgRlMZW9uLk1hbmRyYWtlQGV4YW1w
+bGUuY29tMBQGA1UdIAQNMAswCQYHZ4EMAQUCAjAtBgNVHR8EJjAkMCKgIKAehhxo
+dHRwOi8vY2Euc29tZWNhLWluYy5jb20vY3JsMA0GCSqGSIb3DQEBCwUAA4ICAQA9
+rxzRKq2xrInDOypmgW37+hMdOVNoNtxXciUYy9r4mIV6DqQWezxqucpBHXbJ8L8p
+9tRQAVPn2WElSwxcmYlV+VIxoIRstTNruGiiSYIJvtHvnuSK7qENtA0xcxYqnv5T
+Qtu4j1JmlCnP6lIhX/OXWgRwQQjHe0DpOPe29sdlD4RlgCk9+6XY8+6/YPXyOb7f
+0BOQwMWjkrImdFLvWQju/yXs/eaTSlWlFUdCGrwl3adKg6zYIZw2SJ2t8fXOyWHs
+5F2h3UAA9U+bxBDk7M+d6ZRlaF0uLpkAWaQwZDuen07ajGUBPWeXVljFkbL2OGIv
+JpttsSjMnL2UJGzCQ1G54tS7rQuDKCrotYmjRrxsSe2A6ZuR4qLI438FOM2jd4SN
+UAh6rHBCnnQGPzfPIX6et6jhigzwaHxcxK27Rlljy3ojXHlduqss9msIPbaWkB/c
+u6aEzcqc1jYvvu6qrQgVmhTKZh3g0yFyjKUIw9/ae8Ue4BYMPj0+Sxg5lnTZGuVS
+m67emtlUT4QCr2XY6+1dI5OLjOfRkyHIGxBy5GxkT8zdwhpkLV3sFNOFf6Mj047F
+nvmudTVGK9C43uRIj4Hrw5dNoG4IgDf+BOuVOYAi5jSGqMRiB1mm4Ge49cLFa4LA
+QHd49YuEtA4jwxJ8weY4Y8Zm0pM1Nk5fWu7MwJRQ7Q==
+-----END CERTIFICATE-----

--- a/v3/testdata/smime/sub1_sm1_ov1_cne1_cno0_eff1.pem
+++ b/v3/testdata/smime/sub1_sm1_ov1_cne1_cno0_eff1.pem
@@ -1,0 +1,117 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            3c:9b:b3:d3:14:12:ec:cf:8a:11:da:1b:18:af:75:35
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=XX, O=Some CA, CN=Fake CA for Zlint testing
+        Validity
+            Not Before: Jul 28 06:29:09 2026 GMT
+            Not After : Jul 28 06:29:09 2027 GMT
+        Subject: C=ES, L=Algún lugar, O=Alguna Compañía, CN=Leon.Mandrake@example.com, organizationIdentifier=ABCES-1234567890
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:de:a0:84:7b:63:3f:00:ee:4d:35:d5:2f:d5:60:
+                    94:51:56:0e:98:d0:c3:a5:11:92:ae:a2:c5:8b:d9:
+                    22:5d:ad:dd:2a:a8:5d:d6:13:f2:1b:9a:86:78:51:
+                    10:2c:f4:21:7c:83:ed:2c:aa:84:38:ab:38:b0:45:
+                    98:c0:e0:bc:7e:15:34:28:64:57:ad:09:32:05:92:
+                    af:91:3a:05:30:b6:7e:4a:6f:86:f3:a2:70:e3:8e:
+                    c4:66:3a:ab:3a:2c:62:9e:e2:b2:3f:61:d0:f9:a1:
+                    e1:1e:c3:99:af:73:48:2b:64:d6:35:89:3f:d0:0b:
+                    f7:ec:e6:fa:9d:77:ed:03:18:b2:21:17:41:ef:9e:
+                    59:eb:34:bd:2c:87:40:d1:18:3f:f1:5d:40:8d:e0:
+                    42:71:e4:85:af:78:1d:fe:c4:c0:27:24:73:f8:92:
+                    b6:28:7e:60:33:e5:54:e5:e6:b8:3d:19:c0:5e:51:
+                    5f:7a:bb:99:df:df:3b:90:50:09:16:e1:90:19:83:
+                    c7:b5:01:5f:d3:44:5a:41:d4:69:51:1b:a1:79:12:
+                    d5:76:fd:c5:2b:50:07:0f:65:b4:4a:65:4a:5b:53:
+                    93:8e:71:38:b2:f8:94:65:87:0d:c0:50:05:cf:79:
+                    79:5a:8e:88:6b:cd:bd:3c:4e:89:14:33:79:3c:94:
+                    20:f9
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Client Authentication, E-mail Protection
+            X509v3 Subject Key Identifier: 
+                2D:4B:D5:05:41:76:5E:95:4B:68:AF:06:00:DA:5C:64:5E:D2:A2:53
+            X509v3 Authority Key Identifier: 
+                E8:B6:F6:76:4B:D0:3B:E5:46:A5:F9:54:D4:7E:07:B3:DE:0D:60:3E
+            Authority Information Access: 
+                OCSP - URI:http://ca.someca-inc.com/ocsp
+                CA Issuers - URI:http://ca.someca-inc.com/root
+            X509v3 Subject Alternative Name: 
+                email:Leon.Mandrake@example.com
+            X509v3 Certificate Policies: 
+                Policy: 2.23.140.1.5.2.2
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://ca.someca-inc.com/crl
+
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        54:8b:59:38:34:60:4d:e4:48:db:5b:87:85:de:d6:0a:f5:d4:
+        81:77:69:6b:83:db:6b:1f:5f:10:4a:c4:cf:eb:50:4d:89:c8:
+        9b:77:32:94:61:f6:5d:64:02:ee:94:12:de:48:3f:b9:09:0e:
+        91:f6:3b:3f:d8:a3:98:7b:49:b4:7d:79:09:3c:e8:4c:bd:12:
+        34:61:89:28:f0:ea:12:e4:ca:89:2c:1a:3a:78:25:5b:a3:81:
+        55:52:24:98:50:5e:16:69:13:8a:c4:14:7e:2e:9d:cf:c5:b5:
+        7a:e2:6d:80:5a:2f:13:54:7a:67:a1:1b:6d:21:39:3b:11:f1:
+        e4:45:26:6f:be:cf:34:f4:0d:6f:b1:d8:c8:18:3c:db:51:f8:
+        9a:7e:94:81:5a:db:a8:97:f1:45:a7:9d:98:e0:06:6b:b6:c5:
+        3a:21:5e:26:96:11:8c:d2:45:56:cd:06:a1:63:52:3f:1c:d6:
+        35:5c:7b:28:c4:5e:dc:58:6f:b0:33:10:d7:18:13:39:9c:1a:
+        82:af:13:27:36:25:3c:7e:34:61:1f:73:4e:9d:31:3d:61:3d:
+        e9:46:5b:6a:b9:90:b8:be:d7:2d:a7:e4:75:8d:e4:ac:07:04:
+        7f:41:e5:8e:6e:2d:f0:5c:11:4c:b6:95:bb:d7:1c:b2:5a:09:
+        21:70:a4:05:1b:2e:45:f9:41:40:d6:e3:79:d2:00:a8:77:91:
+        04:5b:f9:68:da:2c:f2:41:9e:cd:7c:30:0d:86:44:29:fe:2a:
+        f3:03:c2:13:9c:74:1a:26:16:3b:56:2e:38:13:d6:a4:f1:d1:
+        6e:e5:93:19:04:7c:fe:f4:da:99:d7:0a:f9:95:ed:a9:3d:12:
+        a8:f8:b6:0d:08:e9:eb:3a:60:79:2f:4a:86:66:4e:65:fa:27:
+        d2:3a:24:5f:88:ef:9a:0e:ff:de:90:16:77:28:de:8a:7c:18:
+        63:c2:ee:9c:80:9c:d5:ef:5e:12:d7:39:cc:05:2e:51:f7:a4:
+        63:17:37:42:6c:21:4f:9c:e9:8f:d2:fb:1d:00:29:eb:c9:ec:
+        92:b5:08:75:57:ff:a2:8c:9c:dc:3f:69:52:7a:9f:06:e4:0f:
+        88:24:9a:29:64:72:ad:92:aa:a4:e6:b2:eb:ee:ea:00:c8:11:
+        d6:c0:5c:e5:7c:29:af:eb:77:05:c7:89:86:7b:1a:94:57:99:
+        3a:56:11:30:25:96:8f:e6:8e:05:5d:c9:68:b4:0c:97:0b:79:
+        1a:20:19:7e:aa:e5:c3:0e:f8:ca:f4:1e:93:31:72:14:ed:56:
+        02:38:c6:18:ec:80:3b:ad:4e:a7:2c:61:be:e2:58:dd:14:6d:
+        e7:3d:a8:c5:8e:5a:7b:37
+-----BEGIN CERTIFICATE-----
+MIIFkjCCA3qgAwIBAgIQPJuz0xQS7M+KEdobGK91NTANBgkqhkiG9w0BAQsFADBD
+MQswCQYDVQQGEwJYWDEQMA4GA1UEChMHU29tZSBDQTEiMCAGA1UEAxMZRmFrZSBD
+QSBmb3IgWmxpbnQgdGVzdGluZzAeFw0yNjA3MjgwNjI5MDlaFw0yNzA3MjgwNjI5
+MDlaMH8xCzAJBgNVBAYTAkVTMRUwEwYDVQQHDAxBbGfDum4gbHVnYXIxGjAYBgNV
+BAoMEUFsZ3VuYSBDb21wYcOxw61hMSIwIAYDVQQDDBlMZW9uLk1hbmRyYWtlQGV4
+YW1wbGUuY29tMRkwFwYDVQRhExBBQkNFUy0xMjM0NTY3ODkwMIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3qCEe2M/AO5NNdUv1WCUUVYOmNDDpRGSrqLF
+i9kiXa3dKqhd1hPyG5qGeFEQLPQhfIPtLKqEOKs4sEWYwOC8fhU0KGRXrQkyBZKv
+kToFMLZ+Sm+G86Jw447EZjqrOixinuKyP2HQ+aHhHsOZr3NIK2TWNYk/0Av37Ob6
+nXftAxiyIRdB755Z6zS9LIdA0Rg/8V1AjeBCceSFr3gd/sTAJyRz+JK2KH5gM+VU
+5ea4PRnAXlFferuZ3987kFAJFuGQGYPHtQFf00RaQdRpURuheRLVdv3FK1AHD2W0
+SmVKW1OTjnE4sviUZYcNwFAFz3l5Wo6Ia829PE6JFDN5PJQg+QIDAQABo4IBRDCC
+AUAwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcD
+BDAdBgNVHQ4EFgQULUvVBUF2XpVLaK8GANpcZF7SolMwHwYDVR0jBBgwFoAU6Lb2
+dkvQO+VGpflU1H4Hs94NYD4wZAYIKwYBBQUHAQEEWDBWMCkGCCsGAQUFBzABhh1o
+dHRwOi8vY2Euc29tZWNhLWluYy5jb20vb2NzcDApBggrBgEFBQcwAoYdaHR0cDov
+L2NhLnNvbWVjYS1pbmMuY29tL3Jvb3QwJAYDVR0RBB0wG4EZTGVvbi5NYW5kcmFr
+ZUBleGFtcGxlLmNvbTAUBgNVHSAEDTALMAkGB2eBDAEFAgIwLQYDVR0fBCYwJDAi
+oCCgHoYcaHR0cDovL2NhLnNvbWVjYS1pbmMuY29tL2NybDANBgkqhkiG9w0BAQsF
+AAOCAgEAVItZODRgTeRI21uHhd7WCvXUgXdpa4Pbax9fEErEz+tQTYnIm3cylGH2
+XWQC7pQS3kg/uQkOkfY7P9ijmHtJtH15CTzoTL0SNGGJKPDqEuTKiSwaOnglW6OB
+VVIkmFBeFmkTisQUfi6dz8W1euJtgFovE1R6Z6EbbSE5OxHx5EUmb77PNPQNb7HY
+yBg821H4mn6UgVrbqJfxRaedmOAGa7bFOiFeJpYRjNJFVs0GoWNSPxzWNVx7KMRe
+3FhvsDMQ1xgTOZwagq8TJzYlPH40YR9zTp0xPWE96UZbarmQuL7XLafkdY3krAcE
+f0Hljm4t8FwRTLaVu9ccsloJIXCkBRsuRflBQNbjedIAqHeRBFv5aNos8kGezXww
+DYZEKf4q8wPCE5x0GiYWO1YuOBPWpPHRbuWTGQR8/vTamdcK+ZXtqT0SqPi2DQjp
+6zpgeS9KhmZOZfon0jokX4jvmg7/3pAWdyjeinwYY8LunICc1e9eEtc5zAUuUfek
+Yxc3QmwhT5zpj9L7HQAp68nskrUIdVf/ooyc3D9pUnqfBuQPiCSaKWRyrZKqpOay
+6+7qAMgR1sBc5Xwpr+t3BceJhnsalFeZOlYRMCWWj+aOBV3JaLQMlwt5GiAZfqrl
+ww74yvQekzFyFO1WAjjGGOyAO61OpyxhvuJY3RRt5z2oxY5aezc=
+-----END CERTIFICATE-----


### PR DESCRIPTION
Section 7.1.4.2.2 (Subject Distinguished Name Fields) of the CABF S/MIME BRs requires that, for **Organization Validated** S/MIME certificates, the `commonName` attribute contain either an email address or the same value as the `organizationName` attribute. 

I realized that a lint for this requirement was still missing, so here is my proposal. 
