### PR TITLE
Improve robustness of the "e_org_validated_invalid_cn" lint for S/MIME OV certificates

### DIFF
--- a/v3/lints/cabf_smime_br/lint_org_validated_invalid_cn.go
+++ b/v3/lints/cabf_smime_br/lint_org_validated_invalid_cn.go
@@ -42,7 +42,8 @@ func NewOrgValidatedInvalidCN() lint.LintInterface {
 }
 
 func (l *OrgValidatedInvalidCN) CheckApplies(c *x509.Certificate) bool {
-	return util.IsSubscriberCert(c) && util.IsOrganizationValidatedCertificate(c) && c.Subject.CommonName != ""
+	return util.IsSubscriberCert(c) && util.IsOrganizationValidatedCertificate(c) &&
+		len(c.Subject.Organization) > 0
 }
 
 func isEmail(s string) bool {
@@ -56,7 +57,7 @@ func isEmail(s string) bool {
 func (l *OrgValidatedInvalidCN) Execute(c *x509.Certificate) *lint.LintResult {
 
 	if isEmail(c.Subject.CommonName) ||
-		(len(c.Subject.Organization) > 0 && c.Subject.CommonName == c.Subject.Organization[0]) {
+		c.Subject.CommonName == c.Subject.Organization[0] {
 		return &lint.LintResult{Status: lint.Pass}
 	}
 


### PR DESCRIPTION
Added a check for the organizationName to actually appear in the certificate Subject, which is mandatory in S/MIME OV certs but shouldn't be taken for granted. This will prevent a panic when referencing element #0 of the `c.Subject.Organization` array. Thanks to Wayne for suggesting this; I missed it.