### PR TITLE
Add n_suspicious_chars_in_address lint

### DIFF
--- a/v3/integration/config.json
+++ b/v3/integration/config.json
@@ -1016,6 +1016,9 @@
 	  },
     "e_utf8_replacement_char_in_subject": {
 		  "ErrCount": 2
-	  }
+	  },
+    "n_suspicious_chars_in_address": {
+      "NoticeCount": 1231
+    }
   }
 }

--- a/v3/lints/community/lint_suspicious_chars_in_address.go
+++ b/v3/lints/community/lint_suspicious_chars_in_address.go
@@ -1,0 +1,88 @@
+/*
+ * ZLint Copyright 2026 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package community
+
+import (
+	"regexp"
+
+	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/util"
+)
+
+func init() {
+	lint.RegisterCertificateLint(&lint.CertificateLint{
+		LintMetadata: lint.LintMetadata{
+			Name: "n_suspicious_chars_in_address",
+			Description: "Checks whether Subject:localityName or Subject:stateOrProvinceName contain " +
+				"characters that suggest the attribute holds more than one concatenated address component",
+			Citation: "ZLint community heuristic, informed by real-world incident reports: a comma, colon, " +
+				"equals sign, quotation mark, or parenthesis inside localityName or stateOrProvinceName is a " +
+				"strong sign that the attribute improperly concatenates multiple address components (e.g. a " +
+				"locality plus a street address, or a locality plus a region) rather than naming a single " +
+				"locality or region. This is not codified in any formal specification, so this lint is " +
+				"informational only and may not indicate an error in every case.",
+			Source:        lint.Community,
+			EffectiveDate: util.ZeroDate,
+		},
+		Lint: NewSuspiciousCharsInAddress,
+	})
+}
+
+type SuspiciousCharsInAddress struct{}
+
+func NewSuspiciousCharsInAddress() lint.LintInterface {
+	return &SuspiciousCharsInAddress{}
+}
+
+func (l *SuspiciousCharsInAddress) CheckApplies(c *x509.Certificate) bool {
+	return len(c.Subject.Locality) > 0 || len(c.Subject.Province) > 0
+}
+
+var suspiciousCharsInAddressRegexp = regexp.MustCompile(`[,:="()]`)
+
+func containsSuspiciousChars(values []string) bool {
+	for _, v := range values {
+		if suspiciousCharsInAddressRegexp.MatchString(v) {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *SuspiciousCharsInAddress) Execute(c *x509.Certificate) *lint.LintResult {
+	locSuspicious := containsSuspiciousChars(c.Subject.Locality)
+	stateSuspicious := containsSuspiciousChars(c.Subject.Province)
+
+	switch {
+	case locSuspicious && stateSuspicious:
+		return &lint.LintResult{
+			Status:  lint.Notice,
+			Details: "Subject:localityName and Subject:stateOrProvinceName both contain suspicious character(s)",
+		}
+	case locSuspicious:
+		return &lint.LintResult{
+			Status:  lint.Notice,
+			Details: "Subject:localityName contains suspicious character(s)",
+		}
+	case stateSuspicious:
+		return &lint.LintResult{
+			Status:  lint.Notice,
+			Details: "Subject:stateOrProvinceName contains suspicious character(s)",
+		}
+	default:
+		return &lint.LintResult{Status: lint.Pass}
+	}
+}

--- a/v3/lints/community/lint_suspicious_chars_in_address_test.go
+++ b/v3/lints/community/lint_suspicious_chars_in_address_test.go
@@ -1,0 +1,90 @@
+/*
+ * ZLint Copyright 2026 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package community
+
+import (
+	"testing"
+
+	"github.com/zmap/zlint/v3/lint"
+	"github.com/zmap/zlint/v3/test"
+)
+
+func TestSuspiciousCharsInAddress(t *testing.T) {
+	testCases := []struct {
+		desc string
+		path string
+		want lint.LintStatus
+	}{
+		{
+			desc: "certificate without localityName or stateOrProvinceName",
+			path: "suspicious_locnull_stnull.pem",
+			want: lint.NA,
+		},
+		{
+			desc: "certificate without localityName, with clean stateOrProvinceName",
+			path: "suspicious_locnull_stgood.pem",
+			want: lint.Pass,
+		},
+		{
+			desc: "certificate without localityName, with suspicious stateOrProvinceName",
+			path: "suspicious_locnull_stbad.pem",
+			want: lint.Notice,
+		},
+		{
+			desc: "certificate with clean localityName, without stateOrProvinceName",
+			path: "suspicious_locgood_stnull.pem",
+			want: lint.Pass,
+		},
+		{
+			desc: "certificate with suspicious localityName, without stateOrProvinceName",
+			path: "suspicious_locbad_stnull.pem",
+			want: lint.Notice,
+		},
+		{
+			desc: "certificate with clean localityName and stateOrProvinceName",
+			path: "suspicious_locgood_stgood.pem",
+			want: lint.Pass,
+		},
+		{
+			desc: "certificate with clean localityName and suspicious stateOrProvinceName",
+			path: "suspicious_locgood_stbad.pem",
+			want: lint.Notice,
+		},
+		{
+			desc: "certificate with suspicious localityName and stateOrProvinceName",
+			path: "suspicious_locbad_stbad.pem",
+			want: lint.Notice,
+		},
+		{
+			desc: "certificate with two localityName values, only the second suspicious",
+			path: "suspicious_locmulti_secondbad.pem",
+			want: lint.Notice,
+		},
+		{
+			desc: "certificate with two stateOrProvinceName values, only the second suspicious",
+			path: "suspicious_stmulti_secondbad.pem",
+			want: lint.Notice,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			out := test.TestLint("n_suspicious_chars_in_address", tc.path)
+			if out.Status != tc.want {
+				t.Errorf("expected status %s for %s, got %s", tc.want, tc.path, out.Status)
+			}
+		})
+	}
+}

--- a/v3/testdata/suspicious_locbad_stbad.pem
+++ b/v3/testdata/suspicious_locbad_stbad.pem
@@ -1,0 +1,40 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 10 (0xa)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: May  1 00:00:00 2008 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.org, L = Gothenburg: Main Street 1, ST = "Vastra Gotaland, Sweden"
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:63:9f:ec:00:48:3b:75:0d:8c:73:12:42:3a:8b:
+                    4e:ae:f5:04:73:13:86:a7:f8:7e:62:31:08:77:cd:
+                    b1:65:a6:f8:53:28:87:a3:d9:51:92:0b:22:f4:53:
+                    0b:40:95:e9:4d:25:bc:9c:fb:15:7e:a7:25:9d:07:
+                    e8:aa:dc:96:b9
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:21:00:bb:64:17:dc:89:bc:18:a7:78:49:2a:84:c7:
+        12:44:a9:ab:ba:63:9f:35:62:29:06:4d:e1:cb:67:19:19:05:
+        61:02:20:40:21:ee:89:7c:db:13:6b:8f:d8:db:66:36:18:d0:
+        2d:6f:18:ba:70:b5:60:25:40:78:27:3e:2f:cd:39:ba:7a
+-----BEGIN CERTIFICATE-----
+MIIBXTCCAQOgAwIBAgIBCjAKBggqhkjOPQQDAjAAMCAXDTA4MDUwMTAwMDAwMFoY
+Dzk5OTgxMTMwMDAwMDAwWjBcMRQwEgYDVQQDEwtleGFtcGxlLm9yZzEiMCAGA1UE
+BxMZR290aGVuYnVyZzogTWFpbiBTdHJlZXQgMTEgMB4GA1UECBMXVmFzdHJhIEdv
+dGFsYW5kLCBTd2VkZW4wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARjn+wASDt1
+DYxzEkI6i06u9QRzE4an+H5iMQh3zbFlpvhTKIej2VGSCyL0UwtAlelNJbyc+xV+
+pyWdB+iq3Ja5oxAwDjAMBgNVHRMBAf8EAjAAMAoGCCqGSM49BAMCA0gAMEUCIQC7
+ZBfcibwYp3hJKoTHEkSpq7pjnzViKQZN4ctnGRkFYQIgQCHuiXzbE2uP2NtmNhjQ
+LW8YunC1YCVAeCc+L805uno=
+-----END CERTIFICATE-----

--- a/v3/testdata/suspicious_locbad_stnull.pem
+++ b/v3/testdata/suspicious_locbad_stnull.pem
@@ -1,0 +1,39 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 7 (0x7)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: May  1 00:00:00 2008 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.org, L = Gothenburg (Vastra Gotaland)
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:6d:1f:bd:84:43:d3:5a:20:44:d0:5b:28:ad:5e:
+                    53:70:e1:1e:0c:1a:7f:06:f3:6e:aa:11:87:19:b6:
+                    49:d0:ee:68:70:27:6d:97:02:72:eb:07:de:b0:66:
+                    61:ed:e0:e1:75:c9:cf:e9:ba:d3:62:76:4a:42:4d:
+                    b6:ad:8c:5b:a0
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:21:00:96:8f:7d:6e:84:6f:30:dd:20:e2:e2:3a:53:
+        06:bd:ee:b8:61:a0:12:b6:51:3a:ee:70:5d:6d:e6:97:f8:be:
+        f7:02:20:0d:ea:bf:dd:ea:68:55:90:07:07:97:46:a8:ae:21:
+        ef:ab:1a:e4:f9:af:d0:3f:81:24:a7:d1:36:34:bb:b2:64
+-----BEGIN CERTIFICATE-----
+MIIBPTCB5KADAgECAgEHMAoGCCqGSM49BAMCMAAwIBcNMDgwNTAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMD0xFDASBgNVBAMTC2V4YW1wbGUub3JnMSUwIwYDVQQH
+ExxHb3RoZW5idXJnIChWYXN0cmEgR290YWxhbmQpMFkwEwYHKoZIzj0CAQYIKoZI
+zj0DAQcDQgAEbR+9hEPTWiBE0FsorV5TcOEeDBp/BvNuqhGHGbZJ0O5ocCdtlwJy
+6wfesGZh7eDhdcnP6brTYnZKQk22rYxboKMQMA4wDAYDVR0TAQH/BAIwADAKBggq
+hkjOPQQDAgNIADBFAiEAlo99boRvMN0g4uI6Uwa97rhhoBK2UTrucF1t5pf4vvcC
+IA3qv93qaFWQBweXRqiuIe+rGuT5r9A/gSSn0TY0u7Jk
+-----END CERTIFICATE-----

--- a/v3/testdata/suspicious_locgood_stbad.pem
+++ b/v3/testdata/suspicious_locgood_stbad.pem
@@ -1,0 +1,40 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 9 (0x9)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: May  1 00:00:00 2008 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.org, L = Gothenburg, ST = "Vastra Gotaland, Sweden"
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:43:f0:5e:ba:41:7d:5d:9c:7f:ba:d3:35:b8:32:
+                    70:7d:11:87:88:ca:69:de:98:9d:36:7b:70:4c:2d:
+                    c1:86:82:ce:28:41:d6:0d:8c:d5:cd:ff:1f:a5:1a:
+                    d7:5a:74:c6:ac:cc:1c:94:a2:8a:13:53:f2:4c:52:
+                    5e:fd:d0:7d:9d
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:21:00:f0:83:a7:40:e0:64:33:09:a3:2d:53:b1:0a:
+        2b:95:fc:9b:a9:b7:61:1d:9b:d5:be:30:cd:73:67:bc:27:aa:
+        63:02:20:1d:b3:81:c3:c2:33:03:94:15:d5:f2:01:37:cb:f8:
+        73:37:6d:3b:1f:84:9f:de:fd:d3:a5:f0:f8:7d:98:72:1e
+-----BEGIN CERTIFICATE-----
+MIIBTTCB9KADAgECAgEJMAoGCCqGSM49BAMCMAAwIBcNMDgwNTAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaME0xFDASBgNVBAMTC2V4YW1wbGUub3JnMRMwEQYDVQQH
+EwpHb3RoZW5idXJnMSAwHgYDVQQIExdWYXN0cmEgR290YWxhbmQsIFN3ZWRlbjBZ
+MBMGByqGSM49AgEGCCqGSM49AwEHA0IABEPwXrpBfV2cf7rTNbgycH0Rh4jKad6Y
+nTZ7cEwtwYaCzihB1g2M1c3/H6Ua11p0xqzMHJSiihNT8kxSXv3QfZ2jEDAOMAwG
+A1UdEwEB/wQCMAAwCgYIKoZIzj0EAwIDSAAwRQIhAPCDp0DgZDMJoy1TsQorlfyb
+qbdhHZvVvjDNc2e8J6pjAiAds4HDwjMDlBXV8gE3y/hzN207H4Sf3v3TpfD4fZhy
+Hg==
+-----END CERTIFICATE-----

--- a/v3/testdata/suspicious_locgood_stgood.pem
+++ b/v3/testdata/suspicious_locgood_stgood.pem
@@ -1,0 +1,39 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 8 (0x8)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: May  1 00:00:00 2008 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.org, L = Gothenburg, ST = Vastra Gotaland
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:16:3d:59:19:50:f3:3b:71:e0:cd:35:90:7f:e0:
+                    59:d0:c0:b6:2c:7f:c6:f0:42:58:89:c2:80:e5:f1:
+                    7f:ef:d3:79:3e:6d:a2:5f:fd:49:ab:79:17:3a:62:
+                    41:39:7a:24:f6:b1:56:e0:64:43:1b:00:a1:c3:e2:
+                    c3:54:94:bb:1a
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:46:02:21:00:f7:ef:bc:cf:c3:f6:30:d2:14:04:d2:46:95:
+        18:fe:3d:63:14:60:9f:5d:46:13:1b:69:51:c0:3c:44:68:c1:
+        87:02:21:00:c4:99:bd:5f:0a:ca:36:49:83:43:d7:44:90:bf:
+        bf:e3:88:2b:9e:22:66:5b:2d:db:fc:2f:f0:0e:54:81:77:9f
+-----BEGIN CERTIFICATE-----
+MIIBRjCB7KADAgECAgEIMAoGCCqGSM49BAMCMAAwIBcNMDgwNTAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMEUxFDASBgNVBAMTC2V4YW1wbGUub3JnMRMwEQYDVQQH
+EwpHb3RoZW5idXJnMRgwFgYDVQQIEw9WYXN0cmEgR290YWxhbmQwWTATBgcqhkjO
+PQIBBggqhkjOPQMBBwNCAAQWPVkZUPM7ceDNNZB/4FnQwLYsf8bwQliJwoDl8X/v
+03k+baJf/UmreRc6YkE5eiT2sVbgZEMbAKHD4sNUlLsaoxAwDjAMBgNVHRMBAf8E
+AjAAMAoGCCqGSM49BAMCA0kAMEYCIQD377zPw/Yw0hQE0kaVGP49YxRgn11GExtp
+UcA8RGjBhwIhAMSZvV8KyjZJg0PXRJC/v+OIK54iZlst2/wv8A5UgXef
+-----END CERTIFICATE-----

--- a/v3/testdata/suspicious_locgood_stnull.pem
+++ b/v3/testdata/suspicious_locgood_stnull.pem
@@ -1,0 +1,39 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 6 (0x6)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: May  1 00:00:00 2008 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.org, L = Gothenburg
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:06:55:d2:8b:0a:63:55:ad:bd:62:82:4b:9b:70:
+                    75:af:7b:2f:6c:19:98:fb:0c:1b:f2:75:7d:c9:ad:
+                    37:eb:5d:d2:27:5e:8d:fd:e8:06:9e:3d:7b:bb:a7:
+                    9c:55:26:d2:06:4c:bb:68:0f:3c:e1:8c:eb:bc:cb:
+                    b6:78:93:b5:6d
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:21:00:b3:e7:52:e2:68:81:69:47:67:8c:04:6d:7c:
+        d7:43:7f:9a:3a:9f:31:7d:f3:dc:96:c2:6b:97:ea:cf:72:7c:
+        5a:02:20:2d:5b:e4:14:2c:02:d9:94:80:59:59:80:65:43:4d:
+        98:18:bd:38:77:4f:c7:70:18:c5:f3:53:f6:5d:d5:e4:a3
+-----BEGIN CERTIFICATE-----
+MIIBKzCB0qADAgECAgEGMAoGCCqGSM49BAMCMAAwIBcNMDgwNTAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMCsxFDASBgNVBAMTC2V4YW1wbGUub3JnMRMwEQYDVQQH
+EwpHb3RoZW5idXJnMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBlXSiwpjVa29
+YoJLm3B1r3svbBmY+wwb8nV9ya03613SJ16N/egGnj17u6ecVSbSBky7aA884Yzr
+vMu2eJO1baMQMA4wDAYDVR0TAQH/BAIwADAKBggqhkjOPQQDAgNIADBFAiEAs+dS
+4miBaUdnjARtfNdDf5o6nzF989yWwmuX6s9yfFoCIC1b5BQsAtmUgFlZgGVDTZgY
+vTh3T8dwGMXzU/Zd1eSj
+-----END CERTIFICATE-----

--- a/v3/testdata/suspicious_locmulti_secondbad.pem
+++ b/v3/testdata/suspicious_locmulti_secondbad.pem
@@ -1,0 +1,40 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 11 (0xb)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: May  1 00:00:00 2008 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.org, L = Gothenburg + L = "Gothenburg, Main Street 1"
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:b2:6b:35:d5:99:c2:4e:29:6b:5c:f3:25:51:9b:
+                    5e:90:aa:7a:e1:bc:89:85:6b:db:84:2b:e3:be:a7:
+                    8a:17:3a:fd:44:ce:56:7b:bc:ed:75:5a:a4:57:c8:
+                    48:28:ee:d9:88:98:f2:dd:1a:3c:f0:3e:77:2d:62:
+                    87:aa:9a:23:a6
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:20:3d:ec:dc:6f:73:3d:99:b2:01:4a:a4:99:2d:35:
+        14:e5:51:5c:10:59:8d:5b:09:12:08:e4:e3:82:68:b0:49:99:
+        02:21:00:f2:97:ab:5e:cb:47:bc:0e:e3:68:70:07:c2:fd:34:
+        bf:06:7d:1d:db:d1:b9:5d:78:21:f4:9f:66:ee:4e:b9:c3
+-----BEGIN CERTIFICATE-----
+MIIBTTCB9KADAgECAgELMAoGCCqGSM49BAMCMAAwIBcNMDgwNTAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaME0xFDASBgNVBAMTC2V4YW1wbGUub3JnMTUwEQYDVQQH
+EwpHb3RoZW5idXJnMCAGA1UEBxMZR290aGVuYnVyZywgTWFpbiBTdHJlZXQgMTBZ
+MBMGByqGSM49AgEGCCqGSM49AwEHA0IABLJrNdWZwk4pa1zzJVGbXpCqeuG8iYVr
+24Qr476nihc6/UTOVnu87XVapFfISCju2YiY8t0aPPA+dy1ih6qaI6ajEDAOMAwG
+A1UdEwEB/wQCMAAwCgYIKoZIzj0EAwIDSAAwRQIgPezcb3M9mbIBSqSZLTUU5VFc
+EFmNWwkSCOTjgmiwSZkCIQDyl6tey0e8DuNocAfC/TS/Bn0d29G5XXgh9J9m7k65
+ww==
+-----END CERTIFICATE-----

--- a/v3/testdata/suspicious_locnull_stbad.pem
+++ b/v3/testdata/suspicious_locnull_stbad.pem
@@ -1,0 +1,39 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 5 (0x5)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: May  1 00:00:00 2008 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.org, ST = "Vastra Gotaland, Sweden"
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:00:e8:52:58:f7:ef:2d:97:6d:96:11:95:97:7f:
+                    4e:f8:0c:aa:4c:c2:eb:e6:7b:b7:47:95:fc:68:7c:
+                    89:f2:a4:8b:df:b5:0d:ee:9d:b4:9d:2a:99:b9:1a:
+                    d8:91:a3:78:9e:30:5a:7d:32:f3:61:99:9c:4a:28:
+                    67:5e:2a:66:f5
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:46:02:21:00:a5:cd:e9:a2:4f:f8:90:b5:80:35:57:31:40:
+        2c:7f:d8:3b:29:cc:5b:d2:c5:fd:b7:7a:0f:02:b9:9a:71:19:
+        43:02:21:00:f3:bf:9e:a6:18:55:9f:44:18:86:6e:0e:0c:4c:
+        a1:6c:2f:61:36:15:16:e3:59:81:08:b2:99:d0:aa:69:42:65
+-----BEGIN CERTIFICATE-----
+MIIBOTCB36ADAgECAgEFMAoGCCqGSM49BAMCMAAwIBcNMDgwNTAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMDgxFDASBgNVBAMTC2V4YW1wbGUub3JnMSAwHgYDVQQI
+ExdWYXN0cmEgR290YWxhbmQsIFN3ZWRlbjBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABADoUlj37y2XbZYRlZd/TvgMqkzC6+Z7t0eV/Gh8ifKki9+1De6dtJ0qmbka
+2JGjeJ4wWn0y82GZnEooZ14qZvWjEDAOMAwGA1UdEwEB/wQCMAAwCgYIKoZIzj0E
+AwIDSQAwRgIhAKXN6aJP+JC1gDVXMUAsf9g7Kcxb0sX9t3oPArmacRlDAiEA87+e
+phhVn0QYhm4ODEyhbC9hNhUW41mBCLKZ0KppQmU=
+-----END CERTIFICATE-----

--- a/v3/testdata/suspicious_locnull_stgood.pem
+++ b/v3/testdata/suspicious_locnull_stgood.pem
@@ -1,0 +1,39 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 4 (0x4)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: May  1 00:00:00 2008 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.org, ST = Vastra Gotaland
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:18:e9:19:fc:b1:f5:c7:af:6a:cf:6e:35:37:8d:
+                    87:e6:98:c0:a0:5f:9b:60:13:fa:83:4b:1e:7c:3f:
+                    2a:24:d5:99:60:79:79:1b:97:ea:39:d6:b3:5b:78:
+                    db:73:c0:78:e2:82:0a:81:dd:35:49:ae:78:02:e6:
+                    2c:94:79:3c:f3
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:20:5a:1f:ee:1d:dc:f4:9b:8e:e7:08:db:04:a0:c4:
+        78:96:1d:81:7c:bc:76:41:cf:05:50:9c:50:72:03:58:1c:51:
+        02:21:00:a9:03:df:75:35:09:17:53:0f:c2:70:44:57:38:17:
+        7a:78:44:cb:4b:32:83:4b:50:fb:6e:4e:89:fb:a3:a8:b0
+-----BEGIN CERTIFICATE-----
+MIIBMDCB16ADAgECAgEEMAoGCCqGSM49BAMCMAAwIBcNMDgwNTAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMDAxFDASBgNVBAMTC2V4YW1wbGUub3JnMRgwFgYDVQQI
+Ew9WYXN0cmEgR290YWxhbmQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQY6Rn8
+sfXHr2rPbjU3jYfmmMCgX5tgE/qDSx58Pyok1ZlgeXkbl+o51rNbeNtzwHjiggqB
+3TVJrngC5iyUeTzzoxAwDjAMBgNVHRMBAf8EAjAAMAoGCCqGSM49BAMCA0gAMEUC
+IFof7h3c9JuO5wjbBKDEeJYdgXy8dkHPBVCcUHIDWBxRAiEAqQPfdTUJF1MPwnBE
+VzgXenhEy0syg0tQ+25OifujqLA=
+-----END CERTIFICATE-----

--- a/v3/testdata/suspicious_locnull_stnull.pem
+++ b/v3/testdata/suspicious_locnull_stnull.pem
@@ -1,0 +1,38 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: May  1 00:00:00 2008 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.org
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:6f:a0:94:65:30:c8:27:03:bc:bb:33:0d:96:12:
+                    1c:be:5f:c8:37:31:e6:93:e4:6d:3a:2d:49:e5:7b:
+                    5b:8e:20:83:be:ee:b7:96:97:17:b1:05:85:60:d4:
+                    1a:73:15:85:71:ea:01:d6:0a:a2:d5:13:57:2b:f3:
+                    39:68:37:7f:23
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:45:02:20:55:d2:39:67:f8:b9:5c:68:9b:a9:50:5c:06:64:
+        c5:9f:a5:b8:e4:5b:fa:ba:93:c4:72:0f:5c:ce:e4:3a:d0:23:
+        02:21:00:e9:cd:03:8a:6c:94:b6:64:29:c9:5f:08:6d:20:df:
+        12:d2:c4:ea:fa:62:a1:9c:c7:9a:00:7e:83:d6:24:6c:95
+-----BEGIN CERTIFICATE-----
+MIIBFjCBvaADAgECAgEDMAoGCCqGSM49BAMCMAAwIBcNMDgwNTAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMBYxFDASBgNVBAMTC2V4YW1wbGUub3JnMFkwEwYHKoZI
+zj0CAQYIKoZIzj0DAQcDQgAEb6CUZTDIJwO8uzMNlhIcvl/INzHmk+RtOi1J5Xtb
+jiCDvu63lpcXsQWFYNQacxWFceoB1gqi1RNXK/M5aDd/I6MQMA4wDAYDVR0TAQH/
+BAIwADAKBggqhkjOPQQDAgNIADBFAiBV0jln+LlcaJupUFwGZMWfpbjkW/q6k8Ry
+D1zO5DrQIwIhAOnNA4pslLZkKclfCG0g3xLSxOr6YqGcx5oAfoPWJGyV
+-----END CERTIFICATE-----

--- a/v3/testdata/suspicious_stmulti_secondbad.pem
+++ b/v3/testdata/suspicious_stmulti_secondbad.pem
@@ -1,0 +1,40 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 12 (0xc)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: 
+        Validity
+            Not Before: May  1 00:00:00 2008 GMT
+            Not After : Nov 30 00:00:00 9998 GMT
+        Subject: CN = example.org, ST = Vastra Gotaland + ST = "Vastra Gotaland, Sweden"
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:48:96:de:ed:83:a9:4c:12:6e:61:a7:92:a3:18:
+                    e1:64:92:5b:aa:00:46:47:40:e5:92:6e:4b:46:9d:
+                    e2:c6:89:1f:5f:66:41:82:92:d8:a8:b8:b6:37:52:
+                    2c:88:fa:4b:47:f7:a0:aa:28:2a:0f:0b:3c:86:79:
+                    b6:5b:e6:96:33
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:44:02:20:58:2e:25:8c:9b:ef:28:09:39:2b:30:4d:f3:66:
+        26:65:d3:ba:28:27:1b:88:4c:fb:04:c4:01:0d:5f:a0:c3:96:
+        02:20:06:b8:e1:9d:ea:8a:a8:63:38:a5:4c:e3:b3:2b:7c:e0:
+        ed:02:7a:34:d4:a8:8e:89:55:92:e6:30:a2:ee:a3:3c
+-----BEGIN CERTIFICATE-----
+MIIBTzCB96ADAgECAgEMMAoGCCqGSM49BAMCMAAwIBcNMDgwNTAxMDAwMDAwWhgP
+OTk5ODExMzAwMDAwMDBaMFAxFDASBgNVBAMTC2V4YW1wbGUub3JnMTgwFgYDVQQI
+Ew9WYXN0cmEgR290YWxhbmQwHgYDVQQIExdWYXN0cmEgR290YWxhbmQsIFN3ZWRl
+bjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABEiW3u2DqUwSbmGnkqMY4WSSW6oA
+RkdA5ZJuS0ad4saJH19mQYKS2Ki4tjdSLIj6S0f3oKooKg8LPIZ5tlvmljOjEDAO
+MAwGA1UdEwEB/wQCMAAwCgYIKoZIzj0EAwIDRwAwRAIgWC4ljJvvKAk5KzBN82Ym
+ZdO6KCcbiEz7BMQBDV+gw5YCIAa44Z3qiqhjOKVM47MrfODtAno01KiOiVWS5jCi
+7qM8
+-----END CERTIFICATE-----


### PR DESCRIPTION
Adds `n_suspicious_chars_in_address`, which checks whether Subject:localityName or Subject:stateOrProvinceName contain characters (comma, colon, equals sign, quote, or parenthesis) suggesting the attribute improperly concatenates multiple address components, such as a locality plus a street address (a Community heuristic informed by real-world incident reports; not codified in a formal specification, hence `Notice` rather than `Warn`/`Error`).

This is an independent implementation addressing review feedback on #1084: correct `n_`/`Notice` severity per CONTRIBUTING.md's rule against using `Warn` for non-deterministic checks, a substantive citation in place of a placeholder, and checking every `Locality`/`Province` value rather than only the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2zAx7WHAc1xTGSGiMeuNn