### PR TITLE
Update description for e_server_cert_valid_time_longer_than_200_days

### DIFF
--- a/v3/lints/cabf_br/lint_e_server_cert_valid_time_longer_than_200_days.go
+++ b/v3/lints/cabf_br/lint_e_server_cert_valid_time_longer_than_200_days.go
@@ -53,7 +53,7 @@ func init() {
 	lint.RegisterCertificateLint(&lint.CertificateLint{
 		LintMetadata: lint.LintMetadata{
 			Name:            "e_server_cert_valid_time_longer_than_200_days",
-			Description:     "TLS server certificates issued on or after on or after March 15, 2026 00:00 GMT/UTC must not have a validity period greater than 200 days",
+			Description:     "TLS server certificates issued on or after March 15, 2026 00:00 GMT/UTC must not have a validity period greater than 200 days",
 			Citation:        "https://github.com/cabforum/servercert/pull/553",
 			Source:          lint.CABFBaselineRequirements,
 			EffectiveDate:   util.CABF_SC081_FIRST_MILESTONE,


### PR DESCRIPTION
I noticed that this lint had some stuttering with its wording. This PR updates the description to remove this.